### PR TITLE
Fix typo in supported chip name (S3 -> S2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # ESPFlash
+
 [![Actions Status](https://github.com/esp-rs/espflash/workflows/CI/badge.svg)](https://github.com/esp-rs/espflash/actions?query=workflow%3A"CI")
 
 _ESP8266_ and _ESP32_ family serial flasher based on [esptool.py](https://github.com/espressif/esptool).
@@ -8,7 +9,7 @@ _ESP8266_ and _ESP32_ family serial flasher based on [esptool.py](https://github
 
 ## Status
 
-Flashing _should_ work for __ESP32__, __ESP32-S3__, __ESP32-C3__, and __ESP8266__.
+Flashing _should_ work for __ESP32__, __ESP32-S2__, __ESP32-C3__, and __ESP8266__.
 
 If you have an ELF file that flashes correctly with `esptool.py` but not with this tool then please open an issue with the ELF in question.
 

--- a/cargo-espflash/README.md
+++ b/cargo-espflash/README.md
@@ -1,6 +1,6 @@
 # `cargo-espflash`
 
-Cross-compiler and serial flasher cargo subcommand for Espressif devices. Currently supports __ESP32__, __ESP32-S3__, __ESP32-C3__, and __ESP8266__.
+Cross-compiler and serial flasher cargo subcommand for Espressif devices. Currently supports __ESP32__, __ESP32-S2__, __ESP32-C3__, and __ESP8266__.
 
 Prior to flashing, the project is built using the `build-std` unstable cargo feature. Please refer to the [cargo documentation](https://doc.rust-lang.org/cargo/reference/unstable.html#build-std) for more information.
 

--- a/espflash/README.md
+++ b/espflash/README.md
@@ -1,6 +1,6 @@
 # `espflash`
 
-__ESP32__, __ESP32-S3__, __ESP32-C3__, and __ESP8266__ serial flasher library and CLI application.
+__ESP32__, __ESP32-S2__, __ESP32-C3__, and __ESP8266__ serial flasher library and CLI application.
 
 [![asciicast](https://asciinema.org/a/367205.svg)](https://asciinema.org/a/367205)
 


### PR DESCRIPTION
We have been lying to our users 😁 🙉 