### PR TITLE
Add `--package` option

### DIFF
--- a/cargo-espflash/README.md
+++ b/cargo-espflash/README.md
@@ -46,6 +46,9 @@ OPTIONS:
         --monitor
             Open a serial monitor after flashing
 
+        --package <PACKAGE>
+            Specify a (binary) package within a workspace to be built
+
         --partition-table <PARTITION_TABLE>
             Path to a CSV file containing partition table
 

--- a/cargo-espflash/src/error.rs
+++ b/cargo-espflash/src/error.rs
@@ -10,7 +10,8 @@ pub enum Error {
     #[error("No executable artifact found")]
     #[diagnostic(
         code(cargo_espflash::no_artifact),
-        help("If you're trying to run an example you need to specify it using the `--example` argument")
+        help("If you're trying to run an example you need to specify it using the `--example` argument\n\
+              or if you're in a cargo workspace, specify the binary package with `--package`.")
     )]
     NoArtifact,
     #[error("'build-std' not configured")]

--- a/cargo-espflash/src/main.rs
+++ b/cargo-espflash/src/main.rs
@@ -198,6 +198,11 @@ fn build(
         args.push(example);
     }
 
+    if let Some(package) = build_options.package.as_deref() {
+        args.push("--package");
+        args.push(package);
+    }
+
     if let Some(features) = build_options.features.as_deref() {
         args.push("--features");
         args.extend(features.iter().map(|f| f.as_str()));

--- a/espflash/src/cli/clap.rs
+++ b/espflash/src/cli/clap.rs
@@ -17,6 +17,9 @@ pub struct BuildArgs {
     /// Example to build and flash
     #[clap(long)]
     pub example: Option<String>,
+    /// Specify a (binary) package within a workspace to be built
+    #[clap(long)]
+    pub package: Option<String>,
     /// Comma delimited list of build features
     #[clap(long, use_delimiter(true))]
     pub features: Option<Vec<String>>,


### PR DESCRIPTION
Examples in a project (or just the project in general) might be organized as packages within a cargo workspace.

To make `cargo espflash` handle those scenarios, the `--package` option has to be supported and forwarded to the build step. If a binary crate was selected with the `--package` option, the build step will return the path to the generated binary in the shared `target` folder just like in the other scenarios. 

If a library crate was selected with `--package`, an error `cargo_espflash::no_artifact` will be issued. The help text for that error has been updated as part of the PR.

I've also updated the READMEs by just adding the option to the command help section, but since these sections are not in line with the code right now (see #94), I propose to rebase and properly document this PR once #94 has been merged. Therefore I've marked it as WIP.