### PR TITLE
Initial support for increased flashing speeds for the ESP32

### DIFF
--- a/espflash/src/connection.rs
+++ b/espflash/src/connection.rs
@@ -1,4 +1,4 @@
-use std::io::Write;
+use std::io::{Write};
 use std::thread::sleep;
 use std::time::Duration;
 
@@ -6,7 +6,7 @@ use crate::encoder::SlipEncoder;
 use crate::error::{Error, RomError};
 use binread::io::Cursor;
 use binread::{BinRead, BinReaderExt};
-use serial::SerialPort;
+use serial::{SerialPort, BaudRate, SerialPortSettings};
 use slip_codec::Decoder;
 
 pub struct Connection {
@@ -63,6 +63,13 @@ impl Connection {
 
     pub fn set_timeout(&mut self, timeout: Duration) -> Result<(), Error> {
         self.serial.set_timeout(timeout)?;
+        Ok(())
+    }
+
+    pub fn set_baud(&mut self, speed: BaudRate) -> Result<(), Error> {
+        self.serial.reconfigure(&|setup: &mut dyn SerialPortSettings| {
+            setup.set_baud_rate(speed)
+        })?;
         Ok(())
     }
 

--- a/espflash/src/main.rs
+++ b/espflash/src/main.rs
@@ -41,7 +41,7 @@ fn main() -> Result<(), MainError> {
         Ok(())
     })?;
 
-    let mut flasher = Flasher::connect(serial)?;
+    let mut flasher = Flasher::connect(serial, None)?;
 
     if board_info {
         println!("Chip type: {:?}", flasher.chip());


### PR DESCRIPTION
```
$ time cargo espflash --chip esp32 --example blinky --speed 115200 /dev/ttyUSB0
    Finished dev [unoptimized + debuginfo] target(s) in 0.01s
cargo espflash --chip esp32 --example blinky --speed 115200 /dev/ttyUSB0  0.09s user 0.17s system 1% cpu 15.113 total
```

```
time cargo espflash --chip esp32 --example blinky --speed 921600 /dev/ttyUSB0
    Finished dev [unoptimized + debuginfo] target(s) in 0.01s
WARN setting baud rate higher than 115200 can cause issues.
cargo espflash --chip esp32 --example blinky --speed 921600 /dev/ttyUSB0  0.09s user 0.17s system 6% cpu 4.181 total
```

15s -> 4s :tada: 