### PR TITLE
If flash size cannot be detected, print a warning and default to 4MB

### DIFF
--- a/espflash/src/image_format/esp32bootloader.rs
+++ b/espflash/src/image_format/esp32bootloader.rs
@@ -1,17 +1,18 @@
-use crate::chip::Esp32Params;
-use crate::elf::{
-    merge_segments, update_checksum, CodeSegment, FirmwareImage, RomSegment, ESP_CHECKSUM_MAGIC,
-};
-use crate::error::{Error, FlashDetectError};
-use crate::flasher::FlashSize;
-use crate::image_format::{
-    EspCommonHeader, ImageFormat, SegmentHeader, ESP_MAGIC, WP_PIN_DISABLED,
-};
-use crate::{Chip, PartitionTable};
-use bytemuck::bytes_of;
-use bytemuck::{Pod, Zeroable};
-use sha2::{Digest, Sha256};
 use std::{borrow::Cow, io::Write, iter::once};
+
+use bytemuck::{bytes_of, Pod, Zeroable};
+use sha2::{Digest, Sha256};
+
+use crate::{
+    chip::Esp32Params,
+    elf::{
+        merge_segments, update_checksum, CodeSegment, FirmwareImage, RomSegment, ESP_CHECKSUM_MAGIC,
+    },
+    error::{Error, FlashDetectError},
+    flasher::FlashSize,
+    image_format::{EspCommonHeader, ImageFormat, SegmentHeader, ESP_MAGIC, WP_PIN_DISABLED},
+    Chip, PartitionTable,
+};
 
 /// Image format for esp32 family chips using a 2nd stage bootloader
 pub struct Esp32BootloaderFormat<'a> {
@@ -72,7 +73,8 @@ impl<'a> Esp32BootloaderFormat<'a> {
                 if pad_len > 0 {
                     if pad_len > SEG_HEADER_LEN {
                         if let Some(ram_segment) = ram_segments.first_mut() {
-                            // save up to `pad_len` from the ram segment, any remaining bits in the ram segments will be saved later
+                            // save up to `pad_len` from the ram segment, any remaining bits in the
+                            // ram segments will be saved later
                             let pad_segment = ram_segment.split_off(pad_len as usize);
                             checksum = save_segment(&mut data, &pad_segment, checksum)?;
                             if ram_segment.data().is_empty() {
@@ -152,14 +154,12 @@ impl<'a> ImageFormat<'a> for Esp32BootloaderFormat<'a> {
 
 fn encode_flash_size(size: FlashSize) -> Result<u8, FlashDetectError> {
     match size {
-        FlashSize::Flash256Kb => Err(FlashDetectError::from(size as u8)),
-        FlashSize::Flash512Kb => Err(FlashDetectError::from(size as u8)),
         FlashSize::Flash1Mb => Ok(0x00),
         FlashSize::Flash2Mb => Ok(0x10),
         FlashSize::Flash4Mb => Ok(0x20),
         FlashSize::Flash8Mb => Ok(0x30),
         FlashSize::Flash16Mb => Ok(0x40),
-        FlashSize::FlashRetry => Err(FlashDetectError::from(size as u8)),
+        _ => Err(FlashDetectError::from(size as u8)),
     }
 }
 

--- a/espflash/src/image_format/esp8266.rs
+++ b/espflash/src/image_format/esp8266.rs
@@ -1,10 +1,14 @@
-use crate::elf::{update_checksum, CodeSegment, FirmwareImage, RomSegment, ESP_CHECKSUM_MAGIC};
-use crate::error::{Error, FlashDetectError};
-use crate::flasher::FlashSize;
-use crate::image_format::{EspCommonHeader, ImageFormat, SegmentHeader, ESP_MAGIC};
-use crate::Chip;
-use bytemuck::bytes_of;
 use std::{borrow::Cow, io::Write, iter::once, mem::size_of};
+
+use bytemuck::bytes_of;
+
+use crate::{
+    elf::{update_checksum, CodeSegment, FirmwareImage, RomSegment, ESP_CHECKSUM_MAGIC},
+    error::{Error, FlashDetectError},
+    flasher::FlashSize,
+    image_format::{EspCommonHeader, ImageFormat, SegmentHeader, ESP_MAGIC},
+    Chip,
+};
 
 const IROM_MAP_START: u32 = 0x40200000;
 
@@ -122,6 +126,6 @@ fn encode_flash_size(size: FlashSize) -> Result<u8, FlashDetectError> {
         FlashSize::Flash4Mb => Ok(0x40),
         FlashSize::Flash8Mb => Ok(0x80),
         FlashSize::Flash16Mb => Ok(0x90),
-        FlashSize::FlashRetry => Err(FlashDetectError::from(size as u8)),
+        _ => Err(FlashDetectError::from(size as u8)),
     }
 }


### PR DESCRIPTION
This replicates the behaviour in `esptool.py`. Rather than terminate the flashing process, it's likely that using a sane default value will still work. If this flash size is not supported for the detected chip or the application image is too large an error should be generated regardless.

I have an ESP32-S3 development board whose flash ID is _not_ recognized, which was what prompted me to do this.

Additionally adds two flash sizes and IDs from `esptool.py` which were not present here.