### PR TITLE
(in)validate docker cache for rust-xtensa clone

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,8 @@ RUN apt-get update && apt-get install -y \
    && apt-get autoremove -y \
    && rm -rf /var/lib/apt/lists/*
 
+# (In)validate docker cache with latest commit information
+ADD https://api.github.com/repos/esp-rs/espflash/commits/master /dev/null
 # Init rust-xtensa
 RUN git clone https://github.com/esp-rs/rust /rust-xtensa
 RUN cd rust-xtensa && git submodule init && git submodule update


### PR DESCRIPTION
Hi,

This allow to let Docker know when it should update its git clone of esp-rs/rust, by using the Last-Modified HTTP header provided by Github,
It is not exact, but I find it a good compromise  between cache hit, speed, and rebuild triggering when there is anything new.