### PR TITLE
Improve builder

### DIFF
--- a/cargo-espflash/Cargo.toml
+++ b/cargo-espflash/Cargo.toml
@@ -15,7 +15,8 @@ cargo-project = "0.2.4"
 espflash = { version = "0.1.3", path = "../espflash" }
 pico-args = "0.4.0"
 serial = "0.4"
-color-eyre = "0.5.10"
 serde = { version = "1", features = ["derive"] }
 toml = "0.5"
+cargo_metadata = "0.14.0"
 guess_host_triple = "0.1.2"
+anyhow = "1.0"

--- a/cargo-espflash/src/cargo_config.rs
+++ b/cargo-espflash/src/cargo_config.rs
@@ -31,10 +31,8 @@ pub fn has_build_std<P: AsRef<Path>>(project_path: P) -> bool {
         Ok(toml) => toml,
         Err(_) => return false,
     };
-    toml.unstable
-        .build_std
-        .iter()
-        .any(|option| option == "core")
+
+    !toml.unstable.build_std.is_empty()
 }
 
 fn config_path(project_path: &Path) -> Option<PathBuf> {


### PR DESCRIPTION
Builds on top of #29 

Based on the way `cargo flash` handles [building the project](https://github.com/probe-rs/probe-rs/blob/9bdf72209e42b02db4911d958f45d46fb227e434/probe-rs-cli-util/src/lib.rs#L79).

With these changes I can successfully flash both bare metal Xtensa/RiscV esp programs & std library ones, such as [`ivmarkov`](https://github.com/ivmarkov/rust-esp32-std-hello)'s 