### PR TITLE
More error improvements

### DIFF
--- a/cargo-espflash/src/cargo_config.rs
+++ b/cargo-espflash/src/cargo_config.rs
@@ -4,41 +4,55 @@ use serde::Deserialize;
 use std::fs;
 use std::path::{Path, PathBuf};
 
-#[derive(Debug, Deserialize)]
-struct CargoConfig {
+#[derive(Debug, Deserialize, Default)]
+pub struct CargoConfig {
     #[serde(default)]
     unstable: Unstable,
+    #[serde(default)]
+    build: Build,
+}
+
+impl CargoConfig {
+    pub fn has_build_std(&self) -> bool {
+        !self.unstable.build_std.is_empty()
+    }
+
+    pub fn target(&self) -> Option<&str> {
+        self.build.target.as_deref()
+    }
 }
 
 #[derive(Debug, Default, Deserialize)]
 #[serde(rename_all = "kebab-case")]
-struct Unstable {
+pub struct Unstable {
     #[serde(default)]
     build_std: Vec<String>,
 }
 
-/// Check if the build-std option seems to be set correctly
-pub fn has_build_std<P: AsRef<Path>>(project_path: P) -> Result<bool> {
+#[derive(Debug, Default, Deserialize)]
+pub struct Build {
+    target: Option<String>,
+}
+
+pub fn parse_cargo_config<P: AsRef<Path>>(project_path: P) -> Result<CargoConfig> {
     let config_path = match config_path(project_path.as_ref()) {
         Some(path) => path,
         None => {
-            return Ok(false);
+            return Ok(CargoConfig::default());
         }
     };
     let content = match fs::read_to_string(&config_path) {
         Ok(content) => content,
-        Err(_) => return Ok(false),
+        Err(_) => return Ok(CargoConfig::default()),
     };
-    let toml: CargoConfig = toml::from_str(&content)
+    toml::from_str(&content)
         .map_err(move |e| TomlError::new(e, content))
         .wrap_err_with(|| {
             format!(
                 "Failed to parse {}",
                 &config_path.as_path().to_string_lossy()
             )
-        })?;
-
-    Ok(!toml.unstable.build_std.is_empty())
+        })
 }
 
 fn config_path(project_path: &Path) -> Option<PathBuf> {

--- a/cargo-espflash/src/error.rs
+++ b/cargo-espflash/src/error.rs
@@ -63,6 +63,12 @@ impl From<cargo_toml::Error> for MaybeTomlError {
     }
 }
 
+impl From<toml::de::Error> for MaybeTomlError {
+    fn from(e: toml::de::Error) -> Self {
+        MaybeTomlError::Toml(e)
+    }
+}
+
 impl TomlError {
     pub fn new(err: impl Into<MaybeTomlError>, source: String) -> Self {
         TomlError {

--- a/cargo-espflash/src/error.rs
+++ b/cargo-espflash/src/error.rs
@@ -1,4 +1,6 @@
-use miette::Diagnostic;
+use miette::{Diagnostic, LabeledSpan, SourceCode, SourceOffset};
+use std::fmt::{Display, Formatter};
+use std::iter::once;
 use thiserror::Error;
 
 #[derive(Error, Debug, Diagnostic)]
@@ -32,4 +34,70 @@ pub enum Error {
     #[error("Specified bootloader table is not a bin file")]
     #[diagnostic(code(cargo_espflash::bootloader_path))]
     InvalidBootloaderPath,
+    #[error("No Cargo.toml found in the current directory")]
+    #[diagnostic(
+        code(cargo_espflash::no_project),
+        help("Ensure that you're running the command from within a cargo project")
+    )]
+    NoProject,
+}
+
+#[derive(Debug)]
+pub struct TomlError {
+    err: MaybeTomlError,
+    source: String,
+}
+
+#[derive(Debug)]
+pub enum MaybeTomlError {
+    Toml(toml::de::Error),
+    Other(std::io::Error),
+}
+
+impl From<cargo_toml::Error> for MaybeTomlError {
+    fn from(e: cargo_toml::Error) -> Self {
+        match e {
+            cargo_toml::Error::Parse(e) => MaybeTomlError::Toml(e),
+            cargo_toml::Error::Io(e) => MaybeTomlError::Other(e),
+        }
+    }
+}
+
+impl TomlError {
+    pub fn new(err: impl Into<MaybeTomlError>, source: String) -> Self {
+        TomlError {
+            err: err.into(),
+            source,
+        }
+    }
+}
+
+impl Display for TomlError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "Failed to parse toml")
+    }
+}
+
+// no `source` on purpose to prevent duplicating the message
+impl std::error::Error for TomlError {}
+
+impl Diagnostic for TomlError {
+    fn source_code(&self) -> Option<&dyn SourceCode> {
+        Some(&self.source)
+    }
+
+    fn labels(&self) -> Option<Box<dyn Iterator<Item = LabeledSpan> + '_>> {
+        match &self.err {
+            MaybeTomlError::Toml(err) => {
+                let (line, col) = err.line_col()?;
+                let offset = SourceOffset::from_location(&self.source, line + 1, col + 1);
+                Some(Box::new(once(LabeledSpan::new(
+                    Some(err.to_string()),
+                    offset.offset(),
+                    0,
+                ))))
+            }
+            _ => None,
+        }
+    }
 }

