### PR TITLE
Partition table validation

### DIFF
--- a/cargo-espflash/src/main.rs
+++ b/cargo-espflash/src/main.rs
@@ -174,8 +174,11 @@ fn main() -> Result<()> {
         .or_else(|| metadata.partition_table.as_deref())
     {
         let path = fs::canonicalize(path).into_diagnostic()?;
-        let data = fs::read_to_string(path).into_diagnostic()?;
-        let table = PartitionTable::try_from_str(data)?;
+        let data = fs::read_to_string(path)
+            .into_diagnostic()
+            .wrap_err("Failed to open partition table")?;
+        let table =
+            PartitionTable::try_from_str(data).wrap_err("Failed to parse partition table")?;
         Some(table)
     } else {
         None

--- a/espflash/Cargo.toml
+++ b/espflash/Cargo.toml
@@ -26,6 +26,7 @@ slip-codec =  "0.2.4"
 thiserror = "1.0.20"
 xmas-elf = "0.8.0"
 serde = { version = "1.0", features = ["derive"] }
+serde_plain = "1"
 toml = "0.5"
 directories-next = "2.0.0"
 color-eyre = "0.5"

--- a/espflash/src/error.rs
+++ b/espflash/src/error.rs
@@ -270,7 +270,7 @@ impl<T> ResultExt for Result<T, Error> {
 pub enum PartitionTableError {
     #[error(transparent)]
     #[diagnostic(transparent)]
-    CSV(#[from] CSVError),
+    Csv(#[from] CSVError),
     #[error(transparent)]
     #[diagnostic(transparent)]
     Overlapping(#[from] OverlappingPartitionsError),
@@ -372,8 +372,8 @@ impl OverlappingPartitionsError {
     pub fn new(source: &str, partition1_line: usize, partition2_line: usize) -> Self {
         OverlappingPartitionsError {
             source_code: source.into(),
-            partition1_span: line_to_span(&source, partition1_line),
-            partition2_span: line_to_span(&source, partition2_line),
+            partition1_span: line_to_span(source, partition1_line),
+            partition2_span: line_to_span(source, partition2_line),
         }
     }
 }
@@ -400,8 +400,8 @@ impl DuplicatePartitionsError {
     ) -> Self {
         DuplicatePartitionsError {
             source_code: source.into(),
-            partition1_span: line_to_span(&source, partition1_line),
-            partition2_span: line_to_span(&source, partition2_line),
+            partition1_span: line_to_span(source, partition1_line),
+            partition2_span: line_to_span(source, partition2_line),
             ty,
         }
     }
@@ -426,7 +426,7 @@ impl InvalidSubTypeError {
     pub fn new(source: &str, line: usize, ty: Type, sub_type: SubType) -> Self {
         InvalidSubTypeError {
             source_code: source.into(),
-            span: line_to_span(&source, line),
+            span: line_to_span(source, line),
             ty,
             sub_type,
         }
@@ -447,7 +447,7 @@ impl UnalignedPartitionError {
     pub fn new(source: &str, line: usize) -> Self {
         UnalignedPartitionError {
             source_code: source.into(),
-            span: line_to_span(&source, line),
+            span: line_to_span(source, line),
         }
     }
 }

--- a/espflash/src/error.rs
+++ b/espflash/src/error.rs
@@ -280,6 +280,9 @@ pub enum PartitionTableError {
     #[error(transparent)]
     #[diagnostic(transparent)]
     InvalidSubType(#[from] InvalidSubTypeError),
+    #[error(transparent)]
+    #[diagnostic(transparent)]
+    UnalignedPartitionError(#[from] UnalignedPartitionError),
 }
 
 #[derive(Debug, Error, Diagnostic)]
@@ -426,6 +429,25 @@ impl InvalidSubTypeError {
             span: line_to_span(&source, line),
             ty,
             sub_type,
+        }
+    }
+}
+
+#[derive(Debug, Error, Diagnostic)]
+#[error("Unaligned partition")]
+#[diagnostic(code(espflash::partition_table::unaligned))]
+pub struct UnalignedPartitionError {
+    #[source_code]
+    source_code: String,
+    #[label("App partition is not aligned to 64k (0x10000)")]
+    span: SourceSpan,
+}
+
+impl UnalignedPartitionError {
+    pub fn new(source: &str, line: usize) -> Self {
+        UnalignedPartitionError {
+            source_code: source.into(),
+            span: line_to_span(&source, line),
         }
     }
 }

--- a/espflash/src/error.rs
+++ b/espflash/src/error.rs
@@ -273,6 +273,9 @@ pub enum PartitionTableError {
     #[error(transparent)]
     #[diagnostic(transparent)]
     Overlapping(#[from] OverlappingPartitionsError),
+    #[error(transparent)]
+    #[diagnostic(transparent)]
+    Duplicate(#[from] DuplicatePartitionsError),
 }
 
 #[derive(Debug, Error, Diagnostic)]
@@ -338,7 +341,7 @@ pub struct OverlappingPartitionsError {
     source_code: String,
     #[label("This partition")]
     partition1_span: SourceSpan,
-    #[label("Overlaps with this partition")]
+    #[label("overlaps with this partition")]
     partition2_span: SourceSpan,
 }
 
@@ -348,6 +351,35 @@ impl OverlappingPartitionsError {
             source_code: source.into(),
             partition1_span: line_to_span(&source, partition1_line),
             partition2_span: line_to_span(&source, partition2_line),
+        }
+    }
+}
+
+#[derive(Debug, Error, Diagnostic)]
+#[error("Duplicate partitions")]
+#[diagnostic(code(espflash::partition_table::duplicate))]
+pub struct DuplicatePartitionsError {
+    #[source_code]
+    source_code: String,
+    #[label("This partition")]
+    partition1_span: SourceSpan,
+    #[label("has the same {} as this partition", self.ty)]
+    partition2_span: SourceSpan,
+    ty: &'static str,
+}
+
+impl DuplicatePartitionsError {
+    pub fn new(
+        source: &str,
+        partition1_line: usize,
+        partition2_line: usize,
+        ty: &'static str,
+    ) -> Self {
+        DuplicatePartitionsError {
+            source_code: source.into(),
+            partition1_span: line_to_span(&source, partition1_line),
+            partition2_span: line_to_span(&source, partition2_line),
+            ty,
         }
     }
 }

--- a/espflash/src/partition_table.rs
+++ b/espflash/src/partition_table.rs
@@ -26,7 +26,7 @@ pub enum Type {
 impl Type {
     pub fn subtype_hint(&self) -> String {
         match self {
-            Type::App => "'factory', 'ota_0' trough 'ota_15' and 'test'".into(),
+            Type::App => "'factory', 'ota_0' through 'ota_15' and 'test'".into(),
             Type::Data => {
                 let types = [
                     DataType::Ota,

--- a/espflash/src/partition_table.rs
+++ b/espflash/src/partition_table.rs
@@ -1,6 +1,6 @@
 use crate::error::{
     CSVError, DuplicatePartitionsError, InvalidSubTypeError, OverlappingPartitionsError,
-    PartitionTableError,
+    PartitionTableError, UnalignedPartitionError,
 };
 use md5::{Context, Digest};
 use regex::Regex;
@@ -9,6 +9,7 @@ use std::cmp::{max, min};
 use std::fmt::Write as _;
 use std::fmt::{Display, Formatter};
 use std::io::Write;
+use std::ops::Rem;
 
 const MAX_PARTITION_LENGTH: usize = 0xC00;
 const PARTITION_TABLE_SIZE: usize = 0x1000;
@@ -260,6 +261,9 @@ impl PartitionTable {
                         partition.sub_type,
                     )
                     .into());
+                }
+                if partition.ty == Type::App && partition.offset.rem(0x10000) != 0 {
+                    return Err(UnalignedPartitionError::new(source, *line).into());
                 }
             }
         }


### PR DESCRIPTION
Adds various validation steps and error messages for partition tables

- Add error when partitions overlap
![Screenshot_20211001_140009](https://user-images.githubusercontent.com/1283854/135625211-7af0ff45-a4de-4ccf-bfbe-563938d192d5.png)
- Add error when two partitions have the same name or sub-type
![Screenshot_20211001_141033](https://user-images.githubusercontent.com/1283854/135625283-27238087-267d-4c53-81ce-34b3bf40401a.png)
- Add error when the type and sub-type don't match for a partition
![Screenshot_20211001_145719](https://user-images.githubusercontent.com/1283854/135625348-ab9fc624-f4cb-41d6-97ba-1883c1a09fdb.png)
  (the "trough" -> "through" typo has been fixed after taking the screenshot)
- Better error message when an unknown sub-type is specified for a partition
![Screenshot_20211001_150801](https://user-images.githubusercontent.com/1283854/135625418-f0f530d5-40f5-4c94-a2ea-af612db562f9.png)
- Add error when app partitions aren't aligned properly
![Screenshot_20211001_152054](https://user-images.githubusercontent.com/1283854/135627123-9c8a88bb-9a84-408e-b9b4-3487000afcee.png)
 