### PR TITLE
split image formats into it's own modules

### DIFF
--- a/espflash/src/chip/esp32.rs
+++ b/espflash/src/chip/esp32.rs
@@ -7,6 +7,7 @@ use crate::{
     Error, PartitionTable,
 };
 
+use std::ops::Range;
 use std::{borrow::Cow, iter::once};
 
 pub struct Esp32;
@@ -42,10 +43,8 @@ impl ChipType for Esp32 {
         miso_length_offset: Some(0x2c),
     };
 
-    fn addr_is_flash(addr: u32) -> bool {
-        (IROM_MAP_START..IROM_MAP_END).contains(&addr)
-            || (DROM_MAP_START..DROM_MAP_END).contains(&addr)
-    }
+    const FLASH_RANGES: &'static [Range<u32>] =
+        &[IROM_MAP_START..IROM_MAP_END, DROM_MAP_START..DROM_MAP_END];
 
     fn get_flash_segments<'a>(
         image: &'a FirmwareImage,

--- a/espflash/src/chip/esp32c3.rs
+++ b/espflash/src/chip/esp32c3.rs
@@ -5,6 +5,7 @@ use crate::{
     elf::{FirmwareImage, RomSegment},
     Chip, Error, PartitionTable,
 };
+use std::ops::Range;
 use std::{borrow::Cow, iter::once};
 
 pub struct Esp32c3;
@@ -41,10 +42,8 @@ impl ChipType for Esp32c3 {
         miso_length_offset: Some(0x28),
     };
 
-    fn addr_is_flash(addr: u32) -> bool {
-        (IROM_MAP_START..IROM_MAP_END).contains(&addr)
-            || (DROM_MAP_START..DROM_MAP_END).contains(&addr)
-    }
+    const FLASH_RANGES: &'static [Range<u32>] =
+        &[IROM_MAP_START..IROM_MAP_END, DROM_MAP_START..DROM_MAP_END];
 
     fn get_flash_segments<'a>(
         image: &'a FirmwareImage,

--- a/espflash/src/chip/esp32c3.rs
+++ b/espflash/src/chip/esp32c3.rs
@@ -5,7 +5,7 @@ use crate::{
     elf::FirmwareImage,
     Chip, Error, PartitionTable,
 };
-use std::borrow::Cow;
+
 use std::ops::Range;
 
 pub struct Esp32c3;
