### PR TITLE
add dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,35 @@
+FROM espressif/idf:release-v4.1
+
+ARG toolchain=nightly-2020-10-09
+ARG xtensalink="https://github.com/espressif/crosstool-NG/releases/download/esp-2020r3/xtensa-esp32-elf-gcc8_4_0-esp-2020r3-linux-amd64.tar.gz"
+
+RUN apt-get update -y && apt-get install -y build-essential cmake clang-6.0
+
+# Init rust-xtensa
+RUN git clone --depth 1 https://github.com/MabezDev/rust-xtensa /rust-xtensa
+RUN cd rust-xtensa && \
+  ./configure --experimental-targets=Xtensa && \
+  ./x.py build --stage 2
+
+ENV CUSTOM_RUSTC=/rust-xtensa
+ENV RUST_BACKTRACE=1
+ENV XARGO_RUST_SRC=$CUSTOM_RUSTC/library
+ENV RUSTC=$CUSTOM_RUSTC/build/x86_64-unknown-linux-gnu/stage2/bin/rustc
+ENV RUSTDOC=$CUSTOM_RUSTC/build/x86_64-unknown-linux-gnu/stage2/bin/rustdoc
+
+# Init xtensa-esp32-elf-gcc8
+RUN wget ${xtensalink} -O /tmp/xtensa-esp32-elf-gcc8.tar.gz && \
+  mkdir -p /esp && \
+  tar -xzf "/tmp/xtensa-esp32-elf-gcc8.tar.gz" -C /esp && \
+  rm "/tmp/xtensa-esp32-elf-gcc8.tar.gz"
+ENV PATH="$PATH:/esp/xtensa-esp32-elf/bin"
+
+# Init espflash
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain none -y
+ENV PATH="/root/.cargo/bin:${PATH}"
+RUN rustup toolchain install ${toolchain} --allow-downgrade --profile minimal
+RUN cargo install cargo-espflash
+
+WORKDIR /espflash
+
+ENTRYPOINT ["cargo", "espflash"]

--- a/README.md
+++ b/README.md
@@ -10,3 +10,22 @@ _ESP8266_ and _ESP32_ serial flasher based on [esptool.py](https://github.com/es
 Flashing _should_ work for both ESP32 and ESP8266.
 
 If you have an ELF file that flashes correctly with `esptool.py` but not with this tool then please open an issue with the ELF in question.
+
+## Quickstart - Docker
+
+The docker image `esp-rs/espflash` contains all necessary toolchains and tooling including espflash to build and flash.
+To clone, build and flash the [xtensa-rust-quickstart](https://github.com/MabezDev/xtensa-rust-quickstart) esp32 example run the following:
+
+```cmd
+git clone --depth 1 https://github.com/MabezDev/xtensa-rust-quickstart.git
+cd xtensa-rust-quickstart
+docker run -v "$(pwd):/espflash" --device=/dev/ttyUSB0 -ti esp-rs/espflash --release --tool=cargo --chip=esp32 --example=esp32 --features="xtensa-lx-rt/lx6 xtensa-lx/lx6 esp32-hal" /dev/ttyUSB0
+```
+
+### Custom Docker Build
+
+```cmd
+git clone --depth 1 https://github.com/esp-rs/espflash.git
+cd espflash
+docker build -t esp-rs/espflash .
+```


### PR DESCRIPTION
Adds a Dockerfile that I think that further reduces the hurdle for building and flashing code for the esp as it basically ships the whole the toolchain. It's basically a one liner to build and deploy software to an esp, no need to setup a toolchain etc.

```cmd
docker run -v "$(pwd):/espflash" --device=/dev/ttyUSB0 -ti esp-rs/espflash --release --tool=cargo --chip=esp32 --example=esp32 --features="xtensa-lx-rt/lx6 xtensa-lx/lx6 esp32-hal" /dev/ttyUSB0
```

This assumes that the image has already been deployed to the docker hub (in this example I assume it's deployed to `esp-rs/espflash`. For manual building the image right now:

```cmd
git clone --depth 1 https://github.com/esp-rs/espflash.git
cd espflash
docker build -t esp-rs/espflash .
```
