### PR TITLE
Improve flashing reliability at higher speeds

### DIFF
--- a/cargo-espflash/Cargo.toml
+++ b/cargo-espflash/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-espflash"
-version = "0.1.3"
+version = "0.1.4"
 description = "Cargo subcommand for flashing the ESP8266 and ESP32 over serial"
 license = "GPL-2.0"
 authors = [
@@ -11,10 +11,10 @@ repository = "https://github.com/icewind1991/espflash"
 edition = "2018"
 
 [dependencies]
-cargo-project = "0.2.4"
-espflash = { version = "0.1.3", path = "../espflash" }
-pico-args = "0.4.0"
+cargo-project = "0.2"
+espflash = { version = "0.1", path = "../espflash" }
+pico-args = "0.4"
 serial = "0.4"
-color-eyre = "0.5.10"
+color-eyre = "0.5"
 serde = { version = "1", features = ["derive"] }
 toml = "0.5"

--- a/espflash/Cargo.toml
+++ b/espflash/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "espflash"
-version = "0.1.3"
+version = "0.1.4"
 authors = ["Robin Appelman <robin@icewind.nl>"]
 edition = "2018"
 license = "GPL-2.0"
@@ -14,20 +14,20 @@ path = "src/main.rs"
 [lib]
 
 [dependencies]
-binread = "2.1.0"
-bytemuck = { version = "1.4.0", features = ["derive"] }
-indicatif = "0.15"
-md5 = "0.7.0"
-pico-args = "0.4.0"
+binread = "2.1"
+bytemuck = { version = "1.7", features = ["derive"] }
+indicatif = "0.16"
+md5 = "0.7"
+pico-args = "0.4"
 serial = "0.4"
-sha2 = "0.9.1"
-slip-codec =  "0.2.4"
-thiserror = "1.0.20"
-xmas-elf = "0.7.0"
+sha2 = "0.9"
+slip-codec =  "0.2"
+thiserror = "1.0"
+xmas-elf = "0.8"
 serde = { version = "1.0", features = ["derive"] }
 toml = "0.5"
-directories-next = "2.0.0"
+directories-next = "2.0"
 color-eyre = "0.5"
 
 [dev-dependencies]
-pretty_assertions = "0.7.1"
+pretty_assertions = "0.7"

--- a/espflash/src/flasher.rs
+++ b/espflash/src/flasher.rs
@@ -229,17 +229,18 @@ impl Flasher {
         self.connection
             .with_timeout(Duration::from_millis(100), |connection| {
                 let data = &[
-                    0x07u8, 0x07, 0x012, 0x20, 0x55, 0x55, 0x55, 0x55, 0x55, 0x55, 0x55, 0x55,
+                    0x07, 0x07, 0x12, 0x20, 0x55, 0x55, 0x55, 0x55, 0x55, 0x55, 0x55, 0x55, 0x55,
                     0x55, 0x55, 0x55, 0x55, 0x55, 0x55, 0x55, 0x55, 0x55, 0x55, 0x55, 0x55, 0x55,
-                    0x55, 0x55, 0x55, 0x55, 0x55, 0x55, 0x55, 0x55, 0x55, 0x55, 0x55,
+                    0x55, 0x55, 0x55, 0x55, 0x55, 0x55, 0x55, 0x55, 0x55, 0x55,
                 ][..];
 
                 connection.write_command(Command::Sync as u8, data, 0)?;
 
-                for _ in 0..10 {
+                for _ in 0..100 {
                     match connection.read_response()? {
                         Some(response) if response.return_op == Command::Sync as u8 => {
                             if response.status == 1 {
+                                let _error = connection.flush();
                                 return Err(Error::RomError(RomError::from(response.error)));
                             } else {
                                 break;
@@ -249,16 +250,17 @@ impl Flasher {
                     }
                 }
 
-                for _ in 0..7 {
-                    loop {
-                        match connection.read_response()? {
-                            Some(_) => break,
-                            _ => continue,
-                        }
-                    }
-                }
                 Ok(())
-            })
+            })?;
+        for _ in 0..7 {
+            for _ in 0..100 {
+                match self.connection.read_response()? {
+                    Some(_) => break,
+                    _ => continue,
+                }
+            }
+        }
+        Ok(())
     }
 
     fn start_connection(&mut self) -> Result<(), Error> {
@@ -525,12 +527,12 @@ impl Flasher {
             );
 
             for (i, block) in chunks.enumerate() {
-                pb_chunk.set_message(&format!("segment 0x{:X} writing chunks", addr));
+                pb_chunk.set_message(format!("segment 0x{:X} writing chunks", addr));
                 let block_padding = FLASH_WRITE_SIZE - block.len();
                 self.block_command(Command::FlashData, block, block_padding, 0xff, i as u32)?;
                 pb_chunk.inc(1);
             }
-            pb_chunk.finish_with_message(&format!("segment 0x{:X}", addr));
+            pb_chunk.finish_with_message(format!("segment 0x{:X}", addr));
         }
 
         self.flash_finish(false)?;
@@ -541,12 +543,17 @@ impl Flasher {
     }
 
     pub fn change_baud(&mut self, speed: BaudRate) -> Result<(), Error> {
+        let new_speed = (speed.speed() as u32).to_le_bytes();
+        let old_speed = 0u32.to_le_bytes();
+
         self.connection.command(
             Command::ChangeBaud as u8,
-            &(speed.speed()).to_le_bytes()[..],
+            &[new_speed, old_speed].concat()[..],
             0,
         )?;
         self.connection.set_baud(speed)?;
+        std::thread::sleep(Duration::from_secs_f32(0.05));
+        self.connection.flush()?;
         Ok(())
     }
 }


### PR DESCRIPTION
I think that the USB to serial chips may be impacting the reliability of the transfer at higher speeds.
I have basically duplicated the esptool retry mechanisms and made sure that buffers are flushed during retries rather than delaying for longer periods.

The boards that I have that wouldn't flash at speeds of 460800 are now flashing faster than 115200.

Might fix #18.