### PR TITLE
disable software flowcontrol for serial

### DIFF
--- a/cargo-espflash/src/main.rs
+++ b/cargo-espflash/src/main.rs
@@ -6,7 +6,7 @@ use espflash::{Config, Flasher, PartitionTable};
 use miette::{IntoDiagnostic, Result, WrapErr};
 use monitor::monitor;
 use package_metadata::CargoEspFlashMeta;
-use serial::{BaudRate, SerialPort};
+use serial::{BaudRate, FlowControl, SerialPort};
 use std::{
     fs,
     path::PathBuf,
@@ -137,6 +137,7 @@ fn main() -> Result<()> {
         .wrap_err_with(|| format!("Failed to open serial port {}", port))?;
     serial
         .reconfigure(&|settings| {
+            settings.set_flow_control(FlowControl::FlowNone);
             settings.set_baud_rate(BaudRate::Baud115200)?;
             Ok(())
         })

--- a/espflash/src/connection.rs
+++ b/espflash/src/connection.rs
@@ -56,7 +56,7 @@ impl Connection {
 
         sleep(Duration::from_millis(50));
 
-        self.serial.set_dtr(true)?;
+        self.serial.set_dtr(false)?;
 
         Ok(())
     }

--- a/espflash/src/main.rs
+++ b/espflash/src/main.rs
@@ -3,7 +3,7 @@ use std::fs::read;
 use espflash::{Config, Error, Flasher};
 use miette::{IntoDiagnostic, Result, WrapErr};
 use pico_args::Arguments;
-use serial::{BaudRate, SerialPort};
+use serial::{BaudRate, FlowControl, SerialPort};
 
 #[allow(clippy::unnecessary_wraps)]
 fn help() -> Result<()> {
@@ -40,6 +40,7 @@ fn main() -> Result<()> {
         .wrap_err_with(|| format!("Failed to open serial port {}", serial))?;
     serial
         .reconfigure(&|settings| {
+            settings.set_flow_control(FlowControl::FlowNone);
             settings.set_baud_rate(BaudRate::Baud115200)?;
 
             Ok(())


### PR DESCRIPTION
Having software flow control enabled causes `FlashDeflateBegin` to time out for some reason