### PR TITLE
Add a method of reading eFuse values

### DIFF
--- a/cargo-espflash/src/main.rs
+++ b/cargo-espflash/src/main.rs
@@ -141,11 +141,13 @@ fn main() -> Result<()> {
         None
     };
 
-    // Connect the Flasher to the target device. If the '--board-info' flag has been
-    // provided, display the board info and terminate the application.
+    // Connect the Flasher to the target device and print the board information
+    // upon connection. If the '--board-info' flag has been provided, we have
+    // nothing left to do so exit early.
     let mut flasher = Flasher::connect(serial, speed)?;
+    flasher.board_info()?;
+
     if matches.is_present("board_info") {
-        board_info(&mut flasher)?;
         return Ok(());
     }
 
@@ -193,31 +195,13 @@ fn main() -> Result<()> {
     } else {
         flasher.load_elf_to_flash(&elf_data, bootloader, partition_table)?;
     }
+    println!("\nFlashing has completed!");
 
     if matches.is_present("monitor") {
         monitor(flasher.into_serial()).into_diagnostic()?;
     }
 
     // We're all done!
-    Ok(())
-}
-
-fn board_info(flasher: &mut Flasher) -> Result<()> {
-    let chip = flasher.chip();
-    let revision = chip.chip_revision(flasher.connection())?;
-    let freq = chip.crystal_freq(flasher.connection())?;
-
-    // Print the detected chip type, and if available the silicon revision.
-    print!("Chip type:         {}", chip);
-    if let Some(revision) = revision {
-        println!(" (revision {})", revision);
-    } else {
-        println!();
-    }
-
-    println!("Crystal frequency: {}MHz", freq);
-    println!("Flash size:        {}", flasher.flash_size());
-
     Ok(())
 }
 

