### PR TITLE
Retry failed connection attempts

### DIFF
--- a/espflash/src/connection.rs
+++ b/espflash/src/connection.rs
@@ -56,7 +56,7 @@ impl Connection {
         Ok(())
     }
 
-    pub fn reset_to_flash(&mut self) -> Result<(), Error> {
+    pub fn reset_to_flash(&mut self, extra_delay: bool) -> Result<(), Error> {
         self.serial.write_data_terminal_ready(false)?;
         self.serial.write_request_to_send(true)?;
 
@@ -65,7 +65,8 @@ impl Connection {
         self.serial.write_data_terminal_ready(true)?;
         self.serial.write_request_to_send(false)?;
 
-        sleep(Duration::from_millis(50));
+        let millis = if extra_delay { 500 } else { 50 };
+        sleep(Duration::from_millis(millis));
 
         self.serial.write_data_terminal_ready(false)?;
 


### PR DESCRIPTION
~~This is built on top of #75, so I will convert it from a draft once that gets merged.~~

I believe this should resolve #18 and #90.

This PR emulates the connection logic performed by `esptool.py` and should help with connection issues on older devices. Essentially this adds two things:

1) Retry the connection until we connect to the device, or reach the attempt limit
2) Alternate between the default delay and a longer delay, which helps with older devices (eg. ESP32 rev 0)