### PR TITLE
Serial port auto-detection

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,9 +10,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: musl-tools
+      - name: build dependencies
         run: |
-          sudo apt-get install musl-tools
+          sudo apt-get install musl-tools libudev-dev
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
         with:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -7,6 +7,9 @@ jobs:
     name: Check
     runs-on: ubuntu-latest
     steps:
+      - name: build dependencies
+        run: |
+          sudo apt-get install musl-tools libudev-dev
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
         with:
@@ -22,6 +25,9 @@ jobs:
     name: Doc Test
     runs-on: ubuntu-latest
     steps:
+      - name: build dependencies
+        run: |
+          sudo apt-get install musl-tools libudev-dev
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
         with:
@@ -38,6 +44,9 @@ jobs:
     name: Unit Test
     runs-on: ubuntu-latest
     steps:
+      - name: build dependencies
+        run: |
+          sudo apt-get install musl-tools libudev-dev
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
         with:
@@ -71,6 +80,9 @@ jobs:
     name: Clippy
     runs-on: ubuntu-latest
     steps:
+      - name: build dependencies
+        run: |
+          sudo apt-get install musl-tools libudev-dev
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
         with:

--- a/cargo-espflash/Cargo.toml
+++ b/cargo-espflash/Cargo.toml
@@ -25,14 +25,13 @@ categories = [
 ]
 
 [dependencies]
-miette = { version = "3", features = ["fancy"] }
 cargo_metadata = "0.14"
 cargo_toml = "0.10"
 clap = "3.0.0-beta.5"
-crossterm = "0.21"
+crossterm = "0.22"
 espflash = { version = "1", path = "../espflash" }
+miette = { version = "3", features = ["fancy"] }
 serde = { version = "1", features = ["derive"] }
-serial = "0.4"
 toml = "0.5"
 thiserror = "1"
 

--- a/espflash/Cargo.toml
+++ b/espflash/Cargo.toml
@@ -37,6 +37,7 @@ flate2 = "1"
 miette = { version = "3", features = ["fancy"] }
 crossterm = "0.22"
 directories-next = "2"
+dialoguer = "0.9"
 
 [package.metadata.binstall]
 pkg-url = "{ repo }/releases/download/v{ version }/{ name }"

--- a/espflash/Cargo.toml
+++ b/espflash/Cargo.toml
@@ -21,7 +21,7 @@ bytemuck = { version = "1", features = ["derive"] }
 indicatif = "0.16"
 md5 = "0.7"
 clap = "3.0.0-beta.5"
-serial = "0.4"
+serialport = { version = "4.0", default-features = false }
 sha2 = "0.9"
 slip-codec = "0.3"
 thiserror = "1"

--- a/espflash/Cargo.toml
+++ b/espflash/Cargo.toml
@@ -21,7 +21,7 @@ bytemuck = { version = "1", features = ["derive"] }
 indicatif = "0.16"
 md5 = "0.7"
 clap = "3.0.0-beta.5"
-serialport = { version = "4.0", default-features = false }
+serialport = "4"
 sha2 = "0.9"
 slip-codec = "0.3"
 thiserror = "1"

