### PR TITLE
Restore CI to working order

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -7,6 +7,10 @@ jobs:
     name: Check
     runs-on: ubuntu-latest
     steps:
+      - name: Change apt mirror
+        run: |
+          sudo sed -i 's/azure.archive.ubuntu.com/archive.ubuntu.com/' /etc/apt/sources.list
+          sudo apt-get update
       - name: build dependencies
         run: |
           sudo apt-get install musl-tools libudev-dev
@@ -25,6 +29,10 @@ jobs:
     name: Doc Test
     runs-on: ubuntu-latest
     steps:
+      - name: Change apt mirror
+        run: |
+          sudo sed -i 's/azure.archive.ubuntu.com/archive.ubuntu.com/' /etc/apt/sources.list
+          sudo apt-get update
       - name: build dependencies
         run: |
           sudo apt-get install musl-tools libudev-dev
@@ -44,6 +52,10 @@ jobs:
     name: Unit Test
     runs-on: ubuntu-latest
     steps:
+      - name: Change apt mirror
+        run: |
+          sudo sed -i 's/azure.archive.ubuntu.com/archive.ubuntu.com/' /etc/apt/sources.list
+          sudo apt-get update
       - name: build dependencies
         run: |
           sudo apt-get install musl-tools libudev-dev
@@ -63,6 +75,10 @@ jobs:
     name: Rustfmt
     runs-on: ubuntu-latest
     steps:
+      - name: Change apt mirror
+        run: |
+          sudo sed -i 's/azure.archive.ubuntu.com/archive.ubuntu.com/' /etc/apt/sources.list
+          sudo apt-get update
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
         with:
@@ -80,6 +96,10 @@ jobs:
     name: Clippy
     runs-on: ubuntu-latest
     steps:
+      - name: Change apt mirror
+        run: |
+          sudo sed -i 's/azure.archive.ubuntu.com/archive.ubuntu.com/' /etc/apt/sources.list
+          sudo apt-get update
       - name: build dependencies
         run: |
           sudo apt-get install musl-tools libudev-dev
@@ -148,10 +168,15 @@ jobs:
         with:
           name: cargo-espflash.exe
           path: target/x86_64-pc-windows-gnu/release/cargo-espflash.exe
+
   msrv:
     name: Check MSRV
     runs-on: ubuntu-latest
     steps:
+      - name: Change apt mirror
+        run: |
+          sudo sed -i 's/azure.archive.ubuntu.com/archive.ubuntu.com/' /etc/apt/sources.list
+          sudo apt-get update
       - name: build dependencies
         run: |
           sudo apt-get install musl-tools libudev-dev

--- a/espflash/src/cli/serial.rs
+++ b/espflash/src/cli/serial.rs
@@ -172,9 +172,7 @@ fn select_serial_port(
 
         match ports.get(index) {
             Some(
-                port_info
-                @
-                SerialPortInfo {
+                port_info @ SerialPortInfo {
                     port_type: SerialPortType::UsbPort(usb_info),
                     ..
                 },


### PR DESCRIPTION
Closes #120.

For whatever reason, we are no longer able to download the `libuv-dev` deb archive from Azure's mirror, so I've just changed the workflow to use the official Ubuntu archives instead. A little hacky and ugly, but it gets the job done.