### PR TITLE
Fix build std presumptions

### DIFF
--- a/cargo-espflash/src/main.rs
+++ b/cargo-espflash/src/main.rs
@@ -202,8 +202,8 @@ fn build(
     };
 
     if let "cargo" = tool {
-        args.push("-Z".to_string());
-        args.push("build-std".to_string());
+        println!("NOTE: --tool cargo currently requires the unstable build-std, ensure .cargo/config{{.toml}} has the appropriate options.");
+        println!("See: https://doc.rust-lang.org/cargo/reference/unstable.html#build-std")
     };
 
     args.push("--target".to_string());


### PR DESCRIPTION
* Remove hardcoded passing of build-std args
* Instead note that the `--tool cargo` requires configuration in
  `.cargo/config{.toml}`

Closes #19 