@@ -26,6 +26,7 @@ pub const PARAMS: Esp32Params = Esp32Params {
     app_addr: 0x10000,
     app_size: 0x3f0000,
     chip_id: 5,
+    default_bootloader: include_bytes!("../../bootloader/esp32c3-bootloader.bin"),
 };
 
 impl ChipType for Esp32c3 {
@@ -56,21 +57,13 @@ impl ChipType for Esp32c3 {
         image_format: ImageFormatId,
     ) -> Result<Box<dyn ImageFormat<'a> + 'a>, Error> {
         match image_format {
-            ImageFormatId::Bootloader => {
-                let bootloader = if let Some(bytes) = bootloader {
-                    Cow::Owned(bytes)
-                } else {
-                    Cow::Borrowed(&include_bytes!("../../bootloader/esp32c3-bootloader.bin")[..])
-                };
-
-                Ok(Box::new(Esp32BootloaderFormat::new(
-                    image,
-                    Chip::Esp32c3,
-                    PARAMS,
-                    partition_table,
-                    bootloader,
-                )?))
-            }
+            ImageFormatId::Bootloader => Ok(Box::new(Esp32BootloaderFormat::new(
+                image,
+                Chip::Esp32c3,
+                PARAMS,
+                partition_table,
+                bootloader,
+            )?)),
             ImageFormatId::DirectBoot => {
                 todo!()
             }

--- a/espflash/src/chip/esp32c3.rs
+++ b/espflash/src/chip/esp32c3.rs
@@ -1,4 +1,5 @@
-use crate::chip::esp32::get_data;
+use crate::chip::Esp32Params;
+use crate::image_format::{Esp32BootloaderFormat, ImageFormat};
 use crate::{
     chip::{ChipType, SpiRegisters},
     elf::{FirmwareImage, RomSegment},
@@ -14,15 +15,17 @@ const IROM_MAP_END: u32 = 0x42800000;
 const DROM_MAP_START: u32 = 0x3c000000;
 const DROM_MAP_END: u32 = 0x3c800000;
 
-const BOOT_ADDR: u32 = 0x0;
-const PARTITION_ADDR: u32 = 0x8000;
-const NVS_ADDR: u32 = 0x9000;
-const PHY_INIT_DATA_ADDR: u32 = 0xf000;
-const APP_ADDR: u32 = 0x10000;
-
-const NVS_SIZE: u32 = 0x6000;
-const PHY_INIT_DATA_SIZE: u32 = 0x1000;
-const APP_SIZE: u32 = 0x3f0000;
+pub const PARAMS: Esp32Params = Esp32Params {
+    boot_addr: 0x0,
+    partition_addr: 0x8000,
+    nvs_addr: 0x9000,
+    nvs_size: 0x6000,
+    phy_init_data_addr: 0xf000,
+    phy_init_data_size: 0x1000,
+    app_addr: 0x10000,
+    app_size: 0x3f0000,
+    chip_id: 5,
+};
 
 impl ChipType for Esp32c3 {
     const CHIP_DETECT_MAGIC_VALUE: u32 = 0x6921506f;
@@ -49,36 +52,14 @@ impl ChipType for Esp32c3 {
         partition_table: Option<PartitionTable>,
     ) -> Box<dyn Iterator<Item = Result<RomSegment<'a>, Error>> + 'a> {
         let bootloader = if let Some(bytes) = bootloader {
-            bytes
+            Cow::Owned(bytes)
         } else {
-            let bytes = include_bytes!("../../bootloader/esp32c3-bootloader.bin");
-            bytes.to_vec()
+            Cow::Borrowed(&include_bytes!("../../bootloader/esp32c3-bootloader.bin")[..])
         };
 
-        let partition_table = if let Some(table) = partition_table {
-            table
-        } else {
-            PartitionTable::basic(
-                NVS_ADDR,
-                NVS_SIZE,
-                PHY_INIT_DATA_ADDR,
-                PHY_INIT_DATA_SIZE,
-                APP_ADDR,
-                APP_SIZE,
-            )
-        };
-        let partition_table = partition_table.to_bytes();
-
-        Box::new(
-            once(Ok(RomSegment {
-                addr: BOOT_ADDR,
-                data: Cow::Owned(bootloader),
-            }))
-            .chain(once(Ok(RomSegment {
-                addr: PARTITION_ADDR,
-                data: Cow::Owned(partition_table),
-            })))
-            .chain(once(get_data(image, 5, Chip::Esp32c3))),
-        )
+        match Esp32BootloaderFormat::new(image, Chip::Esp32, PARAMS, partition_table, bootloader) {
+            Ok(format) => Box::new(format.segments().map(Ok)),
+            Err(e) => Box::new(once(Err(e))),
+        }
     }
 }

--- a/espflash/src/chip/esp32c3.rs
+++ b/espflash/src/chip/esp32c3.rs
@@ -1,12 +1,12 @@
 use crate::chip::Esp32Params;
-use crate::image_format::{Esp32BootloaderFormat, ImageFormat};
+use crate::image_format::{Esp32BootloaderFormat, ImageFormat, ImageFormatId};
 use crate::{
     chip::{ChipType, SpiRegisters},
-    elf::{FirmwareImage, RomSegment},
+    elf::FirmwareImage,
     Chip, Error, PartitionTable,
 };
+use std::borrow::Cow;
 use std::ops::Range;
-use std::{borrow::Cow, iter::once};
 
 pub struct Esp32c3;
 
@@ -45,20 +45,35 @@ impl ChipType for Esp32c3 {
     const FLASH_RANGES: &'static [Range<u32>] =
         &[IROM_MAP_START..IROM_MAP_END, DROM_MAP_START..DROM_MAP_END];
 
+    const DEFAULT_IMAGE_FORMAT: ImageFormatId = ImageFormatId::Bootloader;
+    const SUPPORTED_IMAGE_FORMATS: &'static [ImageFormatId] =
+        &[ImageFormatId::Bootloader, ImageFormatId::DirectBoot];
+
     fn get_flash_segments<'a>(
         image: &'a FirmwareImage,
         bootloader: Option<Vec<u8>>,
         partition_table: Option<PartitionTable>,
-    ) -> Box<dyn Iterator<Item = Result<RomSegment<'a>, Error>> + 'a> {
-        let bootloader = if let Some(bytes) = bootloader {
-            Cow::Owned(bytes)
-        } else {
-            Cow::Borrowed(&include_bytes!("../../bootloader/esp32c3-bootloader.bin")[..])
-        };
+        image_format: ImageFormatId,
+    ) -> Result<Box<dyn ImageFormat<'a> + 'a>, Error> {
+        match image_format {
+            ImageFormatId::Bootloader => {
+                let bootloader = if let Some(bytes) = bootloader {
+                    Cow::Owned(bytes)
+                } else {
+                    Cow::Borrowed(&include_bytes!("../../bootloader/esp32c3-bootloader.bin")[..])
+                };
 
-        match Esp32BootloaderFormat::new(image, Chip::Esp32, PARAMS, partition_table, bootloader) {
-            Ok(format) => Box::new(format.segments().map(Ok)),
-            Err(e) => Box::new(once(Err(e))),
+                Ok(Box::new(Esp32BootloaderFormat::new(
+                    image,
+                    Chip::Esp32c3,
+                    PARAMS,
+                    partition_table,
+                    bootloader,
+                )?))
+            }
+            ImageFormatId::DirectBoot => {
+                todo!()
+            }
         }
     }
 }

--- a/espflash/src/chip/esp32s2.rs
+++ b/espflash/src/chip/esp32s2.rs
@@ -5,7 +5,7 @@ use crate::{
     elf::FirmwareImage,
     Chip, Error, PartitionTable,
 };
-use std::borrow::Cow;
+
 use std::ops::Range;
 
 pub struct Esp32s2;
@@ -26,6 +26,7 @@ pub const PARAMS: Esp32Params = Esp32Params {
     app_addr: 0x10000,
     app_size: 0x100000,
     chip_id: 2,
+    default_bootloader: include_bytes!("../../bootloader/esp32s2-bootloader.bin"),
 };
 
 impl ChipType for Esp32s2 {
@@ -54,21 +55,13 @@ impl ChipType for Esp32s2 {
         image_format: ImageFormatId,
     ) -> Result<Box<dyn ImageFormat<'a> + 'a>, Error> {
         match image_format {
-            ImageFormatId::Bootloader => {
-                let bootloader = if let Some(bytes) = bootloader {
-                    Cow::Owned(bytes)
-                } else {
-                    Cow::Borrowed(&include_bytes!("../../bootloader/esp32s2-bootloader.bin")[..])
-                };
-
-                Ok(Box::new(Esp32BootloaderFormat::new(
-                    image,
-                    Chip::Esp32s2,
-                    PARAMS,
-                    partition_table,
-                    bootloader,
-                )?))
-            }
+            ImageFormatId::Bootloader => Ok(Box::new(Esp32BootloaderFormat::new(
+                image,
+                Chip::Esp32s2,
+                PARAMS,
+                partition_table,
+                bootloader,
+            )?)),
             ImageFormatId::DirectBoot => {
                 todo!()
             }

--- a/espflash/src/chip/esp32s2.rs
+++ b/espflash/src/chip/esp32s2.rs
@@ -5,6 +5,7 @@ use crate::{
     elf::{FirmwareImage, RomSegment},
     Chip, Error, PartitionTable,
 };
+use std::ops::Range;
 use std::{borrow::Cow, iter::once};
 
 pub struct Esp32s2;
@@ -40,10 +41,8 @@ impl ChipType for Esp32s2 {
         miso_length_offset: Some(0x28),
     };
 
-    fn addr_is_flash(addr: u32) -> bool {
-        (IROM_MAP_START..IROM_MAP_END).contains(&addr)
-            || (DROM_MAP_START..DROM_MAP_END).contains(&addr)
-    }
+    const FLASH_RANGES: &'static [Range<u32>] =
+        &[IROM_MAP_START..IROM_MAP_END, DROM_MAP_START..DROM_MAP_END];
 
     fn get_flash_segments<'a>(
         image: &'a FirmwareImage,

--- a/espflash/src/chip/esp32s2.rs
+++ b/espflash/src/chip/esp32s2.rs
@@ -1,12 +1,12 @@
 use crate::chip::Esp32Params;
-use crate::image_format::{Esp32BootloaderFormat, ImageFormat};
+use crate::image_format::{Esp32BootloaderFormat, ImageFormat, ImageFormatId};
 use crate::{
     chip::{ChipType, SpiRegisters},
-    elf::{FirmwareImage, RomSegment},
+    elf::FirmwareImage,
     Chip, Error, PartitionTable,
 };
+use std::borrow::Cow;
 use std::ops::Range;
-use std::{borrow::Cow, iter::once};
 
 pub struct Esp32s2;
 
@@ -44,20 +44,34 @@ impl ChipType for Esp32s2 {
     const FLASH_RANGES: &'static [Range<u32>] =
         &[IROM_MAP_START..IROM_MAP_END, DROM_MAP_START..DROM_MAP_END];
 
+    const DEFAULT_IMAGE_FORMAT: ImageFormatId = ImageFormatId::Bootloader;
+    const SUPPORTED_IMAGE_FORMATS: &'static [ImageFormatId] = &[ImageFormatId::Bootloader];
+
     fn get_flash_segments<'a>(
         image: &'a FirmwareImage,
         bootloader: Option<Vec<u8>>,
         partition_table: Option<PartitionTable>,
-    ) -> Box<dyn Iterator<Item = Result<RomSegment<'a>, Error>> + 'a> {
-        let bootloader = if let Some(bytes) = bootloader {
-            Cow::Owned(bytes)
-        } else {
-            Cow::Borrowed(&include_bytes!("../../bootloader/esp32s2-bootloader.bin")[..])
-        };
+        image_format: ImageFormatId,
+    ) -> Result<Box<dyn ImageFormat<'a> + 'a>, Error> {
+        match image_format {
+            ImageFormatId::Bootloader => {
+                let bootloader = if let Some(bytes) = bootloader {
+                    Cow::Owned(bytes)
+                } else {
+                    Cow::Borrowed(&include_bytes!("../../bootloader/esp32s2-bootloader.bin")[..])
+                };
 
-        match Esp32BootloaderFormat::new(image, Chip::Esp32, PARAMS, partition_table, bootloader) {
-            Ok(format) => Box::new(format.segments().map(Ok)),
-            Err(e) => Box::new(once(Err(e))),
+                Ok(Box::new(Esp32BootloaderFormat::new(
+                    image,
+                    Chip::Esp32s2,
+                    PARAMS,
+                    partition_table,
+                    bootloader,
+                )?))
+            }
+            ImageFormatId::DirectBoot => {
+                todo!()
+            }
         }
     }
 }

--- a/espflash/src/chip/esp8266.rs
+++ b/espflash/src/chip/esp8266.rs
@@ -1,15 +1,12 @@
-use bytemuck::bytes_of;
-
-use super::{ChipType, EspCommonHeader, SegmentHeader, ESP_MAGIC};
+use super::ChipType;
 use crate::{
-    chip::{Chip, SpiRegisters},
-    elf::{update_checksum, CodeSegment, FirmwareImage, RomSegment, ESP_CHECKSUM_MAGIC},
-    error::FlashDetectError,
-    flasher::FlashSize,
+    chip::SpiRegisters,
+    elf::{FirmwareImage, RomSegment},
     Error, PartitionTable,
 };
 
-use std::{borrow::Cow, io::Write, iter::once, mem::size_of};
+use crate::image_format::{Esp8266Format, ImageFormat};
+use std::iter::once;
 
 pub const IROM_MAP_START: u32 = 0x40200000;
 const IROM_MAP_END: u32 = 0x40300000;
@@ -38,101 +35,10 @@ impl ChipType for Esp8266 {
         _bootloader: Option<Vec<u8>>,
         _partition_table: Option<PartitionTable>,
     ) -> Box<dyn Iterator<Item = Result<RomSegment<'a>, Error>> + 'a> {
-        // irom goes into a separate plain bin
-        let irom_data = merge_rom_segments(image.rom_segments(Chip::Esp8266))
-            .into_iter()
-            .map(Ok);
-
-        // my kingdom for a try {} block
-        fn common<'a>(image: &'a FirmwareImage) -> Result<RomSegment<'a>, Error> {
-            let mut common_data = Vec::with_capacity(
-                image
-                    .ram_segments(Chip::Esp8266)
-                    .map(|segment| segment.size() as usize)
-                    .sum(),
-            );
-            // common header
-            let header = EspCommonHeader {
-                magic: ESP_MAGIC,
-                segment_count: image.ram_segments(Chip::Esp8266).count() as u8,
-                flash_mode: image.flash_mode as u8,
-                flash_config: encode_flash_size(image.flash_size)? + image.flash_frequency as u8,
-                entry: image.entry,
-            };
-            common_data.write_all(bytes_of(&header))?;
-
-            let mut total_len = 8;
-
-            let mut checksum = ESP_CHECKSUM_MAGIC;
-
-            for segment in image.ram_segments(Chip::Esp8266) {
-                let data = segment.data();
-                let padding = 4 - data.len() % 4;
-                let segment_header = SegmentHeader {
-                    addr: segment.addr,
-                    length: (data.len() + padding) as u32,
-                };
-                total_len += size_of::<SegmentHeader>() as u32 + segment_header.length;
-                common_data.write_all(bytes_of(&segment_header))?;
-                common_data.write_all(data)?;
-
-                let padding = &[0u8; 4][0..padding];
-                common_data.write_all(padding)?;
-                checksum = update_checksum(data, checksum);
-            }
-
-            let padding = 15 - (total_len % 16);
-            let padding = &[0u8; 16][0..padding as usize];
-            common_data.write_all(padding)?;
-
-            common_data.write_all(&[checksum])?;
-
-            Ok(RomSegment {
-                addr: 0,
-                data: Cow::Owned(common_data),
-            })
+        match Esp8266Format::new(image) {
+            Ok(format) => Box::new(format.segments().map(Ok)),
+            Err(e) => Box::new(once(Err(e))),
         }
-
-        Box::new(irom_data.chain(once(common(image))))
-    }
-}
-
-fn encode_flash_size(size: FlashSize) -> Result<u8, FlashDetectError> {
-    match size {
-        FlashSize::Flash256Kb => Ok(0x10),
-        FlashSize::Flash512Kb => Ok(0x00),
-        FlashSize::Flash1Mb => Ok(0x20),
-        FlashSize::Flash2Mb => Ok(0x30),
-        FlashSize::Flash4Mb => Ok(0x40),
-        FlashSize::Flash8Mb => Ok(0x80),
-        FlashSize::Flash16Mb => Ok(0x90),
-        FlashSize::FlashRetry => Err(FlashDetectError::from(size as u8)),
-    }
-}
-
-fn merge_rom_segments<'a>(
-    mut segments: impl Iterator<Item = CodeSegment<'a>>,
-) -> Option<RomSegment<'a>> {
-    let first = segments.next()?;
-    if let Some(second) = segments.next() {
-        let mut data = Vec::with_capacity(first.data().len() + second.data().len());
-        data.extend_from_slice(first.data());
-
-        for segment in once(second).chain(segments) {
-            let padding_size = segment.addr as usize - first.addr as usize - data.len();
-            data.resize(data.len() + padding_size, 0);
-            data.extend_from_slice(segment.data());
-        }
-
-        Some(RomSegment {
-            addr: first.addr - IROM_MAP_START,
-            data: Cow::Owned(data),
-        })
-    } else {
-        Some(RomSegment {
-            addr: first.addr - IROM_MAP_START,
-            data: Cow::Owned(first.data().into()),
-        })
     }
 }
 

--- a/espflash/src/chip/esp8266.rs
+++ b/espflash/src/chip/esp8266.rs
@@ -7,6 +7,7 @@ use crate::{
 
 use crate::image_format::{Esp8266Format, ImageFormat};
 use std::iter::once;
+use std::ops::Range;
 
 pub const IROM_MAP_START: u32 = 0x40200000;
 const IROM_MAP_END: u32 = 0x40300000;
@@ -26,9 +27,7 @@ impl ChipType for Esp8266 {
         miso_length_offset: None,
     };
 
-    fn addr_is_flash(addr: u32) -> bool {
-        (IROM_MAP_START..IROM_MAP_END).contains(&addr)
-    }
+    const FLASH_RANGES: &'static [Range<u32>] = &[IROM_MAP_START..IROM_MAP_END];
 
     fn get_flash_segments<'a>(
         image: &'a FirmwareImage,

--- a/espflash/src/chip/mod.rs
+++ b/espflash/src/chip/mod.rs
@@ -1,15 +1,12 @@
-use bytemuck::{bytes_of, Pod, Zeroable};
 use strum_macros::Display;
 
 use crate::{
-    elf::{update_checksum, CodeSegment, FirmwareImage, RomSegment},
-    error::{ChipDetectError, FlashDetectError},
+    elf::{FirmwareImage, RomSegment},
+    error::ChipDetectError,
     flash_target::{Esp32Target, Esp8266Target, FlashTarget, RamTarget},
-    flasher::{FlashSize, SpiAttachParams},
+    flasher::SpiAttachParams,
     Error, PartitionTable,
 };
-
-use std::io::Write;
 
 pub use esp32::Esp32;
 pub use esp32c3::Esp32c3;
@@ -21,14 +18,13 @@ mod esp32c3;
 mod esp32s2;
 mod esp8266;
 
-const ESP_MAGIC: u8 = 0xE9;
-const WP_PIN_DISABLED: u8 = 0xEE;
-
 pub trait ChipType {
     const CHIP_DETECT_MAGIC_VALUE: u32;
     const CHIP_DETECT_MAGIC_VALUE2: u32 = 0x0; // give default value, as most chips don't only have one
 
     const SPI_REGISTERS: SpiRegisters;
+
+    fn addr_is_flash(addr: u32) -> bool;
 
     /// Get the firmware segments for writing an image to flash
     fn get_flash_segments<'a>(
@@ -36,8 +32,6 @@ pub trait ChipType {
         bootloader: Option<Vec<u8>>,
         partition_table: Option<PartitionTable>,
     ) -> Box<dyn Iterator<Item = Result<RomSegment<'a>, Error>> + 'a>;
-
-    fn addr_is_flash(addr: u32) -> bool;
 }
 
 pub struct SpiRegisters {
@@ -78,19 +72,6 @@ impl SpiRegisters {
     pub fn miso_length(&self) -> Option<u32> {
         self.miso_length_offset.map(|offset| self.base + offset)
     }
-}
-
-#[derive(Copy, Clone, Zeroable, Pod)]
-#[repr(C)]
-struct ExtendedHeader {
-    wp_pin: u8,
-    clk_q_drv: u8,
-    d_cs_drv: u8,
-    gd_wp_drv: u8,
-    chip_id: u16,
-    min_rev: u8,
-    padding: [u8; 8],
-    append_digest: u8,
 }
 
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Display)]
@@ -162,90 +143,28 @@ impl Chip {
     }
 }
 
-#[derive(Copy, Clone, Zeroable, Pod, Debug)]
-#[repr(C)]
-struct EspCommonHeader {
-    magic: u8,
-    segment_count: u8,
-    flash_mode: u8,
-    flash_config: u8,
-    entry: u32,
+#[derive(Clone, Copy, Debug)]
+pub struct Esp32Params {
+    pub boot_addr: u32,
+    pub partition_addr: u32,
+    pub nvs_addr: u32,
+    pub nvs_size: u32,
+    pub phy_init_data_addr: u32,
+    pub phy_init_data_size: u32,
+    pub app_addr: u32,
+    pub app_size: u32,
+    pub chip_id: u16,
 }
 
-#[derive(Copy, Clone, Zeroable, Pod, Debug)]
-#[repr(C)]
-struct SegmentHeader {
-    addr: u32,
-    length: u32,
-}
-
-// Note that this function ONLY applies to the ESP32 and variants; the ESP8266
-// has defined its own version rather than using this implementation.
-fn encode_flash_size(size: FlashSize) -> Result<u8, FlashDetectError> {
-    match size {
-        FlashSize::Flash256Kb => Err(FlashDetectError::from(size as u8)),
-        FlashSize::Flash512Kb => Err(FlashDetectError::from(size as u8)),
-        FlashSize::Flash1Mb => Ok(0x00),
-        FlashSize::Flash2Mb => Ok(0x10),
-        FlashSize::Flash4Mb => Ok(0x20),
-        FlashSize::Flash8Mb => Ok(0x30),
-        FlashSize::Flash16Mb => Ok(0x40),
-        FlashSize::FlashRetry => Err(FlashDetectError::from(size as u8)),
+impl Esp32Params {
+    pub fn default_partition_table(&self) -> PartitionTable {
+        PartitionTable::basic(
+            self.nvs_addr,
+            self.nvs_size,
+            self.phy_init_data_addr,
+            self.phy_init_data_size,
+            self.app_addr,
+            self.app_size,
+        )
     }
-}
-
-const IROM_ALIGN: u32 = 65536;
-const SEG_HEADER_LEN: u32 = 8;
-
-/// Actual alignment (in data bytes) required for a segment header: positioned
-/// so that after we write the next 8 byte header, file_offs % IROM_ALIGN ==
-/// segment.addr % IROM_ALIGN
-///
-/// (this is because the segment's vaddr may not be IROM_ALIGNed, more likely is
-/// aligned IROM_ALIGN+0x18 to account for the binary file header
-fn get_segment_padding(offset: usize, segment: &CodeSegment) -> u32 {
-    let align_past = (segment.addr - SEG_HEADER_LEN) % IROM_ALIGN;
-    let pad_len = ((IROM_ALIGN - ((offset as u32) % IROM_ALIGN)) + align_past) % IROM_ALIGN;
-    if pad_len == 0 || pad_len == IROM_ALIGN {
-        0
-    } else if pad_len > SEG_HEADER_LEN {
-        pad_len - SEG_HEADER_LEN
-    } else {
-        pad_len + IROM_ALIGN - SEG_HEADER_LEN
-    }
-}
-
-fn save_flash_segment(
-    data: &mut Vec<u8>,
-    segment: &CodeSegment,
-    checksum: u8,
-) -> Result<u8, Error> {
-    let end_pos = (data.len() + segment.data().len()) as u32 + SEG_HEADER_LEN;
-    let segment_reminder = end_pos % IROM_ALIGN;
-
-    let checksum = save_segment(data, segment, checksum)?;
-
-    if segment_reminder < 0x24 {
-        // Work around a bug in ESP-IDF 2nd stage bootloader, that it didn't map the
-        // last MMU page, if an IROM/DROM segment was < 0x24 bytes over the page
-        // boundary.
-        data.write_all(&[0u8; 0x24][0..(0x24 - segment_reminder as usize)])?;
-    }
-    Ok(checksum)
-}
-
-fn save_segment(data: &mut Vec<u8>, segment: &CodeSegment, checksum: u8) -> Result<u8, Error> {
-    let padding = (4 - segment.size() % 4) % 4;
-
-    let header = SegmentHeader {
-        addr: segment.addr,
-        length: segment.size() + padding,
-    };
-    data.write_all(bytes_of(&header))?;
-    data.write_all(segment.data())?;
-
-    let padding = &[0u8; 4][0..padding as usize];
-    data.write_all(padding)?;
-
-    Ok(update_checksum(segment.data(), checksum))
 }

--- a/espflash/src/chip/mod.rs
+++ b/espflash/src/chip/mod.rs
@@ -188,6 +188,7 @@ pub struct Esp32Params {
     pub app_addr: u32,
     pub app_size: u32,
     pub chip_id: u16,
+    pub default_bootloader: &'static [u8],
 }
 
 impl Esp32Params {

--- a/espflash/src/elf.rs
+++ b/espflash/src/elf.rs
@@ -188,6 +188,18 @@ pub struct RomSegment<'a> {
     pub data: Cow<'a, [u8]>,
 }
 
+impl<'a> RomSegment<'a> {
+    pub fn borrow<'b>(&'b self) -> RomSegment<'b>
+    where
+        'a: 'b,
+    {
+        RomSegment {
+            addr: self.addr,
+            data: Cow::Borrowed(self.data.as_ref()),
+        }
+    }
+}
+
 impl<'a> From<CodeSegment<'a>> for RomSegment<'a> {
     fn from(segment: CodeSegment<'a>) -> Self {
         RomSegment {

--- a/espflash/src/flasher.rs
+++ b/espflash/src/flasher.rs
@@ -509,12 +509,13 @@ impl Flasher {
         let mut target = self.chip.flash_target(self.spi_params);
         target.begin(&mut self.connection, &image).flashing()?;
 
-        for segment in self
+        let flash_image = self
             .chip
-            .get_flash_segments(&image, bootloader, partition_table)
-        {
+            .get_flash_image(&image, bootloader, partition_table, None)?;
+
+        for segment in flash_image.segments() {
             target
-                .write_segment(&mut self.connection, segment?)
+                .write_segment(&mut self.connection, segment)
                 .flashing()?;
         }
 

--- a/espflash/src/image_format/esp32bootloader.rs
+++ b/espflash/src/image_format/esp32bootloader.rs
@@ -1,0 +1,225 @@
+use crate::chip::Esp32Params;
+use crate::elf::{
+    merge_segments, update_checksum, CodeSegment, FirmwareImage, RomSegment, ESP_CHECKSUM_MAGIC,
+};
+use crate::error::{Error, FlashDetectError};
+use crate::flasher::FlashSize;
+use crate::image_format::{
+    EspCommonHeader, ImageFormat, SegmentHeader, ESP_MAGIC, WP_PIN_DISABLED,
+};
+use crate::{Chip, PartitionTable};
+use bytemuck::bytes_of;
+use bytemuck::{Pod, Zeroable};
+use sha2::{Digest, Sha256};
+use std::{borrow::Cow, io::Write, iter::once};
+
+/// Image format for esp32 family chips using a 2nd stage bootloader
+pub struct Esp32BootloaderFormat<'a> {
+    params: Esp32Params,
+    bootloader: Cow<'a, [u8]>,
+    partition_table: PartitionTable,
+    flash_segment: RomSegment<'a>,
+}
+
+impl<'a> Esp32BootloaderFormat<'a> {
+    pub fn new(
+        image: &'a FirmwareImage,
+        chip: Chip,
+        params: Esp32Params,
+        partition_table: Option<PartitionTable>,
+        bootloader: Cow<'a, [u8]>,
+    ) -> Result<Self, Error> {
+        let partition_table = partition_table.unwrap_or_else(|| params.default_partition_table());
+
+        let mut data = Vec::new();
+
+        let header = EspCommonHeader {
+            magic: ESP_MAGIC,
+            segment_count: 0,
+            flash_mode: image.flash_mode as u8,
+            flash_config: encode_flash_size(image.flash_size)? + image.flash_frequency as u8,
+            entry: image.entry,
+        };
+        data.write_all(bytes_of(&header))?;
+
+        let extended_header = ExtendedHeader {
+            wp_pin: WP_PIN_DISABLED,
+            clk_q_drv: 0,
+            d_cs_drv: 0,
+            gd_wp_drv: 0,
+            chip_id: params.chip_id,
+            min_rev: 0,
+            padding: [0; 8],
+            append_digest: 1,
+        };
+        data.write_all(bytes_of(&extended_header))?;
+
+        let mut checksum = ESP_CHECKSUM_MAGIC;
+
+        let flash_segments: Vec<_> = merge_segments(image.rom_segments(chip).collect());
+        let mut ram_segments: Vec<_> = merge_segments(image.ram_segments(chip).collect());
+
+        let mut segment_count = 0;
+
+        for segment in flash_segments {
+            loop {
+                let pad_len = get_segment_padding(data.len(), &segment);
+                if pad_len > 0 {
+                    if pad_len > SEG_HEADER_LEN {
+                        if let Some(ram_segment) = ram_segments.first_mut() {
+                            // save up to `pad_len` from the ram segment, any remaining bits in the ram segments will be saved later
+                            let pad_segment = ram_segment.split_off(pad_len as usize);
+                            checksum = save_segment(&mut data, &pad_segment, checksum)?;
+                            if ram_segment.data().is_empty() {
+                                ram_segments.remove(0);
+                            }
+                            segment_count += 1;
+                            continue;
+                        }
+                    }
+                    let pad_header = SegmentHeader {
+                        addr: 0,
+                        length: pad_len as u32,
+                    };
+                    data.write_all(bytes_of(&pad_header))?;
+                    for _ in 0..pad_len {
+                        data.write_all(&[0])?;
+                    }
+                    segment_count += 1;
+                } else {
+                    break;
+                }
+            }
+            checksum = save_flash_segment(&mut data, &segment, checksum)?;
+            segment_count += 1;
+        }
+
+        for segment in ram_segments {
+            checksum = save_segment(&mut data, &segment, checksum)?;
+            segment_count += 1;
+        }
+
+        let padding = 15 - (data.len() % 16);
+        let padding = &[0u8; 16][0..padding as usize];
+        data.write_all(padding)?;
+
+        data.write_all(&[checksum])?;
+
+        // since we added some dummy segments, we need to patch the segment count
+        data[1] = segment_count as u8;
+
+        let mut hasher = Sha256::new();
+        hasher.update(&data);
+        let hash = hasher.finalize();
+        data.write_all(&hash)?;
+
+        let flash_segment = RomSegment {
+            addr: params.app_addr,
+            data: Cow::Owned(data),
+        };
+        Ok(Self {
+            params,
+            bootloader,
+            partition_table,
+            flash_segment,
+        })
+    }
+}
+
+impl<'a> ImageFormat<'a> for Esp32BootloaderFormat<'a> {
+    fn segments(self) -> Box<dyn Iterator<Item = RomSegment<'a>> + 'a> {
+        Box::new(
+            once(RomSegment {
+                addr: self.params.boot_addr,
+                data: self.bootloader,
+            })
+            .chain(once(RomSegment {
+                addr: self.params.partition_addr,
+                data: self.partition_table.to_bytes().into(),
+            }))
+            .chain(once(self.flash_segment)),
+        )
+    }
+}
+
+fn encode_flash_size(size: FlashSize) -> Result<u8, FlashDetectError> {
+    match size {
+        FlashSize::Flash256Kb => Err(FlashDetectError::from(size as u8)),
+        FlashSize::Flash512Kb => Err(FlashDetectError::from(size as u8)),
+        FlashSize::Flash1Mb => Ok(0x00),
+        FlashSize::Flash2Mb => Ok(0x10),
+        FlashSize::Flash4Mb => Ok(0x20),
+        FlashSize::Flash8Mb => Ok(0x30),
+        FlashSize::Flash16Mb => Ok(0x40),
+        FlashSize::FlashRetry => Err(FlashDetectError::from(size as u8)),
+    }
+}
+
+const IROM_ALIGN: u32 = 65536;
+const SEG_HEADER_LEN: u32 = 8;
+
+/// Actual alignment (in data bytes) required for a segment header: positioned
+/// so that after we write the next 8 byte header, file_offs % IROM_ALIGN ==
+/// segment.addr % IROM_ALIGN
+///
+/// (this is because the segment's vaddr may not be IROM_ALIGNed, more likely is
+/// aligned IROM_ALIGN+0x18 to account for the binary file header
+fn get_segment_padding(offset: usize, segment: &CodeSegment) -> u32 {
+    let align_past = (segment.addr - SEG_HEADER_LEN) % IROM_ALIGN;
+    let pad_len = ((IROM_ALIGN - ((offset as u32) % IROM_ALIGN)) + align_past) % IROM_ALIGN;
+    if pad_len == 0 || pad_len == IROM_ALIGN {
+        0
+    } else if pad_len > SEG_HEADER_LEN {
+        pad_len - SEG_HEADER_LEN
+    } else {
+        pad_len + IROM_ALIGN - SEG_HEADER_LEN
+    }
+}
+
+fn save_flash_segment(
+    data: &mut Vec<u8>,
+    segment: &CodeSegment,
+    checksum: u8,
+) -> Result<u8, Error> {
+    let end_pos = (data.len() + segment.data().len()) as u32 + SEG_HEADER_LEN;
+    let segment_reminder = end_pos % IROM_ALIGN;
+
+    let checksum = save_segment(data, segment, checksum)?;
+
+    if segment_reminder < 0x24 {
+        // Work around a bug in ESP-IDF 2nd stage bootloader, that it didn't map the
+        // last MMU page, if an IROM/DROM segment was < 0x24 bytes over the page
+        // boundary.
+        data.write_all(&[0u8; 0x24][0..(0x24 - segment_reminder as usize)])?;
+    }
+    Ok(checksum)
+}
+
+fn save_segment(data: &mut Vec<u8>, segment: &CodeSegment, checksum: u8) -> Result<u8, Error> {
+    let padding = (4 - segment.size() % 4) % 4;
+
+    let header = SegmentHeader {
+        addr: segment.addr,
+        length: segment.size() + padding,
+    };
+    data.write_all(bytes_of(&header))?;
+    data.write_all(segment.data())?;
+
+    let padding = &[0u8; 4][0..padding as usize];
+    data.write_all(padding)?;
+
+    Ok(update_checksum(segment.data(), checksum))
+}
+
+#[derive(Copy, Clone, Zeroable, Pod)]
+#[repr(C)]
+struct ExtendedHeader {
+    wp_pin: u8,
+    clk_q_drv: u8,
+    d_cs_drv: u8,
+    gd_wp_drv: u8,
+    chip_id: u16,
+    min_rev: u8,
+    padding: [u8; 8],
+    append_digest: u8,
+}

--- a/espflash/src/image_format/esp32bootloader.rs
+++ b/espflash/src/image_format/esp32bootloader.rs
@@ -127,17 +127,20 @@ impl<'a> Esp32BootloaderFormat<'a> {
 }
 
 impl<'a> ImageFormat<'a> for Esp32BootloaderFormat<'a> {
-    fn segments(self) -> Box<dyn Iterator<Item = RomSegment<'a>> + 'a> {
+    fn segments<'b>(&'b self) -> Box<dyn Iterator<Item = RomSegment<'b>> + 'b>
+    where
+        'a: 'b,
+    {
         Box::new(
             once(RomSegment {
                 addr: self.params.boot_addr,
-                data: self.bootloader,
+                data: Cow::Borrowed(&self.bootloader),
             })
             .chain(once(RomSegment {
                 addr: self.params.partition_addr,
                 data: self.partition_table.to_bytes().into(),
             }))
-            .chain(once(self.flash_segment)),
+            .chain(once(self.flash_segment.borrow())),
         )
     }
 }

--- a/espflash/src/image_format/esp32bootloader.rs
+++ b/espflash/src/image_format/esp32bootloader.rs
@@ -27,9 +27,14 @@ impl<'a> Esp32BootloaderFormat<'a> {
         chip: Chip,
         params: Esp32Params,
         partition_table: Option<PartitionTable>,
-        bootloader: Cow<'a, [u8]>,
+        bootloader: Option<Vec<u8>>,
     ) -> Result<Self, Error> {
         let partition_table = partition_table.unwrap_or_else(|| params.default_partition_table());
+        let bootloader = if let Some(bytes) = bootloader {
+            Cow::Owned(bytes)
+        } else {
+            Cow::Borrowed(params.default_bootloader)
+        };
 
         let mut data = Vec::new();
 

--- a/espflash/src/image_format/esp8266.rs
+++ b/espflash/src/image_format/esp8266.rs
@@ -74,8 +74,16 @@ impl<'a> Esp8266Format<'a> {
 }
 
 impl<'a> ImageFormat<'a> for Esp8266Format<'a> {
-    fn segments(self) -> Box<dyn Iterator<Item = RomSegment<'a>> + 'a> {
-        Box::new(self.irom_data.into_iter().chain(once(self.flash_segment)))
+    fn segments<'b>(&'b self) -> Box<dyn Iterator<Item = RomSegment<'b>> + 'b>
+    where
+        'a: 'b,
+    {
+        Box::new(
+            self.irom_data
+                .iter()
+                .map(RomSegment::borrow)
+                .chain(once(self.flash_segment.borrow())),
+        )
     }
 }
 

--- a/espflash/src/image_format/esp8266.rs
+++ b/espflash/src/image_format/esp8266.rs
@@ -1,0 +1,119 @@
+use crate::elf::{update_checksum, CodeSegment, FirmwareImage, RomSegment, ESP_CHECKSUM_MAGIC};
+use crate::error::{Error, FlashDetectError};
+use crate::flasher::FlashSize;
+use crate::image_format::{EspCommonHeader, ImageFormat, SegmentHeader, ESP_MAGIC};
+use crate::Chip;
+use bytemuck::bytes_of;
+use std::{borrow::Cow, io::Write, iter::once, mem::size_of};
+
+const IROM_MAP_START: u32 = 0x40200000;
+
+/// Image format for flashing to esp8266 chips
+pub struct Esp8266Format<'a> {
+    irom_data: Option<RomSegment<'a>>,
+    flash_segment: RomSegment<'a>,
+}
+
+impl<'a> Esp8266Format<'a> {
+    pub fn new(image: &'a FirmwareImage) -> Result<Self, Error> {
+        // irom goes into a separate plain bin
+        let irom_data = merge_rom_segments(image.rom_segments(Chip::Esp8266));
+
+        let mut common_data = Vec::with_capacity(
+            image
+                .ram_segments(Chip::Esp8266)
+                .map(|segment| segment.size() as usize)
+                .sum(),
+        );
+        // common header
+        let header = EspCommonHeader {
+            magic: ESP_MAGIC,
+            segment_count: image.ram_segments(Chip::Esp8266).count() as u8,
+            flash_mode: image.flash_mode as u8,
+            flash_config: encode_flash_size(image.flash_size)? + image.flash_frequency as u8,
+            entry: image.entry,
+        };
+        common_data.write_all(bytes_of(&header))?;
+
+        let mut total_len = 8;
+
+        let mut checksum = ESP_CHECKSUM_MAGIC;
+
+        for segment in image.ram_segments(Chip::Esp8266) {
+            let data = segment.data();
+            let padding = 4 - data.len() % 4;
+            let segment_header = SegmentHeader {
+                addr: segment.addr,
+                length: (data.len() + padding) as u32,
+            };
+            total_len += size_of::<SegmentHeader>() as u32 + segment_header.length;
+            common_data.write_all(bytes_of(&segment_header))?;
+            common_data.write_all(data)?;
+
+            let padding = &[0u8; 4][0..padding];
+            common_data.write_all(padding)?;
+            checksum = update_checksum(data, checksum);
+        }
+
+        let padding = 15 - (total_len % 16);
+        let padding = &[0u8; 16][0..padding as usize];
+        common_data.write_all(padding)?;
+
+        common_data.write_all(&[checksum])?;
+
+        let flash_segment = RomSegment {
+            addr: 0,
+            data: Cow::Owned(common_data),
+        };
+
+        Ok(Self {
+            irom_data,
+            flash_segment,
+        })
+    }
+}
+
+impl<'a> ImageFormat<'a> for Esp8266Format<'a> {
+    fn segments(self) -> Box<dyn Iterator<Item = RomSegment<'a>> + 'a> {
+        Box::new(self.irom_data.into_iter().chain(once(self.flash_segment)))
+    }
+}
+
+fn merge_rom_segments<'a>(
+    mut segments: impl Iterator<Item = CodeSegment<'a>>,
+) -> Option<RomSegment<'a>> {
+    let first = segments.next()?;
+    if let Some(second) = segments.next() {
+        let mut data = Vec::with_capacity(first.data().len() + second.data().len());
+        data.extend_from_slice(first.data());
+
+        for segment in once(second).chain(segments) {
+            let padding_size = segment.addr as usize - first.addr as usize - data.len();
+            data.resize(data.len() + padding_size, 0);
+            data.extend_from_slice(segment.data());
+        }
+
+        Some(RomSegment {
+            addr: first.addr - IROM_MAP_START,
+            data: Cow::Owned(data),
+        })
+    } else {
+        Some(RomSegment {
+            addr: first.addr - IROM_MAP_START,
+            data: Cow::Owned(first.data().into()),
+        })
+    }
+}
+
+fn encode_flash_size(size: FlashSize) -> Result<u8, FlashDetectError> {
+    match size {
+        FlashSize::Flash256Kb => Ok(0x10),
+        FlashSize::Flash512Kb => Ok(0x00),
+        FlashSize::Flash1Mb => Ok(0x20),
+        FlashSize::Flash2Mb => Ok(0x30),
+        FlashSize::Flash4Mb => Ok(0x40),
+        FlashSize::Flash8Mb => Ok(0x80),
+        FlashSize::Flash16Mb => Ok(0x90),
+        FlashSize::FlashRetry => Err(FlashDetectError::from(size as u8)),
+    }
+}

--- a/espflash/src/image_format/mod.rs
+++ b/espflash/src/image_format/mod.rs
@@ -1,0 +1,32 @@
+mod esp32bootloader;
+mod esp8266;
+
+use crate::elf::RomSegment;
+
+use bytemuck::{Pod, Zeroable};
+pub use esp32bootloader::*;
+pub use esp8266::*;
+
+const ESP_MAGIC: u8 = 0xE9;
+const WP_PIN_DISABLED: u8 = 0xEE;
+
+#[derive(Copy, Clone, Zeroable, Pod, Debug)]
+#[repr(C)]
+struct EspCommonHeader {
+    magic: u8,
+    segment_count: u8,
+    flash_mode: u8,
+    flash_config: u8,
+    entry: u32,
+}
+
+#[derive(Copy, Clone, Zeroable, Pod, Debug)]
+#[repr(C)]
+struct SegmentHeader {
+    addr: u32,
+    length: u32,
+}
+
+pub trait ImageFormat<'a>: Sized {
+    fn segments(self) -> Box<dyn Iterator<Item = RomSegment<'a>> + 'a>;
+}

