### PR TITLE
actually use the correct partition table when saving

### DIFF
--- a/espflash/src/chip/esp32/partition_table.rs
+++ b/espflash/src/chip/esp32/partition_table.rs
@@ -87,10 +87,8 @@ impl PartitionTable {
     }
 
     pub fn to_bytes(&self) -> Vec<u8> {
-        let table = PartitionTable::basic(0x10000, 0x3f0000);
-
         let mut result = Vec::with_capacity(PARTITION_TABLE_SIZE);
-        table.save(&mut result).unwrap();
+        self.save(&mut result).unwrap();
         result
     }
 


### PR DESCRIPTION
:see_no_evil: 