### PR TITLE
Fix image creation for direct boot

### DIFF
--- a/espflash/src/image_format/esp32directboot.rs
+++ b/espflash/src/image_format/esp32directboot.rs
@@ -14,7 +14,7 @@ pub struct Esp32DirectBootFormat<'a> {
 impl<'a> Esp32DirectBootFormat<'a> {
     pub fn new(image: &'a FirmwareImage) -> Result<Self, Error> {
         let mut segment = image
-            .segments()
+            .segments_with_load_addresses()
             .map(|mut segment| {
                 // map address to the first 4MB
                 segment.addr %= 0x400000;


### PR DESCRIPTION
This goes together with: https://github.com/MabezDev/esp32c3-experiments/pull/5

~~It just doesn't produce gaps between the segments.~~

Edit:
Turned out the code used the VMA addresses of the sections but it's needed to use the LMA

Some additional logging statements revealed this:
```
CodeSegment addr=42000000 len=8, new addr = 0
CodeSegment addr=42000008 len=b378, new addr = 8
CodeSegment addr=3c00b380 len=32d8, new addr = b380
CodeSegment addr=3fc80000 len=c, new addr = 80000
length = 524300
```

So, it added 478336 zero bytes before the _.data_ section

Now it looks like this
```
CodeSegment addr=0 len=8, new addr = 0
CodeSegment addr=8 len=b378, new addr = 8
CodeSegment addr=b380 len=32d8, new addr = b380
CodeSegment addr=e660 len=c, new addr = e660
length = 58988
```

Also, the final image looks like this when using _probe-rs_ for flashing.
