### PR TITLE
add support for flashing direct-boot images to esp32c3

### DIFF
--- a/cargo-espflash/src/main.rs
+++ b/cargo-espflash/src/main.rs
@@ -388,7 +388,7 @@ fn save_image(
         .transpose()?
         .or(metadata.format);
 
-    let flash_image = chip.get_flash_image(&image, None, None, image_format)?;
+    let flash_image = chip.get_flash_image(&image, None, None, image_format, None)?;
     let parts: Vec<_> = flash_image.ota_segments().collect();
 
     let out_path = matches.value_of("file").unwrap();

--- a/cargo-espflash/src/main.rs
+++ b/cargo-espflash/src/main.rs
@@ -237,8 +237,8 @@ fn flash(
     let image_format = matches
         .value_of("format")
         .map(ImageFormatId::from_str)
-        .transpose()
-        .into_diagnostic()?;
+        .transpose()?
+        .or(metadata.format);
 
     // Read the ELF data from the build path and load it to the target.
     let elf_data = fs::read(path).into_diagnostic()?;
@@ -368,7 +368,7 @@ fn build(
 fn save_image(
     matches: &ArgMatches,
     _config: Config,
-    _metadata: CargoEspFlashMeta,
+    metadata: CargoEspFlashMeta,
     cargo_config: CargoConfig,
 ) -> Result<()> {
     let target = cargo_config
@@ -385,8 +385,8 @@ fn save_image(
     let image_format = matches
         .value_of("format")
         .map(ImageFormatId::from_str)
-        .transpose()
-        .into_diagnostic()?;
+        .transpose()?
+        .or(metadata.format);
 
     let flash_image = chip.get_flash_image(&image, None, None, image_format)?;
     let parts: Vec<_> = flash_image.ota_segments().collect();

--- a/cargo-espflash/src/main.rs
+++ b/cargo-espflash/src/main.rs
@@ -8,7 +8,7 @@ use std::{
 use cargo_metadata::Message;
 use clap::{App, Arg, ArgMatches, SubCommand};
 use error::Error;
-use espflash::{Chip, Config, FirmwareImage, Flasher, PartitionTable};
+use espflash::{Chip, Config, FirmwareImage, Flasher, ImageFormatId, PartitionTable};
 use miette::{IntoDiagnostic, Result, WrapErr};
 use monitor::monitor;
 use package_metadata::CargoEspFlashMeta;
@@ -17,6 +17,7 @@ use serial::{BaudRate, FlowControl, SerialPort};
 use crate::cargo_config::CargoConfig;
 use crate::error::NoTargetError;
 use crate::{cargo_config::parse_cargo_config, error::UnsupportedTargetError};
+use std::str::FromStr;
 
 mod cargo_config;
 mod error;
@@ -42,6 +43,11 @@ fn main() -> Result<()> {
             .takes_value(true)
             .value_name("FEATURES")
             .help("Comma delimited list of build features"),
+        Arg::with_name("format")
+            .long("format")
+            .takes_value(true)
+            .value_name("image format")
+            .help("Image format to flash"),
     ];
     let connect_args = [Arg::with_name("serial")
         .takes_value(true)
@@ -228,12 +234,18 @@ fn flash(
         None
     };
 
+    let image_format = matches
+        .value_of("format")
+        .map(ImageFormatId::from_str)
+        .transpose()
+        .into_diagnostic()?;
+
     // Read the ELF data from the build path and load it to the target.
     let elf_data = fs::read(path).into_diagnostic()?;
     if matches.is_present("ram") {
         flasher.load_elf_to_ram(&elf_data)?;
     } else {
-        flasher.load_elf_to_flash(&elf_data, bootloader, partition_table)?;
+        flasher.load_elf_to_flash(&elf_data, bootloader, partition_table, image_format)?;
     }
     println!("\nFlashing has completed!");
 
@@ -266,13 +278,6 @@ fn build(
     cargo_config: &CargoConfig,
     chip: Option<Chip>,
 ) -> Result<PathBuf> {
-    // The 'build-std' unstable cargo feature is required to enable
-    // cross-compilation. If it has not been set then we cannot build the
-    // application.
-    if !cargo_config.has_build_std() {
-        return Err(Error::NoBuildStd.into());
-    };
-
     let target = cargo_config
         .target()
         .ok_or_else(|| NoTargetError::new(chip))?;
@@ -281,6 +286,13 @@ fn build(
             return Err(Error::UnsupportedTarget(UnsupportedTargetError::new(target, chip)).into());
         }
     }
+    // The 'build-std' unstable cargo feature is required to enable
+    // cross-compilation for xtensa targets.
+    // If it has not been set then we cannot build the
+    // application.
+    if !cargo_config.has_build_std() && target.starts_with("xtensa-") {
+        return Err(Error::NoBuildStd.into());
+    };
 
     // Build the list of arguments to pass to 'cargo build'.
     let mut args = vec![];
@@ -370,7 +382,13 @@ fn save_image(
 
     let image = FirmwareImage::from_data(&elf_data)?;
 
-    let flash_image = chip.get_flash_image(&image, None, None, None)?;
+    let image_format = matches
+        .value_of("format")
+        .map(ImageFormatId::from_str)
+        .transpose()
+        .into_diagnostic()?;
+
+    let flash_image = chip.get_flash_image(&image, None, None, image_format)?;
     let parts: Vec<_> = flash_image.ota_segments().collect();
 
     let out_path = matches.value_of("file").unwrap();

--- a/cargo-espflash/src/package_metadata.rs
+++ b/cargo-espflash/src/package_metadata.rs
@@ -1,5 +1,6 @@
 use crate::error::{Error, TomlError};
 use cargo_toml::Manifest;
+use espflash::ImageFormatId;
 use miette::{IntoDiagnostic, Result, WrapErr};
 use serde::Deserialize;
 use std::fs::read_to_string;
@@ -9,6 +10,7 @@ use std::path::Path;
 pub struct CargoEspFlashMeta {
     pub partition_table: Option<String>,
     pub bootloader: Option<String>,
+    pub format: Option<ImageFormatId>,
 }
 
 #[derive(Clone, Debug, Default, Deserialize)]

--- a/espflash/src/chip/esp32/esp32.rs
+++ b/espflash/src/chip/esp32/esp32.rs
@@ -118,6 +118,7 @@ impl ChipType for Esp32 {
         bootloader: Option<Vec<u8>>,
         partition_table: Option<PartitionTable>,
         image_format: ImageFormatId,
+        _chip_revision: Option<u32>,
     ) -> Result<Box<dyn ImageFormat<'a> + 'a>, Error> {
         match image_format {
             ImageFormatId::Bootloader => Ok(Box::new(Esp32BootloaderFormat::new(
@@ -127,7 +128,7 @@ impl ChipType for Esp32 {
                 partition_table,
                 bootloader,
             )?)),
-            _ => Err(UnsupportedImageFormatError::new(image_format, Chip::Esp8266).into()),
+            _ => Err(UnsupportedImageFormatError::new(image_format, Chip::Esp32, None).into()),
         }
     }
 

--- a/espflash/src/chip/esp32/esp32.rs
+++ b/espflash/src/chip/esp32/esp32.rs
@@ -1,6 +1,7 @@
 use std::ops::Range;
 
 use super::Esp32Params;
+use crate::error::UnsupportedImageFormatError;
 use crate::{
     chip::{bytes_to_mac_addr, Chip, ChipType, ReadEFuse, SpiRegisters},
     connection::Connection,
@@ -126,9 +127,7 @@ impl ChipType for Esp32 {
                 partition_table,
                 bootloader,
             )?)),
-            ImageFormatId::DirectBoot => {
-                todo!()
-            }
+            _ => Err(UnsupportedImageFormatError::new(image_format, Chip::Esp8266).into()),
         }
     }
 

--- a/espflash/src/chip/esp32/esp32c3.rs
+++ b/espflash/src/chip/esp32/esp32c3.rs
@@ -1,6 +1,7 @@
 use std::ops::Range;
 
 use super::Esp32Params;
+use crate::error::UnsupportedImageFormatError;
 use crate::image_format::Esp32DirectBootFormat;
 use crate::{
     chip::{bytes_to_mac_addr, ChipType, ReadEFuse, SpiRegisters},
@@ -71,16 +72,22 @@ impl ChipType for Esp32c3 {
         bootloader: Option<Vec<u8>>,
         partition_table: Option<PartitionTable>,
         image_format: ImageFormatId,
+        chip_revision: Option<u32>,
     ) -> Result<Box<dyn ImageFormat<'a> + 'a>, Error> {
-        match image_format {
-            ImageFormatId::Bootloader => Ok(Box::new(Esp32BootloaderFormat::new(
+        match (image_format, chip_revision) {
+            (ImageFormatId::Bootloader, _) => Ok(Box::new(Esp32BootloaderFormat::new(
                 image,
                 Chip::Esp32c3,
                 PARAMS,
                 partition_table,
                 bootloader,
             )?)),
-            ImageFormatId::DirectBoot => Ok(Box::new(Esp32DirectBootFormat::new(image)?)),
+            (ImageFormatId::DirectBoot, None | Some(3..)) => {
+                Ok(Box::new(Esp32DirectBootFormat::new(image)?))
+            }
+            _ => Err(
+                UnsupportedImageFormatError::new(image_format, Chip::Esp32c3, chip_revision).into(),
+            ),
         }
     }
 

--- a/espflash/src/chip/esp32/esp32c3.rs
+++ b/espflash/src/chip/esp32/esp32c3.rs
@@ -1,6 +1,7 @@
 use std::ops::Range;
 
 use super::Esp32Params;
+use crate::image_format::Esp32DirectBootFormat;
 use crate::{
     chip::{bytes_to_mac_addr, ChipType, ReadEFuse, SpiRegisters},
     connection::Connection,
@@ -79,9 +80,7 @@ impl ChipType for Esp32c3 {
                 partition_table,
                 bootloader,
             )?)),
-            ImageFormatId::DirectBoot => {
-                todo!()
-            }
+            ImageFormatId::DirectBoot => Ok(Box::new(Esp32DirectBootFormat::new(image)?)),
         }
     }
 

--- a/espflash/src/chip/esp32/esp32s2.rs
+++ b/espflash/src/chip/esp32/esp32s2.rs
@@ -95,6 +95,7 @@ impl ChipType for Esp32s2 {
         bootloader: Option<Vec<u8>>,
         partition_table: Option<PartitionTable>,
         image_format: ImageFormatId,
+        _chip_revision: Option<u32>,
     ) -> Result<Box<dyn ImageFormat<'a> + 'a>, Error> {
         match image_format {
             ImageFormatId::Bootloader => Ok(Box::new(Esp32BootloaderFormat::new(
@@ -104,7 +105,7 @@ impl ChipType for Esp32s2 {
                 partition_table,
                 bootloader,
             )?)),
-            _ => Err(UnsupportedImageFormatError::new(image_format, Chip::Esp8266).into()),
+            _ => Err(UnsupportedImageFormatError::new(image_format, Chip::Esp32s2, None).into()),
         }
     }
 

--- a/espflash/src/chip/esp32/esp32s2.rs
+++ b/espflash/src/chip/esp32/esp32s2.rs
@@ -1,6 +1,7 @@
 use std::ops::Range;
 
 use super::Esp32Params;
+use crate::error::UnsupportedImageFormatError;
 use crate::{
     chip::{bytes_to_mac_addr, ChipType, ReadEFuse, SpiRegisters},
     connection::Connection,
@@ -103,9 +104,7 @@ impl ChipType for Esp32s2 {
                 partition_table,
                 bootloader,
             )?)),
-            ImageFormatId::DirectBoot => {
-                todo!()
-            }
+            _ => Err(UnsupportedImageFormatError::new(image_format, Chip::Esp8266).into()),
         }
     }
 

--- a/espflash/src/chip/esp8266.rs
+++ b/espflash/src/chip/esp8266.rs
@@ -47,10 +47,11 @@ impl ChipType for Esp8266 {
         _bootloader: Option<Vec<u8>>,
         _partition_table: Option<PartitionTable>,
         image_format: ImageFormatId,
+        _chip_revision: Option<u32>,
     ) -> Result<Box<dyn ImageFormat<'a> + 'a>, Error> {
         match image_format {
             ImageFormatId::Bootloader => Ok(Box::new(Esp8266Format::new(image)?)),
-            _ => Err(UnsupportedImageFormatError::new(image_format, Chip::Esp8266).into()),
+            _ => Err(UnsupportedImageFormatError::new(image_format, Chip::Esp8266, None).into()),
         }
     }
 

--- a/espflash/src/chip/mod.rs
+++ b/espflash/src/chip/mod.rs
@@ -53,6 +53,7 @@ pub trait ChipType {
         bootloader: Option<Vec<u8>>,
         partition_table: Option<PartitionTable>,
         image_format: ImageFormatId,
+        chip_revision: Option<u32>,
     ) -> Result<Box<dyn ImageFormat<'a> + 'a>, Error>;
 
     /// Read the MAC address of the connected chip.
@@ -158,20 +159,35 @@ impl Chip {
         bootloader: Option<Vec<u8>>,
         partition_table: Option<PartitionTable>,
         image_format: Option<ImageFormatId>,
+        chip_revision: Option<u32>,
     ) -> Result<Box<dyn ImageFormat<'a> + 'a>, Error> {
         let image_format = image_format.unwrap_or_else(|| self.default_image_format());
 
         match self {
-            Chip::Esp32 => {
-                Esp32::get_flash_segments(image, bootloader, partition_table, image_format)
+            Chip::Esp32 => Esp32::get_flash_segments(
+                image,
+                bootloader,
+                partition_table,
+                image_format,
+                chip_revision,
+            ),
+            Chip::Esp32c3 => Esp32c3::get_flash_segments(
+                image,
+                bootloader,
+                partition_table,
+                image_format,
+                chip_revision,
+            ),
+            Chip::Esp32s2 => Esp32s2::get_flash_segments(
+                image,
+                bootloader,
+                partition_table,
+                image_format,
+                chip_revision,
+            ),
+            Chip::Esp8266 => {
+                Esp8266::get_flash_segments(image, None, None, image_format, chip_revision)
             }
-            Chip::Esp32c3 => {
-                Esp32c3::get_flash_segments(image, bootloader, partition_table, image_format)
-            }
-            Chip::Esp32s2 => {
-                Esp32s2::get_flash_segments(image, bootloader, partition_table, image_format)
-            }
-            Chip::Esp8266 => Esp8266::get_flash_segments(image, None, None, image_format),
         }
     }
 

--- a/espflash/src/error.rs
+++ b/espflash/src/error.rs
@@ -57,6 +57,15 @@ pub enum Error {
         help("The following image formats are {}", ImageFormatId::VARIANTS.join(", "))
     )]
     UnknownImageFormat(String),
+    #[error("binary is not setup correct to support direct boot")]
+    #[diagnostic(
+        code(espflash::invalid_direct_boot),
+        help(
+            "See the following page for documentation on how to setup your binary for direct boot:
+https://github.com/espressif/esp32c3-direct-boot-example"
+        )
+    )]
+    InvalidDirectBootBinary,
 }
 
 #[derive(Error, Debug, Diagnostic)]

--- a/espflash/src/error.rs
+++ b/espflash/src/error.rs
@@ -6,7 +6,7 @@ use miette::{Diagnostic, SourceOffset, SourceSpan};
 use slip_codec::Error as SlipError;
 use std::fmt::{Display, Formatter};
 use std::io;
-use strum::AsStaticRef;
+use strum::{AsStaticRef, VariantNames};
 use thiserror::Error;
 
 #[derive(Error, Debug, Diagnostic)]
@@ -51,6 +51,12 @@ pub enum Error {
     #[error(transparent)]
     #[diagnostic(transparent)]
     UnsupportedImageFormat(#[from] UnsupportedImageFormatError),
+    #[error("Unrecognized image format {0}")]
+    #[diagnostic(
+        code(espflash::unknown_format),
+        help("The following image formats are {}", ImageFormatId::VARIANTS.join(", "))
+    )]
+    UnknownImageFormat(String),
 }
 
 #[derive(Error, Debug, Diagnostic)]

--- a/espflash/src/flasher.rs
+++ b/espflash/src/flasher.rs
@@ -542,9 +542,13 @@ impl Flasher {
         let mut target = self.chip.flash_target(self.spi_params);
         target.begin(&mut self.connection, &image).flashing()?;
 
-        let flash_image =
-            self.chip
-                .get_flash_image(&image, bootloader, partition_table, image_format)?;
+        let flash_image = self.chip.get_flash_image(
+            &image,
+            bootloader,
+            partition_table,
+            image_format,
+            self.chip.chip_revision(&mut self.connection)?,
+        )?;
 
         for segment in flash_image.flash_segments() {
             target

--- a/espflash/src/flasher.rs
+++ b/espflash/src/flasher.rs
@@ -4,6 +4,7 @@ use bytemuck::{__core::time::Duration, bytes_of, Pod, Zeroable};
 use serial::{BaudRate, SystemPort};
 use strum_macros::Display;
 
+use crate::image_format::ImageFormatId;
 use crate::{
     chip::Chip,
     connection::Connection,
@@ -533,6 +534,7 @@ impl Flasher {
         elf_data: &[u8],
         bootloader: Option<Vec<u8>>,
         partition_table: Option<PartitionTable>,
+        image_format: Option<ImageFormatId>,
     ) -> Result<(), Error> {
         let mut image = FirmwareImage::from_data(elf_data)?;
         image.flash_size = self.flash_size();
@@ -540,9 +542,9 @@ impl Flasher {
         let mut target = self.chip.flash_target(self.spi_params);
         target.begin(&mut self.connection, &image).flashing()?;
 
-        let flash_image = self
-            .chip
-            .get_flash_image(&image, bootloader, partition_table, None)?;
+        let flash_image =
+            self.chip
+                .get_flash_image(&image, bootloader, partition_table, image_format)?;
 
         for segment in flash_image.flash_segments() {
             target

--- a/espflash/src/image_format/esp32bootloader.rs
+++ b/espflash/src/image_format/esp32bootloader.rs
@@ -6,7 +6,8 @@ use sha2::{Digest, Sha256};
 use crate::{
     chip::Esp32Params,
     elf::{
-        merge_segments, update_checksum, CodeSegment, FirmwareImage, RomSegment, ESP_CHECKSUM_MAGIC,
+        merge_adjacent_segments, update_checksum, CodeSegment, FirmwareImage, RomSegment,
+        ESP_CHECKSUM_MAGIC,
     },
     error::{Error, FlashDetectError},
     flasher::FlashSize,
@@ -62,8 +63,8 @@ impl<'a> Esp32BootloaderFormat<'a> {
 
         let mut checksum = ESP_CHECKSUM_MAGIC;
 
-        let flash_segments: Vec<_> = merge_segments(image.rom_segments(chip).collect());
-        let mut ram_segments: Vec<_> = merge_segments(image.ram_segments(chip).collect());
+        let flash_segments: Vec<_> = merge_adjacent_segments(image.rom_segments(chip).collect());
+        let mut ram_segments: Vec<_> = merge_adjacent_segments(image.ram_segments(chip).collect());
 
         let mut segment_count = 0;
 

--- a/espflash/src/image_format/esp32directboot.rs
+++ b/espflash/src/image_format/esp32directboot.rs
@@ -26,6 +26,12 @@ impl<'a> Esp32DirectBootFormat<'a> {
             });
         segment.pad_align(4);
 
+        if segment.addr != 0
+            || segment.data()[0..8] != [0x1d, 0x04, 0xdb, 0xae, 0x1d, 0x04, 0xdb, 0xae]
+        {
+            return Err(Error::InvalidDirectBootBinary);
+        }
+
         Ok(Self {
             segment: segment.into(),
         })

--- a/espflash/src/image_format/esp32directboot.rs
+++ b/espflash/src/image_format/esp32directboot.rs
@@ -1,0 +1,49 @@
+use crate::elf::CodeSegment;
+use crate::{
+    elf::{FirmwareImage, RomSegment},
+    error::Error,
+    image_format::ImageFormat,
+};
+use std::iter::once;
+
+/// Image format for esp32 family chips using a 2nd stage bootloader
+pub struct Esp32DirectBootFormat<'a> {
+    segment: RomSegment<'a>,
+}
+
+impl<'a> Esp32DirectBootFormat<'a> {
+    pub fn new(image: &'a FirmwareImage) -> Result<Self, Error> {
+        let mut segment = image
+            .segments()
+            .map(|mut segment| {
+                // map address to the first 4MB
+                segment.addr %= 0x400000;
+                segment
+            })
+            .fold(CodeSegment::default(), |mut a, b| {
+                a += &b;
+                a
+            });
+        segment.pad_align(4);
+
+        Ok(Self {
+            segment: segment.into(),
+        })
+    }
+}
+
+impl<'a> ImageFormat<'a> for Esp32DirectBootFormat<'a> {
+    fn flash_segments<'b>(&'b self) -> Box<dyn Iterator<Item = RomSegment<'b>> + 'b>
+    where
+        'a: 'b,
+    {
+        Box::new(once(self.segment.borrow()))
+    }
+
+    fn ota_segments<'b>(&'b self) -> Box<dyn Iterator<Item = RomSegment<'b>> + 'b>
+    where
+        'a: 'b,
+    {
+        Box::new(once(self.segment.borrow()))
+    }
+}

--- a/espflash/src/image_format/mod.rs
+++ b/espflash/src/image_format/mod.rs
@@ -9,6 +9,7 @@ pub use esp32directboot::*;
 pub use esp8266::*;
 
 use crate::error::Error;
+use serde::Deserialize;
 use std::str::FromStr;
 use strum_macros::{AsStaticStr, Display, EnumVariantNames};
 
@@ -46,8 +47,11 @@ pub trait ImageFormat<'a> {
         'a: 'b;
 }
 
-#[derive(Debug, Copy, Clone, Eq, PartialEq, Display, AsStaticStr, EnumVariantNames)]
+#[derive(
+    Debug, Copy, Clone, Eq, PartialEq, Display, AsStaticStr, EnumVariantNames, Deserialize,
+)]
 #[strum(serialize_all = "kebab-case")]
+#[serde(rename_all = "kebab-case")]
 pub enum ImageFormatId {
     Bootloader,
     DirectBoot,

--- a/espflash/src/image_format/mod.rs
+++ b/espflash/src/image_format/mod.rs
@@ -1,9 +1,11 @@
 mod esp32bootloader;
+mod esp32directboot;
 mod esp8266;
 
 use crate::elf::RomSegment;
 use bytemuck::{Pod, Zeroable};
 pub use esp32bootloader::*;
+pub use esp32directboot::*;
 pub use esp8266::*;
 
 use strum_macros::{AsStaticStr, Display, EnumString};

--- a/espflash/src/image_format/mod.rs
+++ b/espflash/src/image_format/mod.rs
@@ -8,7 +8,9 @@ pub use esp32bootloader::*;
 pub use esp32directboot::*;
 pub use esp8266::*;
 
-use strum_macros::{AsStaticStr, Display, EnumString};
+use crate::error::Error;
+use std::str::FromStr;
+use strum_macros::{AsStaticStr, Display, EnumVariantNames};
 
 const ESP_MAGIC: u8 = 0xE9;
 const WP_PIN_DISABLED: u8 = 0xEE;
@@ -44,10 +46,21 @@ pub trait ImageFormat<'a> {
         'a: 'b;
 }
 
-#[derive(Debug, Copy, Clone, Eq, PartialEq, Display, EnumString, AsStaticStr)]
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Display, AsStaticStr, EnumVariantNames)]
+#[strum(serialize_all = "kebab-case")]
 pub enum ImageFormatId {
-    #[strum(serialize = "bootloader")]
     Bootloader,
-    #[strum(serialize = "direct-boot")]
     DirectBoot,
+}
+
+impl FromStr for ImageFormatId {
+    type Err = Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "bootloader" => Ok(Self::Bootloader),
+            "direct-boot" => Ok(Self::DirectBoot),
+            _ => Err(Error::UnknownImageFormat(s.into())),
+        }
+    }
 }

--- a/espflash/src/lib.rs
+++ b/espflash/src/lib.rs
@@ -14,4 +14,5 @@ pub use config::Config;
 pub use elf::FirmwareImage;
 pub use error::Error;
 pub use flasher::Flasher;
+pub use image_format::ImageFormatId;
 pub use partition_table::PartitionTable;

--- a/espflash/src/main.rs
+++ b/espflash/src/main.rs
@@ -90,11 +90,7 @@ fn main() -> Result<()> {
         let image_format = image_format_string
             .as_deref()
             .map(ImageFormatId::from_str)
-            .transpose()
-            .into_diagnostic()
-            .wrap_err_with(|| {
-                format!("Unrecognized image format {}", image_format_string.unwrap())
-            })?;
+            .transpose()?;
         let partition_table = partition_table_path
             .as_deref()
             .map(|path| {


### PR DESCRIPTION
Fixes #53

Tested with https://github.com/MabezDev/esp32c3-experiments

Todo:

- [x] validate that the elf is valid for direct boot
- [x] better error message for invalid `--format` options
- [x] allow setting image format in `Cargo.toml`