### PR TITLE
Explicitly set build target to use --target value if provided

### DIFF
--- a/cargo-espflash/src/main.rs
+++ b/cargo-espflash/src/main.rs
@@ -267,13 +267,10 @@ fn save_image(
         .build_args
         .target
         .as_deref()
-        .or_else(|| cargo_config.target());
+        .or_else(|| cargo_config.target())
+        .ok_or_else(|| NoTargetError::new(None))
+        .into_diagnostic()?;
 
-    if target.is_none() {
-        return Err(NoTargetError::new(None)).into_diagnostic();
-    }
-
-    let target = target.unwrap();
     let chip = Chip::from_target(target).ok_or_else(|| Error::UnknownTarget(target.into()))?;
 
     let path = build(&matches.build_args, &cargo_config, Some(chip))?;

--- a/espflash/src/chip/esp32/esp32.rs
+++ b/espflash/src/chip/esp32/esp32.rs
@@ -142,10 +142,6 @@ impl ChipType for Esp32 {
 
         Ok(bytes_to_mac_addr(bytes))
     }
-
-    fn supports_target(target: &str) -> bool {
-        target.starts_with("xtensa-esp32-")
-    }
 }
 
 impl ReadEFuse for Esp32 {

--- a/espflash/src/chip/esp32/esp32c3.rs
+++ b/espflash/src/chip/esp32/esp32c3.rs
@@ -89,10 +89,6 @@ impl ChipType for Esp32c3 {
             ),
         }
     }
-
-    fn supports_target(target: &str) -> bool {
-        target.starts_with("riscv32imc-")
-    }
 }
 
 impl ReadEFuse for Esp32c3 {

--- a/espflash/src/chip/esp32/esp32s2.rs
+++ b/espflash/src/chip/esp32/esp32s2.rs
@@ -108,10 +108,6 @@ impl ChipType for Esp32s2 {
             _ => Err(UnsupportedImageFormatError::new(image_format, Chip::Esp32s2, None).into()),
         }
     }
-
-    fn supports_target(target: &str) -> bool {
-        target.starts_with("xtensa-esp32s2-")
-    }
 }
 
 impl ReadEFuse for Esp32s2 {

--- a/espflash/src/chip/esp32/esp32s3.rs
+++ b/espflash/src/chip/esp32/esp32s3.rs
@@ -82,10 +82,6 @@ impl ChipType for Esp32s3 {
             ImageFormatId::DirectBoot => Ok(Box::new(Esp32DirectBootFormat::new(image)?)),
         }
     }
-
-    fn supports_target(target: &str) -> bool {
-        target.starts_with("xtensa-esp32s3-")
-    }
 }
 
 impl ReadEFuse for Esp32s3 {

--- a/espflash/src/chip/esp8266.rs
+++ b/espflash/src/chip/esp8266.rs
@@ -80,10 +80,6 @@ impl ChipType for Esp8266 {
 
         Ok(bytes_to_mac_addr(&bytes))
     }
-
-    fn supports_target(target: &str) -> bool {
-        target.starts_with("xtensa-esp8266-")
-    }
 }
 
 impl ReadEFuse for Esp8266 {

--- a/espflash/src/chip/mod.rs
+++ b/espflash/src/chip/mod.rs
@@ -69,7 +69,9 @@ pub trait ChipType: ReadEFuse {
         Ok(bytes_to_mac_addr(bytes))
     }
 
-    fn supports_target(target: &str) -> bool;
+    fn supports_target(target: &str) -> bool {
+        Self::SUPPORTED_TARGETS.contains(&target)
+    }
 }
 
 pub trait ReadEFuse {


### PR DESCRIPTION
I made a pretty silly mistake in #88 in that I wasn't actually providing the target to cargo. This should fix that.

I also made the `supports_target` function more strict and changed it to use a default implementation. Using the `starts_with` method it is still possible to pass an invalid target value.