--- a/espflash/src/image_format/mod.rs
+++ b/espflash/src/image_format/mod.rs
@@ -2,10 +2,11 @@ mod esp32bootloader;
 mod esp8266;
 
 use crate::elf::RomSegment;
-
 use bytemuck::{Pod, Zeroable};
 pub use esp32bootloader::*;
 pub use esp8266::*;
+
+use strum_macros::{AsStaticStr, Display, EnumString};
 
 const ESP_MAGIC: u8 = 0xE9;
 const WP_PIN_DISABLED: u8 = 0xEE;
@@ -27,6 +28,16 @@ struct SegmentHeader {
     length: u32,
 }
 
-pub trait ImageFormat<'a>: Sized {
-    fn segments(self) -> Box<dyn Iterator<Item = RomSegment<'a>> + 'a>;
+pub trait ImageFormat<'a> {
+    fn segments<'b>(&'b self) -> Box<dyn Iterator<Item = RomSegment<'b>> + 'b>
+    where
+        'a: 'b;
+}
+
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Display, EnumString, AsStaticStr)]
+pub enum ImageFormatId {
+    #[strum(serialize = "bootloader")]
+    Bootloader,
+    #[strum(serialize = "direct-boot")]
+    DirectBoot,
 }

--- a/espflash/src/lib.rs
+++ b/espflash/src/lib.rs
@@ -6,6 +6,7 @@ mod encoder;
 mod error;
 mod flash_target;
 mod flasher;
+mod image_format;
 mod partition_table;
 
 pub use chip::Chip;


### PR DESCRIPTION
for now it still only supports the default esp8266 and esp32 formats, but this paves the way for adding support for alternative formats later on