--- a/cargo-espflash/src/error.rs
+++ b/cargo-espflash/src/error.rs
@@ -44,6 +44,12 @@ pub enum Error {
     #[error(transparent)]
     #[diagnostic(transparent)]
     UnsupportedTarget(UnsupportedTargetError),
+    #[error("No target specified in cargo configuration")]
+    #[diagnostic(
+        code(cargo_espflash::no_target),
+        help("Specify the target in `.cargo/config.toml`, the {} support the following targets: {}", chip, chip.supported_targets().join(", "))
+    )]
+    NoTarget { chip: Chip },
 }
 
 #[derive(Debug)]

--- a/cargo-espflash/src/main.rs
+++ b/cargo-espflash/src/main.rs
@@ -151,7 +151,8 @@ fn main() -> Result<()> {
     let example = matches.value_of("example");
     let features = matches.value_of("features");
 
-    let path = build(release, example, features, flasher.chip())?;
+    let path =
+        build(release, example, features, flasher.chip()).wrap_err("Failed to build project")?;
 
     // If the '--bootloader' option is provided, load the binary file at the
     // specified path.
@@ -215,10 +216,9 @@ fn build(
         return Err(Error::NoBuildStd.into());
     };
 
-    if let Some(target) = cargo_config.target() {
-        if !chip.supports_target(target) {
-            return Err(Error::UnsupportedTarget(UnsupportedTargetError::new(target, chip)).into());
-        }
+    let target = cargo_config.target().ok_or(Error::NoTarget { chip })?;
+    if !chip.supports_target(target) {
+        return Err(Error::UnsupportedTarget(UnsupportedTargetError::new(target, chip)).into());
     }
 
     // Build the list of arguments to pass to 'cargo build'.

--- a/cargo-espflash/src/main.rs
+++ b/cargo-espflash/src/main.rs
@@ -212,7 +212,7 @@ fn build(release: bool, example: Option<&str>, features: Option<&str>) -> Result
     // The 'build-std' unstable cargo feature is required to enable
     // cross-compilation. If it has not been set then we cannot build the
     // application.
-    if !has_build_std(".") {
+    if !has_build_std(".")? {
         return Err(Error::NoBuildStd.into());
     };
 

--- a/espflash/src/chip/esp32.rs
+++ b/espflash/src/chip/esp32.rs
@@ -49,6 +49,9 @@ impl ChipType for Esp32 {
     const DEFAULT_IMAGE_FORMAT: ImageFormatId = ImageFormatId::Bootloader;
     const SUPPORTED_IMAGE_FORMATS: &'static [ImageFormatId] = &[ImageFormatId::Bootloader];
 
+    const SUPPORTED_TARGETS: &'static [&'static str] =
+        &["xtensa-esp32-none-elf", "xtensa-esp32-espidf"];
+
     fn get_flash_segments<'a>(
         image: &'a FirmwareImage,
         bootloader: Option<Vec<u8>>,
@@ -67,6 +70,10 @@ impl ChipType for Esp32 {
                 todo!()
             }
         }
+    }
+
+    fn supports_target(target: &str) -> bool {
+        target.starts_with("xtensa-esp32-")
     }
 }
 

