### PR TITLE
docker: switch to python 3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN apt-get update && apt-get install -y \
     wget \
     xz-utils \
     zip \
-    python \
+    python-is-python3 \
     ninja-build \
     build-essential \
     cmake \
@@ -46,7 +46,7 @@ RUN apt-get update && apt-get install -y \
     unzip \
     wget \
     zip \
-    python \
+    python-is-python3 \
     build-essential \
    && apt-get autoremove -y \
    && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
to fix:

```
Building LLVM for x86_64-unknown-linux-gnu
[…]
CMake Error at /usr/share/cmake-3.16/Modules/FindPackageHandleStandardArgs.cmake:146 (message):
  Could NOT find Python3 (missing: Python3_EXECUTABLE Interpreter)
Call Stack (most recent call first):
  /usr/share/cmake-3.16/Modules/FindPackageHandleStandardArgs.cmake:393 (_FPHSA_FAILURE_MESSAGE)
  /usr/share/cmake-3.16/Modules/FindPython/Support.cmake:2214 (find_package_handle_standard_args)
  /usr/share/cmake-3.16/Modules/FindPython3.cmake:300 (include)
  CMakeLists.txt:700 (find_package)
```

since https://github.com/espressif/llvm-project/commit/5e31e226b5b2b682607a6578ff5adb33daf4fe39