### PR TITLE
Buffer reads

### DIFF
--- a/espflash/src/connection.rs
+++ b/espflash/src/connection.rs
@@ -109,7 +109,7 @@ impl Connection {
 
     pub fn read_response(&mut self) -> Result<Option<CommandResponse>, Error> {
         match self.read(10)? {
-            None => return Ok(None),
+            None => Ok(None),
             Some(response) => {
                 let mut cursor = Cursor::new(response);
                 let header = cursor.read_le()?;


### PR DESCRIPTION
Normally I would like to avoid moving data from a `Vec` to a `VecDeque` and back again but at this point of time, we are only reading 10 bytes at a time and I wanted this PR to be small.

Hopefully this resolves #116