--- a/espflash/src/chip/mod.rs
+++ b/espflash/src/chip/mod.rs
@@ -41,8 +41,7 @@ pub trait ChipType: ReadEFuse {
     /// Determine the frequency of the crytal on the connected chip.
     fn crystal_freq(&self, connection: &mut Connection) -> Result<u32, Error> {
         let uart_div = connection.read_reg(Self::UART_CLKDIV_REG)? & Self::UART_CLKDIV_MASK;
-        let est_xtal =
-            (connection.get_baud().speed() as u32 * uart_div) / 1_000_000 / Self::XTAL_CLK_DIVIDER;
+        let est_xtal = (connection.get_baud()? * uart_div) / 1_000_000 / Self::XTAL_CLK_DIVIDER;
         let norm_xtal = if est_xtal > 33 { 40 } else { 26 };
 
         Ok(norm_xtal)

--- a/espflash/src/cli/clap.rs
+++ b/espflash/src/cli/clap.rs
@@ -6,7 +6,7 @@ pub struct ConnectArgs {
     pub serial: Option<String>,
     /// Baud rate at which to flash target device
     #[clap(long)]
-    pub speed: Option<usize>,
+    pub speed: Option<u32>,
 }
 
 #[derive(Parser)]

--- a/espflash/src/cli/config.rs
+++ b/espflash/src/cli/config.rs
@@ -1,11 +1,14 @@
+use std::fs::read;
+
 use directories_next::ProjectDirs;
 use serde::Deserialize;
-use std::fs::read;
 
 #[derive(Debug, Deserialize, Default)]
 pub struct Config {
     #[serde(default)]
     pub connection: Connection,
+    #[serde(default)]
+    pub usb_device: UsbDevice,
 }
 
 #[derive(Debug, Deserialize, Default)]
@@ -13,11 +16,18 @@ pub struct Connection {
     pub serial: Option<String>,
 }
 
+#[derive(Debug, Deserialize, Default)]
+pub struct UsbDevice {
+    pub vid: Option<u16>,
+    pub pid: Option<u16>,
+}
+
 impl Config {
     /// Load the config from config file
     pub fn load() -> Self {
         let dirs = ProjectDirs::from("rs", "esp", "espflash").unwrap();
         let file = dirs.config_dir().join("espflash.toml");
+
         if let Ok(data) = read(&file) {
             toml::from_slice(&data).unwrap()
         } else {

--- a/espflash/src/cli/config.rs
+++ b/espflash/src/cli/config.rs
@@ -2,13 +2,14 @@ use std::fs::read;
 
 use directories_next::ProjectDirs;
 use serde::Deserialize;
+use serialport::UsbPortInfo;
 
 #[derive(Debug, Deserialize, Default)]
 pub struct Config {
     #[serde(default)]
     pub connection: Connection,
     #[serde(default)]
-    pub usb_device: UsbDevice,
+    pub usb_device: Vec<UsbDevice>,
 }
 
 #[derive(Debug, Deserialize, Default)]
@@ -18,8 +19,14 @@ pub struct Connection {
 
 #[derive(Debug, Deserialize, Default)]
 pub struct UsbDevice {
-    pub vid: Option<u16>,
-    pub pid: Option<u16>,
+    pub vid: u16,
+    pub pid: u16,
+}
+
+impl UsbDevice {
+    pub fn matches(&self, port: &UsbPortInfo) -> bool {
+        self.vid == port.vid && self.pid == port.pid
+    }
 }
 
 impl Config {

--- a/espflash/src/cli/mod.rs
+++ b/espflash/src/cli/mod.rs
@@ -9,26 +9,71 @@ use self::clap::ConnectArgs;
 use crate::error::Error;
 use crate::Flasher;
 use config::Config;
-use miette::{Result, WrapErr};
-use serialport::FlowControl;
+use dialoguer::{theme::ColorfulTheme, Select};
+use miette::{IntoDiagnostic, Result, WrapErr};
+use serialport::{available_ports, FlowControl, SerialPortType};
 
-pub fn get_serial_port(matches: &ConnectArgs, config: &Config) -> Option<String> {
-    // The serial port must be specified, either as a command-line argument or in
+fn get_serial_port(matches: &ConnectArgs, config: &Config) -> Result<String, Error> {
+    // The serial port should be specified, either as a command-line argument or in
     // the cargo configuration file. In the case that both have been provided the
     // command-line argument will take precedence.
+    //
+    // If neither have been provided:
+    //   a) if there is only one serial port detected, it will be used
+    //   b) if there is more than one serial port detected, the user will be
+    //      prompted to select one or exit
     if let Some(serial) = &matches.serial {
-        Some(serial.to_string())
+        Ok(serial.into())
+    } else if let Some(serial) = &config.connection.serial {
+        Ok(serial.into())
+    } else if let Ok(ports) = detect_serial_ports() {
+        let maybe_serial = if ports.len() > 1 {
+            println!(
+                "{} serial ports detected, please select one or press Ctrl+c to exit\n",
+                ports.len()
+            );
+            let index = Select::with_theme(&ColorfulTheme::default())
+                .items(&ports)
+                .default(0)
+                .interact()
+                .unwrap();
+
+            ports.get(index)
+        } else {
+            ports.get(0)
+        };
+
+        match maybe_serial {
+            Some(serial) => Ok(serial.into()),
+            None => Err(Error::NoSerial),
+        }
     } else {
-        config
-            .connection
-            .serial
-            .as_ref()
-            .map(|serial| serial.into())
+        Err(Error::NoSerial)
     }
 }
 
+fn detect_serial_ports() -> Result<Vec<String>> {
+    // Find all available serial ports on the host and filter them down to only
+    // those which are likely candidates for ESP devices. At this time we are only
+    // interested in USB devices and no further filtering is being done, however
+    // this may change.
+    let ports = available_ports().into_diagnostic()?;
+    let ports = ports
+        .iter()
+        .filter(|&port| matches!(&port.port_type, SerialPortType::UsbPort(..)));
+
+    // Now that we have a vector of candidate serial ports, the only information we
+    // need from them are the ports' names.
+    let port_names = ports
+        .cloned()
+        .map(|port| port.port_name)
+        .collect::<Vec<_>>();
+
+    Ok(port_names)
+}
+
 pub fn connect(matches: &ConnectArgs, config: &Config) -> Result<Flasher> {
-    let port = get_serial_port(matches, config).ok_or(Error::NoSerial)?;
+    let port = get_serial_port(matches, config)?;
 
     // Attempt to open the serial port and set its initial baud rate.
     println!("Serial port: {}", port);

--- a/espflash/src/cli/mod.rs
+++ b/espflash/src/cli/mod.rs
@@ -81,7 +81,8 @@ fn select_serial_port(ports: Vec<SerialPortInfo>, devices: &[UsbDevice]) -> Resu
         let index = Select::with_theme(&ColorfulTheme::default())
             .items(&port_names)
             .default(0)
-            .interact()?;
+            .interact_opt()?
+            .ok_or(Error::Canceled)?;
 
         match ports.get(index) {
             Some(port_info) => Ok(port_info.port_name.to_owned()),
@@ -98,7 +99,8 @@ fn select_serial_port(ports: Vec<SerialPortInfo>, devices: &[UsbDevice]) -> Resu
         if device_matches(port_info)
             || Confirm::with_theme(&ColorfulTheme::default())
                 .with_prompt(format!("Use serial port '{}'?", port_name))
-                .interact()?
+                .interact_opt()?
+                .ok_or(Error::Canceled)?
         {
             Ok(port_name)
         } else {

--- a/espflash/src/cli/mod.rs
+++ b/espflash/src/cli/mod.rs
@@ -64,10 +64,15 @@ fn select_serial_port(ports: Vec<SerialPortInfo>, devices: &[UsbDevice]) -> Resu
             .iter()
             .map(|port_info| match &port_info.port_type {
                 SerialPortType::UsbPort(info) => {
-                    if device_matches(info) {
-                        format!("{}", port_info.port_name.as_str().bold())
+                    let formatted = if device_matches(info) {
+                        port_info.port_name.as_str().bold()
                     } else {
-                        port_info.port_name.clone()
+                        port_info.port_name.as_str().reset()
+                    };
+                    if let Some(product) = &info.product {
+                        format!("{} - {}", formatted, product)
+                    } else {
+                        format!("{}", formatted)
                     }
                 }
                 _ => port_info.port_name.clone(),

--- a/espflash/src/cli/mod.rs
+++ b/espflash/src/cli/mod.rs
@@ -98,7 +98,13 @@ fn select_serial_port(ports: Vec<SerialPortInfo>, devices: &[UsbDevice]) -> Resu
 
         if device_matches(port_info)
             || Confirm::with_theme(&ColorfulTheme::default())
-                .with_prompt(format!("Use serial port '{}'?", port_name))
+                .with_prompt({
+                    if let Some(product) = &port_info.product {
+                        format!("Use serial port '{}' - {}?", port_name, product)
+                    } else {
+                        format!("Use serial port '{}'?", port_name)
+                    }
+                })
                 .interact_opt()?
                 .ok_or(Error::Canceled)?
         {

--- a/espflash/src/error.rs
+++ b/espflash/src/error.rs
@@ -82,7 +82,7 @@ https://github.com/espressif/esp32c3-direct-boot-example"
 pub enum ConnectionError {
     #[error("IO error while using serial port: {0}")]
     #[diagnostic(code(espflash::serial_error))]
-    Serial(#[source] serial::core::Error),
+    Serial(#[source] serialport::Error),
     #[error("Failed to connect to the device")]
     #[diagnostic(
         code(espflash::connection_failed),
@@ -132,18 +132,18 @@ impl Display for TimedOutCommand {
     }
 }
 
-impl From<serial::Error> for ConnectionError {
-    fn from(err: serial::Error) -> Self {
+impl From<serialport::Error> for ConnectionError {
+    fn from(err: serialport::Error) -> Self {
         match err.kind() {
-            serial::ErrorKind::Io(kind) => from_error_kind(kind, err),
-            serial::ErrorKind::NoDevice => ConnectionError::DeviceNotFound,
+            serialport::ErrorKind::Io(kind) => from_error_kind(kind, err),
+            serialport::ErrorKind::NoDevice => ConnectionError::DeviceNotFound,
             _ => ConnectionError::Serial(err),
         }
     }
 }
 
-impl From<serial::Error> for Error {
-    fn from(err: serial::Error) -> Self {
+impl From<serialport::Error> for Error {
+    fn from(err: serialport::Error) -> Self {
         Self::Connection(err.into())
     }
 }
@@ -160,7 +160,7 @@ impl From<io::Error> for Error {
     }
 }
 
-fn from_error_kind<E: Into<serial::Error>>(kind: io::ErrorKind, err: E) -> ConnectionError {
+fn from_error_kind<E: Into<serialport::Error>>(kind: io::ErrorKind, err: E) -> ConnectionError {
     match kind {
         io::ErrorKind::TimedOut => ConnectionError::Timeout(TimedOutCommand::default()),
         io::ErrorKind::NotFound => ConnectionError::DeviceNotFound,

--- a/espflash/src/error.rs
+++ b/espflash/src/error.rs
@@ -75,6 +75,8 @@ https://github.com/espressif/esp32c3-direct-boot-example"
         help("Add a command line option with the serial port to use")
     )]
     NoSerial,
+    #[error("Canceled by user")]
+    Canceled,
 }
 
 #[derive(Error, Debug, Diagnostic)]


### PR DESCRIPTION
Will eventually close #52.

Tested various chips and functionality on macOS, and minimal testing on Windows 10.

* The `serial` crate was swapped out with `serialport`
    * `serial` has not received an update in ~4 years, `serialport` is somewhat maintained
    * `serialport` was almost a drop-in replacement, and gives us the `available_ports` function as well
* Implements fairly basic port detection for `cargo espflash` and `espflash`
    * If no port has been specified by CLI or config, attempts auto-detection
    * If only one port is detected, it is selected automatically
    * If multiple ports are detected, the user is prompted to select one

Presently I am only filtering serial ports by type, allowing USB ports only. Questions regarding this:
1) Is there any reason to support other port types (other options are `BluetoothPort` or `PciPort`)?
2) If we decide to move forward with VID/PID filtering, what should we begin with? Should we omit unrecognized ports entirely or just mark them as such?

~~I will likely move the port detection logic into the `espflash` crate, especially if there is any substantial filtering logic, but have just included it for `cargo-espflash` until we flesh things out.~~

cc @igrr @icewind1991 