--- a/espflash/src/chip/esp32c3.rs
+++ b/espflash/src/chip/esp32c3.rs
@@ -50,6 +50,9 @@ impl ChipType for Esp32c3 {
     const SUPPORTED_IMAGE_FORMATS: &'static [ImageFormatId] =
         &[ImageFormatId::Bootloader, ImageFormatId::DirectBoot];
 
+    const SUPPORTED_TARGETS: &'static [&'static str] =
+        &["riscv32imc-uknown-none-elf", "riscv32imc-esp-espidf"];
+
     fn get_flash_segments<'a>(
         image: &'a FirmwareImage,
         bootloader: Option<Vec<u8>>,
@@ -68,5 +71,9 @@ impl ChipType for Esp32c3 {
                 todo!()
             }
         }
+    }
+
+    fn supports_target(target: &str) -> bool {
+        target.starts_with("riscv32imc-")
     }
 }

--- a/espflash/src/chip/esp32s2.rs
+++ b/espflash/src/chip/esp32s2.rs
@@ -48,6 +48,9 @@ impl ChipType for Esp32s2 {
     const DEFAULT_IMAGE_FORMAT: ImageFormatId = ImageFormatId::Bootloader;
     const SUPPORTED_IMAGE_FORMATS: &'static [ImageFormatId] = &[ImageFormatId::Bootloader];
 
+    const SUPPORTED_TARGETS: &'static [&'static str] =
+        &["xtensa-esp32s2-none-elf", "xtensa-esp32s2-espidf"];
+
     fn get_flash_segments<'a>(
         image: &'a FirmwareImage,
         bootloader: Option<Vec<u8>>,
@@ -66,5 +69,9 @@ impl ChipType for Esp32s2 {
                 todo!()
             }
         }
+    }
+
+    fn supports_target(target: &str) -> bool {
+        target.starts_with("xtensa-esp32s2-")
     }
 }

--- a/espflash/src/chip/esp8266.rs
+++ b/espflash/src/chip/esp8266.rs
@@ -29,6 +29,8 @@ impl ChipType for Esp8266 {
     const DEFAULT_IMAGE_FORMAT: ImageFormatId = ImageFormatId::Bootloader;
     const SUPPORTED_IMAGE_FORMATS: &'static [ImageFormatId] = &[ImageFormatId::Bootloader];
 
+    const SUPPORTED_TARGETS: &'static [&'static str] = &["xtensa-esp8266-none-elf"];
+
     fn get_flash_segments<'a>(
         image: &'a FirmwareImage,
         _bootloader: Option<Vec<u8>>,
@@ -39,6 +41,10 @@ impl ChipType for Esp8266 {
             ImageFormatId::Bootloader => Ok(Box::new(Esp8266Format::new(image)?)),
             _ => Err(UnsupportedImageFormatError::new(image_format, Chip::Esp8266).into()),
         }
+    }
+
+    fn supports_target(target: &str) -> bool {
+        target.starts_with("xtensa-esp8266-")
     }
 }
 

--- a/espflash/src/chip/mod.rs
+++ b/espflash/src/chip/mod.rs
@@ -30,6 +30,8 @@ pub trait ChipType {
     const DEFAULT_IMAGE_FORMAT: ImageFormatId;
     const SUPPORTED_IMAGE_FORMATS: &'static [ImageFormatId];
 
+    const SUPPORTED_TARGETS: &'static [&'static str];
+
     /// Get the firmware segments for writing an image to flash
     fn get_flash_segments<'a>(
         image: &'a FirmwareImage,
@@ -37,6 +39,8 @@ pub trait ChipType {
         partition_table: Option<PartitionTable>,
         image_format: ImageFormatId,
     ) -> Result<Box<dyn ImageFormat<'a> + 'a>, Error>;
+
+    fn supports_target(target: &str) -> bool;
 }
 
 pub struct SpiRegisters {
@@ -173,6 +177,24 @@ impl Chip {
             Chip::Esp32c3 => Esp32c3::SUPPORTED_IMAGE_FORMATS,
             Chip::Esp32s2 => Esp32s2::SUPPORTED_IMAGE_FORMATS,
             Chip::Esp8266 => Esp8266::SUPPORTED_IMAGE_FORMATS,
+        }
+    }
+
+    pub fn supports_target(&self, target: &str) -> bool {
+        match self {
+            Chip::Esp32 => Esp32::supports_target(target),
+            Chip::Esp32c3 => Esp32c3::supports_target(target),
+            Chip::Esp32s2 => Esp32s2::supports_target(target),
+            Chip::Esp8266 => Esp8266::supports_target(target),
+        }
+    }
+
+    pub fn supported_targets(&self) -> &[&str] {
+        match self {
+            Chip::Esp32 => Esp32::SUPPORTED_TARGETS,
+            Chip::Esp32c3 => Esp32c3::SUPPORTED_TARGETS,
+            Chip::Esp32s2 => Esp32s2::SUPPORTED_TARGETS,
+            Chip::Esp8266 => Esp8266::SUPPORTED_TARGETS,
         }
     }
 }

