### PR TITLE
fallback to regular flashing if compressed flashing times out

### DIFF
--- a/espflash/src/flash_target/esp8266.rs
+++ b/espflash/src/flash_target/esp8266.rs
@@ -29,7 +29,7 @@ impl FlashTarget for Esp8266Target {
     fn write_segment(
         &mut self,
         connection: &mut Connection,
-        segment: RomSegment,
+        segment: &RomSegment,
     ) -> Result<(), Error> {
         let addr = segment.addr;
         let block_count = (segment.data.len() + FLASH_WRITE_SIZE - 1) / FLASH_WRITE_SIZE;

--- a/espflash/src/flash_target/failover.rs
+++ b/espflash/src/flash_target/failover.rs
@@ -1,0 +1,63 @@
+use crate::connection::Connection;
+use crate::elf::{FirmwareImage, RomSegment};
+use crate::error::{ConnectionError, Error};
+use crate::flash_target::FlashTarget;
+
+pub struct FailOver {
+    first: Box<dyn FlashTarget>,
+    second: Box<dyn FlashTarget>,
+    first_failed: bool,
+}
+
+impl FailOver {
+    /// Note, this only works for targets that are close enough together
+    pub fn new(first: impl FlashTarget + 'static, second: impl FlashTarget + 'static) -> Self {
+        FailOver {
+            first: Box::new(first),
+            second: Box::new(second),
+            first_failed: false,
+        }
+    }
+
+    pub fn active(&mut self) -> &mut dyn FlashTarget {
+        if !self.first_failed {
+            self.first.as_mut()
+        } else {
+            self.second.as_mut()
+        }
+    }
+
+    pub fn fail_over(&mut self, err: Error) -> Result<(), Error> {
+        if self.first_failed {
+            Err(err)
+        } else {
+            self.first_failed = true;
+            Ok(())
+        }
+    }
+}
+
+impl FlashTarget for FailOver {
+    fn begin(&mut self, connection: &mut Connection, image: &FirmwareImage) -> Result<(), Error> {
+        self.active().begin(connection, image)
+    }
+
+    fn write_segment(
+        &mut self,
+        connection: &mut Connection,
+        segment: &RomSegment,
+    ) -> Result<(), Error> {
+        match self.active().write_segment(connection, segment) {
+            Err(err @ Error::Flashing(ConnectionError::Timeout))
+            | Err(err @ Error::Connection(ConnectionError::Timeout)) => {
+                self.fail_over(err)?;
+                self.active().write_segment(connection, segment)
+            }
+            res => res,
+        }
+    }
+
+    fn finish(&mut self, connection: &mut Connection, reboot: bool) -> Result<(), Error> {
+        self.active().finish(connection, reboot)
+    }
+}

--- a/espflash/src/flash_target/mod.rs
+++ b/espflash/src/flash_target/mod.rs
@@ -1,5 +1,7 @@
 mod esp32;
+mod esp32_compressed;
 mod esp8266;
+mod failover;
 mod ram;
 
 use crate::connection::Connection;
@@ -8,7 +10,9 @@ use crate::error::Error;
 use crate::flasher::{checksum, Command, Encoder, CHECKSUM_INIT, FLASH_WRITE_SIZE};
 use bytemuck::{bytes_of, Pod, Zeroable};
 pub use esp32::Esp32Target;
+pub use esp32_compressed::Esp32CompressedTarget;
 pub use esp8266::Esp8266Target;
+pub use failover::FailOver;
 pub use ram::RamTarget;
 use std::mem::size_of;
 use std::time::Duration;
@@ -18,7 +22,7 @@ pub trait FlashTarget {
     fn write_segment(
         &mut self,
         connection: &mut Connection,
-        segment: RomSegment,
+        segment: &RomSegment,
     ) -> Result<(), Error>;
     fn finish(&mut self, connection: &mut Connection, reboot: bool) -> Result<(), Error>;
 }

--- a/espflash/src/flash_target/ram.rs
+++ b/espflash/src/flash_target/ram.rs
@@ -31,7 +31,7 @@ impl FlashTarget for RamTarget {
     fn write_segment(
         &mut self,
         connection: &mut Connection,
-        segment: RomSegment,
+        segment: &RomSegment,
     ) -> Result<(), Error> {
         const MAX_RAM_BLOCK_SIZE: usize = 0x1800;
 

--- a/espflash/src/flasher.rs
+++ b/espflash/src/flasher.rs
@@ -479,7 +479,7 @@ impl Flasher {
             target
                 .write_segment(
                     &mut self.connection,
-                    RomSegment {
+                    &RomSegment {
                         addr: segment.addr,
                         data: segment.data.into(),
                     },
@@ -508,7 +508,7 @@ impl Flasher {
             .get_flash_segments(&image, bootloader, partition_table)
         {
             target
-                .write_segment(&mut self.connection, segment?)
+                .write_segment(&mut self.connection, &segment?)
                 .flashing()?;
         }
 


### PR DESCRIPTION
For some unknown reason, sometimes the `FlashDeflateBegin` times out for me, while `FlashBegin` never seems to have this issue.

To prevent this from being an issue for users while still providing the highest potential flashing speeds, this adds a failover mechanism, where it first tries to do a compressed flash. And if the compressed flash times out it will fallback to the regular flash.