### PR TITLE
allow specifying partition table and bootloader in the projects Cargo.toml

### DIFF
--- a/cargo-espflash/Cargo.toml
+++ b/cargo-espflash/Cargo.toml
@@ -26,6 +26,7 @@ categories = [
 [dependencies]
 miette = "2"
 cargo_metadata = "0.14"
+cargo_toml = "0.10"
 clap = "2.33"
 crossterm = "0.21"
 espflash = { version = "*", path = "../espflash" }

--- a/cargo-espflash/README.md
+++ b/cargo-espflash/README.md
@@ -43,6 +43,16 @@ or `%APPDATA%/esp/espflash/espflash.toml` on Windows.
 serial = "/dev/ttyUSB0"
 ```
 
+### Package metadata
+
+You can also specify the bootloader or partition table for a project in the package metadata in `Cargo.toml`
+
+```toml
+[package.metadata.espflash]                                                                                                                                                                                                                                    
+partition_table = "partitions.csv"
+bootloader = "bootloader.bin"
+```
+
 ### Example
 
 ```bash

--- a/cargo-espflash/src/error.rs
+++ b/cargo-espflash/src/error.rs
@@ -26,4 +26,10 @@ pub enum Error {
         help("Please specify which artifact to flash using --bin")
     )]
     MultipleArtifacts,
+    #[error("Specified partition table is not a csv file")]
+    #[diagnostic(code(cargo_espflash::partition_table_path))]
+    InvalidPartitionTablePath,
+    #[error("Specified bootloader table is not a bin file")]
+    #[diagnostic(code(cargo_espflash::bootloader_path))]
+    InvalidBootloaderPath,
 }

--- a/cargo-espflash/src/package_metadata.rs
+++ b/cargo-espflash/src/package_metadata.rs
@@ -1,0 +1,43 @@
+use crate::error::Error;
+use cargo_toml::Manifest;
+use miette::{IntoDiagnostic, Result, WrapErr};
+use serde::Deserialize;
+use std::path::Path;
+
+#[derive(Clone, Debug, Deserialize, Default)]
+pub struct CargoEspFlashMeta {
+    pub partition_table: Option<String>,
+    pub bootloader: Option<String>,
+}
+
+#[derive(Clone, Debug, Default, Deserialize)]
+pub struct Meta {
+    pub espflash: Option<CargoEspFlashMeta>,
+}
+
+impl CargoEspFlashMeta {
+    pub fn load<P: AsRef<Path>>(path: P) -> Result<CargoEspFlashMeta> {
+        let manifest = Manifest::<Meta>::from_path_with_metadata(path)
+            .into_diagnostic()
+            .wrap_err("Failed to parse Cargo.toml")?;
+        let meta = manifest
+            .package
+            .and_then(|pkg| pkg.metadata)
+            .unwrap_or_default()
+            .espflash
+            .unwrap_or_default();
+        match meta.partition_table {
+            Some(table) if !table.ends_with(".csv") => {
+                return Err(Error::InvalidPartitionTablePath.into())
+            }
+            _ => {}
+        }
+        match meta.bootloader {
+            Some(table) if !table.ends_with(".bin") => {
+                return Err(Error::InvalidBootloaderPath.into())
+            }
+            _ => {}
+        }
+        Ok(meta)
+    }
+}


### PR DESCRIPTION
Allow specifying the partition table and bootloader in the project configuration to save users from having to specify the command line options every time.

This currently has a hard requirement on the file extensions of partition table and bootloader files, to keep the option open to have different non-filename options for these fields in the future (maybe specifying a crate name for the bootloader or something)