### PR TITLE
Update repository URLs, remove build tool info from README

### DIFF
--- a/cargo-espflash/Cargo.toml
+++ b/cargo-espflash/Cargo.toml
@@ -7,11 +7,10 @@ authors = [
     "Robin Appelman <robin@icewind.nl>",
     "Jesse Braham <jesse@beta7.io>",
 ]
-repository = "https://github.com/icewind1991/espflash"
+repository = "https://github.com/esp-rs/espflash"
 edition = "2018"
 
 [dependencies]
-cargo-project = "0.2.4"
 espflash = { version = "0.1.3", path = "../espflash" }
 pico-args = "0.4.0"
 serial = "0.4"

--- a/cargo-espflash/README.md
+++ b/cargo-espflash/README.md
@@ -2,31 +2,24 @@
 
 _ESP8266_ and _ESP32_ cross-compiler and serial flasher cargo subcommand.
 
-To build the project before flashing, `cargo-espflash` has a few options, specified with the `--tool TOOL` flag.
-
- - `--tool xbuild`, build using `cargo xbuild`. Requires [cargo xbuild](https://github.com/rust-osdev/cargo-xbuild) installed on your system. This is the default option.
- - `--tool cargo`, build using the `build-std` unstable cargo feature.
- - `--tool xargo`, build using `xargo`. Requires [xargo](https://github.com/japaric/xargo) installed on your system.
+Prior to flashing, the project is built using the `build-std` unstable cargo feature. Please refer to the [cargo documentation](https://doc.rust-lang.org/cargo/reference/unstable.html#build-std) for more information.
 
 ## Usage
 
 ```bash
-$ cargo espflash [--board-info] [--ram] [--release] [--example EXAMPLE] [--chip {esp32,esp8266}] [--tool {{cargo,xargo,xbuild}}] <serial>
+$ cargo espflash [--board-info] [--ram] [--release] [--example EXAMPLE] [--chip {esp32,esp8266}] <serial>
 ```
 
 When the `--ram` option is specified, the provided ELF image will be loaded into ram and executed without touching the flash.
 
 ### Config
 
-You can also specify the serial port or build tool by setting it in the config file located at `~/.config/espflash/espflash.toml` or Linux
+You can also specify the serial port by setting it in the config file located at `~/.config/espflash/espflash.toml` or Linux
 or `%APPDATA%/esp/espflash/espflash.toml` on Windows.
 
 ```toml
 [connection]
 serial = "/dev/ttyUSB0"
-
-[build]
-tool = "cargo"
 ```
 
 ### Example

--- a/espflash/Cargo.toml
+++ b/espflash/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Robin Appelman <robin@icewind.nl>"]
 edition = "2018"
 license = "GPL-2.0"
 description = "ESP8266 and ESP32 serial flasher"
-repository = "https://github.com/icewind1991/espflash"
+repository = "https://github.com/esp-rs/espflash"
 
 [[bin]]
 name = "espflash"


### PR DESCRIPTION
Just a few small things:

- update `repository` fields in both `Cargo.toml` files to point to organization
- remove any mention of build tools from the `cargo-espflash` README
- remove unused dependency from `cargo-espflash`