### PR TITLE
Use buffered writer

### DIFF
--- a/espflash/src/connection.rs
+++ b/espflash/src/connection.rs
@@ -1,4 +1,8 @@
-use std::{io::Write, thread::sleep, time::Duration};
+use std::{
+    io::{BufWriter, Write},
+    thread::sleep,
+    time::Duration,
+};
 
 use binread::{io::Cursor, BinRead, BinReaderExt};
 use bytemuck::{Pod, Zeroable};
@@ -113,7 +117,8 @@ impl Connection {
     }
 
     pub fn write_command(&mut self, command: Command) -> Result<(), Error> {
-        let mut encoder = SlipEncoder::new(&mut self.serial)?;
+        let mut writer = BufWriter::new(&mut self.serial);
+        let mut encoder = SlipEncoder::new(&mut writer)?;
         command.write(&mut encoder)?;
         encoder.finish()?;
         Ok(())


### PR DESCRIPTION
Speed up flashing by infinite %!

Resolves #113 

Flashing binary before:
```
WARN setting baud rate higher than 115200 can cause issues.
[00:00:07] ########################################      16/16      segment 0x1000
[00:00:00] ########################################       1/1       segment 0x8000
[00:06:01] ########################################     742/742     segment 0x30000
```

Flashing binary after:
```
WARN setting baud rate higher than 115200 can cause issues.
[00:00:00] ########################################      16/16      segment 0x1000
[00:00:00] ########################################       1/1       segment 0x8000
[00:00:25] ########################################     742/742     segment 0x30000
```