--- a/espflash/src/chip/esp32/esp32.rs
+++ b/espflash/src/chip/esp32/esp32.rs
@@ -2,7 +2,7 @@ use std::ops::Range;
 
 use super::Esp32Params;
 use crate::{
-    chip::{Chip, ChipType, SpiRegisters},
+    chip::{Chip, ChipType, ReadEFuse, SpiRegisters},
     elf::FirmwareImage,
     image_format::{Esp32BootloaderFormat, ImageFormat, ImageFormatId},
     Error, PartitionTable,
@@ -74,6 +74,10 @@ impl ChipType for Esp32 {
     fn supports_target(target: &str) -> bool {
         target.starts_with("xtensa-esp32-")
     }
+}
+
+impl ReadEFuse for Esp32 {
+    const EFUSE_REG_BASE: u32 = 0x3ff5a000;
 }
 
 #[test]

--- a/espflash/src/chip/esp32/esp32.rs
+++ b/espflash/src/chip/esp32/esp32.rs
@@ -1,13 +1,12 @@
-use crate::chip::Esp32Params;
+use std::ops::Range;
 
-use crate::image_format::{Esp32BootloaderFormat, ImageFormat, ImageFormatId};
+use super::Esp32Params;
 use crate::{
     chip::{Chip, ChipType, SpiRegisters},
     elf::FirmwareImage,
+    image_format::{Esp32BootloaderFormat, ImageFormat, ImageFormatId},
     Error, PartitionTable,
 };
-
-use std::ops::Range;
 
 pub struct Esp32;
 
@@ -27,7 +26,7 @@ pub const PARAMS: Esp32Params = Esp32Params {
     app_addr: 0x10000,
     app_size: 0x3f0000,
     chip_id: 0,
-    default_bootloader: include_bytes!("../../bootloader/esp32-bootloader.bin"),
+    default_bootloader: include_bytes!("../../../bootloader/esp32-bootloader.bin"),
 };
 
 impl ChipType for Esp32 {

--- a/espflash/src/chip/esp32/esp32c3.rs
+++ b/espflash/src/chip/esp32/esp32c3.rs
@@ -1,12 +1,12 @@
-use crate::chip::Esp32Params;
-use crate::image_format::{Esp32BootloaderFormat, ImageFormat, ImageFormatId};
+use std::ops::Range;
+
+use super::Esp32Params;
 use crate::{
     chip::{ChipType, SpiRegisters},
     elf::FirmwareImage,
+    image_format::{Esp32BootloaderFormat, ImageFormat, ImageFormatId},
     Chip, Error, PartitionTable,
 };
-
-use std::ops::Range;
 
 pub struct Esp32c3;
 
@@ -26,7 +26,7 @@ pub const PARAMS: Esp32Params = Esp32Params {
     app_addr: 0x10000,
     app_size: 0x3f0000,
     chip_id: 5,
-    default_bootloader: include_bytes!("../../bootloader/esp32c3-bootloader.bin"),
+    default_bootloader: include_bytes!("../../../bootloader/esp32c3-bootloader.bin"),
 };
 
 impl ChipType for Esp32c3 {

--- a/espflash/src/chip/esp32/esp32c3.rs
+++ b/espflash/src/chip/esp32/esp32c3.rs
@@ -2,7 +2,7 @@ use std::ops::Range;
 
 use super::Esp32Params;
 use crate::{
-    chip::{ChipType, SpiRegisters},
+    chip::{ChipType, ReadEFuse, SpiRegisters},
     elf::FirmwareImage,
     image_format::{Esp32BootloaderFormat, ImageFormat, ImageFormatId},
     Chip, Error, PartitionTable,
@@ -76,4 +76,8 @@ impl ChipType for Esp32c3 {
     fn supports_target(target: &str) -> bool {
         target.starts_with("riscv32imc-")
     }
+}
+
+impl ReadEFuse for Esp32c3 {
+    const EFUSE_REG_BASE: u32 = 0x60008830;
 }

--- a/espflash/src/chip/esp32/esp32s2.rs
+++ b/espflash/src/chip/esp32/esp32s2.rs
@@ -1,12 +1,12 @@
-use crate::chip::Esp32Params;
-use crate::image_format::{Esp32BootloaderFormat, ImageFormat, ImageFormatId};
+use std::ops::Range;
+
+use super::Esp32Params;
 use crate::{
     chip::{ChipType, SpiRegisters},
     elf::FirmwareImage,
+    image_format::{Esp32BootloaderFormat, ImageFormat, ImageFormatId},
     Chip, Error, PartitionTable,
 };
-
-use std::ops::Range;
 
 pub struct Esp32s2;
 
@@ -26,7 +26,7 @@ pub const PARAMS: Esp32Params = Esp32Params {
     app_addr: 0x10000,
     app_size: 0x100000,
     chip_id: 2,
-    default_bootloader: include_bytes!("../../bootloader/esp32s2-bootloader.bin"),
+    default_bootloader: include_bytes!("../../../bootloader/esp32s2-bootloader.bin"),
 };
 
 impl ChipType for Esp32s2 {

--- a/espflash/src/chip/esp32/esp32s2.rs
+++ b/espflash/src/chip/esp32/esp32s2.rs
@@ -3,6 +3,7 @@ use std::ops::Range;
 use super::Esp32Params;
 use crate::{
     chip::{ChipType, ReadEFuse, SpiRegisters},
+    connection::Connection,
     elf::FirmwareImage,
     image_format::{Esp32BootloaderFormat, ImageFormat, ImageFormatId},
     Chip, Error, PartitionTable,
@@ -32,6 +33,8 @@ pub const PARAMS: Esp32Params = Esp32Params {
 impl ChipType for Esp32s2 {
     const CHIP_DETECT_MAGIC_VALUE: u32 = 0x000007c6;
 
+    const UART_CLKDIV_REG: u32 = 0x3f400014;
+
     const SPI_REGISTERS: SpiRegisters = SpiRegisters {
         base: 0x3f402000,
         usr_offset: 0x18,
@@ -50,6 +53,11 @@ impl ChipType for Esp32s2 {
 
     const SUPPORTED_TARGETS: &'static [&'static str] =
         &["xtensa-esp32s2-none-elf", "xtensa-esp32s2-espidf"];
+
+    fn crystal_freq(&self, _connection: &mut Connection) -> Result<u32, Error> {
+        // The ESP32-S2's XTAL has a fixed frequency of 40MHz.
+        Ok(40)
+    }
 
     fn get_flash_segments<'a>(
         image: &'a FirmwareImage,

--- a/espflash/src/chip/esp32/esp32s2.rs
+++ b/espflash/src/chip/esp32/esp32s2.rs
@@ -2,7 +2,7 @@ use std::ops::Range;
 
 use super::Esp32Params;
 use crate::{
-    chip::{ChipType, SpiRegisters},
+    chip::{ChipType, ReadEFuse, SpiRegisters},
     elf::FirmwareImage,
     image_format::{Esp32BootloaderFormat, ImageFormat, ImageFormatId},
     Chip, Error, PartitionTable,
@@ -74,4 +74,8 @@ impl ChipType for Esp32s2 {
     fn supports_target(target: &str) -> bool {
         target.starts_with("xtensa-esp32s2-")
     }
+}
+
+impl ReadEFuse for Esp32s2 {
+    const EFUSE_REG_BASE: u32 = 0x3F41A030;
 }

--- a/espflash/src/chip/esp32/mod.rs
+++ b/espflash/src/chip/esp32/mod.rs
@@ -1,5 +1,6 @@
 use crate::PartitionTable;
 
+#[allow(clippy::module_inception)]
 mod esp32;
 mod esp32c3;
 mod esp32s2;

--- a/espflash/src/chip/esp32/mod.rs
+++ b/espflash/src/chip/esp32/mod.rs
@@ -1,0 +1,36 @@
+use crate::PartitionTable;
+
+mod esp32;
+mod esp32c3;
+mod esp32s2;
+
+pub use esp32::Esp32;
+pub use esp32c3::Esp32c3;
+pub use esp32s2::Esp32s2;
+
+#[derive(Clone, Copy, Debug)]
+pub struct Esp32Params {
+    pub boot_addr: u32,
+    pub partition_addr: u32,
+    pub nvs_addr: u32,
+    pub nvs_size: u32,
+    pub phy_init_data_addr: u32,
+    pub phy_init_data_size: u32,
+    pub app_addr: u32,
+    pub app_size: u32,
+    pub chip_id: u16,
+    pub default_bootloader: &'static [u8],
+}
+
+impl Esp32Params {
+    pub fn default_partition_table(&self) -> PartitionTable {
+        PartitionTable::basic(
+            self.nvs_addr,
+            self.nvs_size,
+            self.phy_init_data_addr,
+            self.phy_init_data_size,
+            self.app_addr,
+            self.app_size,
+        )
+    }
+}

--- a/espflash/src/chip/esp8266.rs
+++ b/espflash/src/chip/esp8266.rs
@@ -1,12 +1,15 @@
-use super::ChipType;
-use crate::{chip::SpiRegisters, elf::FirmwareImage, Chip, Error, PartitionTable};
-
-use crate::error::UnsupportedImageFormatError;
-use crate::image_format::{Esp8266Format, ImageFormat, ImageFormatId};
-
 use std::ops::Range;
 
-pub const IROM_MAP_START: u32 = 0x40200000;
+use super::ChipType;
+use crate::{
+    chip::SpiRegisters,
+    elf::FirmwareImage,
+    error::UnsupportedImageFormatError,
+    image_format::{Esp8266Format, ImageFormat, ImageFormatId},
+    Chip, Error, PartitionTable,
+};
+
+const IROM_MAP_START: u32 = 0x40200000;
 const IROM_MAP_END: u32 = 0x40300000;
 
 pub struct Esp8266;

--- a/espflash/src/chip/esp8266.rs
+++ b/espflash/src/chip/esp8266.rs
@@ -2,7 +2,7 @@ use std::ops::Range;
 
 use super::ChipType;
 use crate::{
-    chip::SpiRegisters,
+    chip::{ReadEFuse, SpiRegisters},
     elf::FirmwareImage,
     error::UnsupportedImageFormatError,
     image_format::{Esp8266Format, ImageFormat, ImageFormatId},
@@ -51,10 +51,15 @@ impl ChipType for Esp8266 {
     }
 }
 
+impl ReadEFuse for Esp8266 {
+    const EFUSE_REG_BASE: u32 = 0x3ff00050;
+}
+
 #[test]
 fn test_esp8266_rom() {
-    use pretty_assertions::assert_eq;
     use std::fs::read;
+
+    use pretty_assertions::assert_eq;
 
     let input_bytes = read("./tests/data/esp8266").unwrap();
     let expected_bin = read("./tests/data/esp8266.bin").unwrap();

--- a/espflash/src/chip/esp8266.rs
+++ b/espflash/src/chip/esp8266.rs
@@ -17,6 +17,9 @@ pub struct Esp8266;
 impl ChipType for Esp8266 {
     const CHIP_DETECT_MAGIC_VALUE: u32 = 0xfff0c101;
 
+    const UART_CLKDIV_REG: u32 = 0x60000014;
+    const XTAL_CLK_DIVIDER: u32 = 2;
+
     const SPI_REGISTERS: SpiRegisters = SpiRegisters {
         base: 0x60000200,
         usr_offset: 0x1c,

--- a/espflash/src/chip/mod.rs
+++ b/espflash/src/chip/mod.rs
@@ -1,3 +1,5 @@
+use std::ops::Range;
+
 use strum_macros::Display;
 
 use crate::{
@@ -5,20 +7,15 @@ use crate::{
     error::ChipDetectError,
     flash_target::{Esp32Target, Esp8266Target, FlashTarget, RamTarget},
     flasher::SpiAttachParams,
+    image_format::{ImageFormat, ImageFormatId},
     Error, PartitionTable,
 };
 
-use crate::image_format::{ImageFormat, ImageFormatId};
-pub use esp32::Esp32;
-pub use esp32c3::Esp32c3;
-pub use esp32s2::Esp32s2;
-pub use esp8266::Esp8266;
-use std::ops::Range;
-
 mod esp32;
-mod esp32c3;
-mod esp32s2;
 mod esp8266;
+
+pub use esp32::{Esp32, Esp32Params, Esp32c3, Esp32s2};
+pub use esp8266::Esp8266;
 
 pub trait ChipType {
     const CHIP_DETECT_MAGIC_VALUE: u32;
@@ -196,32 +193,5 @@ impl Chip {
             Chip::Esp32s2 => Esp32s2::SUPPORTED_TARGETS,
             Chip::Esp8266 => Esp8266::SUPPORTED_TARGETS,
         }
-    }
-}
-
-#[derive(Clone, Copy, Debug)]
-pub struct Esp32Params {
-    pub boot_addr: u32,
-    pub partition_addr: u32,
-    pub nvs_addr: u32,
-    pub nvs_size: u32,
-    pub phy_init_data_addr: u32,
-    pub phy_init_data_size: u32,
-    pub app_addr: u32,
-    pub app_size: u32,
-    pub chip_id: u16,
-    pub default_bootloader: &'static [u8],
-}
-
-impl Esp32Params {
-    pub fn default_partition_table(&self) -> PartitionTable {
-        PartitionTable::basic(
-            self.nvs_addr,
-            self.nvs_size,
-            self.phy_init_data_addr,
-            self.phy_init_data_size,
-            self.app_addr,
-            self.app_size,
-        )
     }
 }

--- a/espflash/src/flasher.rs
+++ b/espflash/src/flasher.rs
@@ -459,6 +459,24 @@ impl Flasher {
         self.flash_size
     }
 
+    /// Read and print any information we can about the connected board
+    pub fn board_info(&mut self) -> Result<(), Error> {
+        let chip = self.chip();
+        let maybe_revision = chip.chip_revision(self.connection())?;
+        let freq = chip.crystal_freq(self.connection())?;
+        let size = self.flash_size();
+
+        print!("Chip type:         {}", chip);
+        match maybe_revision {
+            Some(revision) => println!(" (revision {})", revision),
+            None => println!(),
+        }
+        println!("Crystal frequency: {}MHz", freq);
+        println!("Flash size:        {}", size);
+
+        Ok(())
+    }
+
     /// Load an elf image to ram and execute it
     ///
     /// Note that this will not touch the flash on the device

--- a/espflash/src/flasher.rs
+++ b/espflash/src/flasher.rs
@@ -444,6 +444,11 @@ impl Flasher {
         Ok(result)
     }
 
+    /// The active serial connection being used by the flasher
+    pub fn connection(&mut self) -> &mut Connection {
+        &mut self.connection
+    }
+
     /// The chip type that the flasher is connected to
     pub fn chip(&self) -> Chip {
         self.chip

--- a/espflash/src/main.rs
+++ b/espflash/src/main.rs
@@ -56,8 +56,7 @@ fn main() -> Result<()> {
     let mut flasher = Flasher::connect(serial, None)?;
 
     if board_info {
-        println!("Chip type: {}", flasher.chip());
-        println!("Flash size: {}", flasher.flash_size());
+        flasher.board_info()?;
 
         return Ok(());
     }


### PR DESCRIPTION
As the title says, adds a way to read eFuse values. Various information such as silicon revision, MAC address, chip features, etc. are accessible via the eFuse memory.

This PR contains a small refactor of the `chip` module as well, just slightly better separation of concerns.

I have additionally moved the `board_info` function out of `cargo-espflash` into the `Flasher` module, so that it can also be used by `espflash` without duplication.

Closes #39.