### PR TITLE
Improve info about image format in help of cargo-espflash

### DIFF
--- a/cargo-espflash/src/main.rs
+++ b/cargo-espflash/src/main.rs
@@ -47,7 +47,7 @@ fn main() -> Result<()> {
             .long("format")
             .takes_value(true)
             .value_name("image format")
-            .help("Image format to flash"),
+            .help("Image format to flash (bootloader/direct-boot)"),
     ];
     let connect_args = [Arg::with_name("serial")
         .takes_value(true)


### PR DESCRIPTION
Tiny improvement - `cargo espflash` lacked list of supported image formats, so here it is