--- a/espflash/src/error.rs
+++ b/espflash/src/error.rs
@@ -180,7 +180,7 @@ impl From<binread::Error> for Error {
 #[allow(dead_code)]
 #[repr(u8)]
 #[non_exhaustive]
-pub enum RomError {
+pub enum RomErrorKind {
     #[error("Invalid message received")]
     #[diagnostic(code(espflash::rom::invalid_message))]
     InvalidMessage = 0x05,
@@ -207,18 +207,34 @@ pub enum RomError {
     Other = 0xff,
 }
 
-impl From<u8> for RomError {
+impl From<u8> for RomErrorKind {
     fn from(raw: u8) -> Self {
         match raw {
-            0x05 => RomError::InvalidMessage,
-            0x06 => RomError::FailedToAct,
-            0x07 => RomError::InvalidCrc,
-            0x08 => RomError::FlashWriteError,
-            0x09 => RomError::FlashReadError,
-            0x0a => RomError::FlashReadLengthError,
-            0x0b => RomError::DeflateError,
-            _ => RomError::Other,
+            0x05 => RomErrorKind::InvalidMessage,
+            0x06 => RomErrorKind::FailedToAct,
+            0x07 => RomErrorKind::InvalidCrc,
+            0x08 => RomErrorKind::FlashWriteError,
+            0x09 => RomErrorKind::FlashReadError,
+            0x0a => RomErrorKind::FlashReadLengthError,
+            0x0b => RomErrorKind::DeflateError,
+            _ => RomErrorKind::Other,
         }
+    }
+}
+
+#[derive(Copy, Clone, Debug, Error, Diagnostic)]
+#[allow(dead_code)]
+#[non_exhaustive]
+#[error("Error while running {command} command")]
+pub struct RomError {
+    command: Command,
+    #[source]
+    kind: RomErrorKind,
+}
+
+impl RomError {
+    pub fn new(command: Command, kind: RomErrorKind) -> RomError {
+        RomError { command, kind }
     }
 }
 

--- a/espflash/src/flasher.rs
+++ b/espflash/src/flasher.rs
@@ -5,10 +5,10 @@ use strum_macros::Display;
 use std::thread::sleep;
 
 use crate::elf::RomSegment;
-use crate::error::{ConnectionError, ElfError, FlashDetectError, ResultExt};
+use crate::error::{ConnectionError, ElfError, FlashDetectError, ResultExt, RomError};
 use crate::{
-    chip::Chip, connection::Connection, elf::FirmwareImage, encoder::SlipEncoder, error::RomError,
-    Error, PartitionTable,
+    chip::Chip, connection::Connection, elf::FirmwareImage, encoder::SlipEncoder,
+    error::RomErrorKind, Error, PartitionTable,
 };
 use std::borrow::Cow;
 
@@ -286,7 +286,10 @@ impl Flasher {
                         Some(response) if response.return_op == Command::Sync as u8 => {
                             if response.status == 1 {
                                 let _error = connection.flush();
-                                return Err(Error::RomError(RomError::from(response.error)));
+                                return Err(Error::RomError(RomError::new(
+                                    Command::Sync,
+                                    RomErrorKind::from(response.error),
+                                )));
                             } else {
                                 break;
                             }


### PR DESCRIPTION
- proper error when `cargo espflash` is being ran outside a project directory
- better error message when `Cargo.toml`/`.cargo/config.toml` can't be parsed
![Screenshot_20210930_182722](https://user-images.githubusercontent.com/1283854/135529884-b60fdfaa-8eff-4c5c-995b-8111e8b7a956.png)
- Error message when configured target for the project doesn't match the attached chip
![Screenshot_20210930_200454](https://user-images.githubusercontent.com/1283854/135529696-8d410f9d-39c2-4813-a20c-8f2012125fdb.png)
- Error message when no target has been configured for the project
![Screenshot_20210930_221648](https://user-images.githubusercontent.com/1283854/135529737-8b63ba11-8358-483f-aff7-fc4a97eb9c75.png)
- Show which command failed when the bootloader returns an error