### PR TITLE
add cargo-espflash subcommand to save the generated image to disk

### DIFF
--- a/espflash/src/chip/esp32/esp32.rs
+++ b/espflash/src/chip/esp32/esp32.rs
@@ -115,7 +115,7 @@ fn test_esp32_rom() {
     let image = FirmwareImage::from_data(&input_bytes).unwrap();
     let flash_image = Esp32BootloaderFormat::new(&image, Chip::Esp32, PARAMS, None, None).unwrap();
 
-    let segments = flash_image.segments().collect::<Vec<_>>();
+    let segments = flash_image.flash_segments().collect::<Vec<_>>();
 
     assert_eq!(3, segments.len());
     let buff = segments[2].data.as_ref();

--- a/espflash/src/chip/esp8266.rs
+++ b/espflash/src/chip/esp8266.rs
@@ -70,7 +70,7 @@ fn test_esp8266_rom() {
     let image = FirmwareImage::from_data(&input_bytes).unwrap();
     let flash_image = Esp8266Format::new(&image).unwrap();
 
-    let segments = flash_image.segments().collect::<Vec<_>>();
+    let segments = flash_image.flash_segments().collect::<Vec<_>>();
 
     assert_eq!(1, segments.len());
     let buff = segments[0].data.as_ref();

--- a/espflash/src/chip/mod.rs
+++ b/espflash/src/chip/mod.rs
@@ -130,6 +130,22 @@ impl Chip {
         }
     }
 
+    pub fn from_target(target: &str) -> Option<Self> {
+        if Esp8266::supports_target(target) {
+            return Some(Chip::Esp8266);
+        }
+        if Esp32::supports_target(target) {
+            return Some(Chip::Esp32);
+        }
+        if Esp32s2::supports_target(target) {
+            return Some(Chip::Esp32s2);
+        }
+        if Esp32c3::supports_target(target) {
+            return Some(Chip::Esp32c3);
+        }
+        None
+    }
+
     pub fn get_flash_image<'a>(
         &self,
         image: &'a FirmwareImage,

--- a/espflash/src/elf.rs
+++ b/espflash/src/elf.rs
@@ -2,6 +2,7 @@ use std::borrow::Cow;
 use std::cmp::Ordering;
 
 use crate::chip::Chip;
+use crate::error::{ElfError, Error};
 use crate::flasher::FlashSize;
 use std::fmt::{Debug, Formatter};
 use std::mem::take;
@@ -38,8 +39,9 @@ pub struct FirmwareImage<'a> {
 }
 
 impl<'a> FirmwareImage<'a> {
-    pub fn from_data(data: &'a [u8]) -> Result<Self, &'static str> {
-        Ok(Self::from_elf(ElfFile::new(data)?))
+    pub fn from_data(data: &'a [u8]) -> Result<Self, Error> {
+        let elf = ElfFile::new(data).map_err(ElfError::from)?;
+        Ok(Self::from_elf(elf))
     }
 
     pub fn from_elf(elf: ElfFile<'a>) -> Self {

--- a/espflash/src/flasher.rs
+++ b/espflash/src/flasher.rs
@@ -9,7 +9,7 @@ use crate::{
     connection::Connection,
     elf::{FirmwareImage, RomSegment},
     encoder::SlipEncoder,
-    error::{ConnectionError, ElfError, FlashDetectError, ResultExt, RomError, RomErrorKind},
+    error::{ConnectionError, FlashDetectError, ResultExt, RomError, RomErrorKind},
     Error, PartitionTable,
 };
 
@@ -498,7 +498,7 @@ impl Flasher {
     ///
     /// Note that this will not touch the flash on the device
     pub fn load_elf_to_ram(&mut self, elf_data: &[u8]) -> Result<(), Error> {
-        let image = FirmwareImage::from_data(elf_data).map_err(ElfError::from)?;
+        let image = FirmwareImage::from_data(elf_data)?;
 
         let mut target = self.chip.ram_target();
         target.begin(&mut self.connection, &image).flashing()?;
@@ -529,7 +529,7 @@ impl Flasher {
         bootloader: Option<Vec<u8>>,
         partition_table: Option<PartitionTable>,
     ) -> Result<(), Error> {
-        let mut image = FirmwareImage::from_data(elf_data).map_err(ElfError::from)?;
+        let mut image = FirmwareImage::from_data(elf_data)?;
         image.flash_size = self.flash_size();
 
         let mut target = self.chip.flash_target(self.spi_params);
@@ -539,7 +539,7 @@ impl Flasher {
             .chip
             .get_flash_image(&image, bootloader, partition_table, None)?;
 
-        for segment in flash_image.segments() {
+        for segment in flash_image.flash_segments() {
             target
                 .write_segment(&mut self.connection, segment)
                 .flashing()?;

--- a/espflash/src/image_format/esp32bootloader.rs
+++ b/espflash/src/image_format/esp32bootloader.rs
@@ -134,7 +134,7 @@ impl<'a> Esp32BootloaderFormat<'a> {
 }
 
 impl<'a> ImageFormat<'a> for Esp32BootloaderFormat<'a> {
-    fn segments<'b>(&'b self) -> Box<dyn Iterator<Item = RomSegment<'b>> + 'b>
+    fn flash_segments<'b>(&'b self) -> Box<dyn Iterator<Item = RomSegment<'b>> + 'b>
     where
         'a: 'b,
     {
@@ -149,6 +149,13 @@ impl<'a> ImageFormat<'a> for Esp32BootloaderFormat<'a> {
             }))
             .chain(once(self.flash_segment.borrow())),
         )
+    }
+
+    fn ota_segments<'b>(&'b self) -> Box<dyn Iterator<Item = RomSegment<'b>> + 'b>
+    where
+        'a: 'b,
+    {
+        Box::new(once(self.flash_segment.borrow()))
     }
 }
 

--- a/espflash/src/image_format/esp8266.rs
+++ b/espflash/src/image_format/esp8266.rs
@@ -78,7 +78,19 @@ impl<'a> Esp8266Format<'a> {
 }
 
 impl<'a> ImageFormat<'a> for Esp8266Format<'a> {
-    fn segments<'b>(&'b self) -> Box<dyn Iterator<Item = RomSegment<'b>> + 'b>
+    fn flash_segments<'b>(&'b self) -> Box<dyn Iterator<Item = RomSegment<'b>> + 'b>
+    where
+        'a: 'b,
+    {
+        Box::new(
+            self.irom_data
+                .iter()
+                .map(RomSegment::borrow)
+                .chain(once(self.flash_segment.borrow())),
+        )
+    }
+
+    fn ota_segments<'b>(&'b self) -> Box<dyn Iterator<Item = RomSegment<'b>> + 'b>
     where
         'a: 'b,
     {

--- a/espflash/src/image_format/mod.rs
+++ b/espflash/src/image_format/mod.rs
@@ -29,7 +29,15 @@ struct SegmentHeader {
 }
 
 pub trait ImageFormat<'a> {
-    fn segments<'b>(&'b self) -> Box<dyn Iterator<Item = RomSegment<'b>> + 'b>
+    /// Get the rom segments needed when flashing to device
+    fn flash_segments<'b>(&'b self) -> Box<dyn Iterator<Item = RomSegment<'b>> + 'b>
+    where
+        'a: 'b;
+
+    /// Get the rom segments to save when exporting for ota
+    ///
+    /// Compared to `flash_segments` this excludes things like bootloader and partition table
+    fn ota_segments<'b>(&'b self) -> Box<dyn Iterator<Item = RomSegment<'b>> + 'b>
     where
         'a: 'b;
 }

--- a/espflash/src/lib.rs
+++ b/espflash/src/lib.rs
@@ -11,6 +11,7 @@ mod partition_table;
 
 pub use chip::Chip;
 pub use config::Config;
+pub use elf::FirmwareImage;
 pub use error::Error;
 pub use flasher::Flasher;
 pub use partition_table::PartitionTable;


### PR DESCRIPTION
Allows saving the rom image instead of flashing it

- No attempt to connect to a device is made
- Image format is determined by matching against the configured target to auto detect the chip
- If an image contains multiple segments (esp8266) the output paths are prefixed by the address for the segment

Fixes #57