### PR TITLE
reconfigure baud rate in cargo-espflash when creating the serial connection

### DIFF
--- a/cargo-espflash/src/main.rs
+++ b/cargo-espflash/src/main.rs
@@ -236,7 +236,12 @@ fn build(
 }
 
 fn chip_detect(port: &str) -> Option<&'static str> {
-    let serial = serial::open(port).ok()?;
+    let mut serial = serial::open(port).ok()?;
+    serial.reconfigure(&|settings| {
+        settings.set_baud_rate(BaudRate::Baud115200)?;
+
+        Ok(())
+    }).ok()?;
     let flasher = Flasher::connect(serial, None).ok()?;
 
     let chip = match flasher.chip() {


### PR DESCRIPTION
`cargo espflash --board-info <serial>` was failing when leaving out the chip id. Fixed it by reconfiguring the baud rate right after creating the serial connection (just like in espflash).