### PR TITLE
Allow for the build target to be specified via the command line as well

### DIFF
--- a/cargo-espflash/src/main.rs
+++ b/cargo-espflash/src/main.rs
@@ -156,9 +156,12 @@ fn build(
     cargo_config: &CargoConfig,
     chip: Option<Chip>,
 ) -> Result<PathBuf> {
-    let target = cargo_config
-        .target()
+    let target = build_options
+        .target
+        .as_deref()
+        .or(cargo_config.target())
         .ok_or_else(|| NoTargetError::new(chip))?;
+
     if let Some(chip) = chip {
         if !chip.supports_target(target) {
             return Err(Error::UnsupportedTarget(UnsupportedTargetError::new(target, chip)).into());

--- a/espflash/src/cli/clap.rs
+++ b/espflash/src/cli/clap.rs
@@ -23,6 +23,9 @@ pub struct BuildArgs {
     /// Image format to flash (bootloader/direct-boot)
     #[clap(long)]
     pub format: Option<String>,
+    /// Target to build for
+    #[clap(long)]
+    pub target: Option<String>,
 }
 
 #[derive(Parser)]


### PR DESCRIPTION
See title. Command-line argument takes priority over cargo config.

cc @georgik