### PR TITLE
Remove references to Xargo and cargo xbuild

### DIFF
--- a/cargo-espflash/Cargo.toml
+++ b/cargo-espflash/Cargo.toml
@@ -18,3 +18,4 @@ serial = "0.4"
 color-eyre = "0.5.10"
 serde = { version = "1", features = ["derive"] }
 toml = "0.5"
+guess_host_triple = "0.1.2"

--- a/espflash/src/chip/mod.rs
+++ b/espflash/src/chip/mod.rs
@@ -102,14 +102,6 @@ impl Chip {
             Chip::Esp32 => Esp32::SPI_REGISTERS,
         }
     }
-
-    /// Get the target triplet for the chip
-    pub fn target(&self) -> &'static str {
-        match self {
-            Chip::Esp8266 => "xtensa-esp8266-none-elf",
-            Chip::Esp32 => "xtensa-esp32-none-elf",
-        }
-    }
 }
 
 impl FromStr for Chip {

--- a/espflash/src/config.rs
+++ b/espflash/src/config.rs
@@ -6,18 +6,11 @@ use std::fs::read;
 pub struct Config {
     #[serde(default)]
     pub connection: Connection,
-    #[serde(default)]
-    pub build: Build,
 }
 
 #[derive(Debug, Deserialize, Default)]
 pub struct Connection {
     pub serial: Option<String>,
-}
-
-#[derive(Debug, Deserialize, Default)]
-pub struct Build {
-    pub tool: Option<String>,
 }
 
 impl Config {


### PR DESCRIPTION
* Default to always use build-std.

Closes #28  