### PR TITLE
Update `clap` to stable version, reset baud when starting serial monitor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -205,9 +205,9 @@ dependencies = [
 
 [[package]]
 name = "cargo_toml"
-version = "0.10.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67110a7844b75a4dda12f4dca5a731c961750d6c8fa3cb6a41ab67411be05d3a"
+checksum = "31f61f8437a6b96dfb0be4aad6b222e01d5681b1ceacac7251501389e169e219"
 dependencies = [
  "serde",
  "serde_derive",
@@ -234,9 +234,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
-version = "3.0.0-rc.7"
+version = "3.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9468f8012246b0836c6fd11725102b0844254985f2462b6c637d50040ef49df0"
+checksum = "2afefa54b5c7dd40918dc1e09f213a171ab5937aadccab45e804780b238f9f43"
 dependencies = [
  "atty",
  "bitflags",
@@ -251,11 +251,11 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "3.0.0-rc.7"
+version = "3.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b72e1af32a4de4d21a43d26de33fe69c00e895371bd8b1523d674f011b610467"
+checksum = "0fd2078197a22f338bd4fbf7d6387eb6f0d6a3c69e6cbc09f5c93e97321fd92a"
 dependencies = [
- "heck",
+ "heck 0.4.0",
  "proc-macro-error",
  "proc-macro2",
  "quote",
@@ -489,6 +489,12 @@ checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
 dependencies = [
  "unicode-segmentation",
 ]
+
+[[package]]
+name = "heck"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2540771e65fc8cb83cd6e8a237f70c319bd5c29f78ed1084ba5d50eeac86f7f9"
 
 [[package]]
 name = "hermit-abi"
@@ -965,9 +971,9 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.132"
+version = "1.0.136"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b9875c23cf305cd1fd7eb77234cbb705f21ea6a72c637a5c6db5fe4b8e7f008"
+checksum = "ce31e24b01e1e524df96f1c2fdd054405f8d7376249a5110886fb4b658484789"
 dependencies = [
  "serde_derive",
 ]
@@ -985,9 +991,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.132"
+version = "1.0.136"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecc0db5cb2556c0e558887d9bbdcf6ac4471e83ff66cf696e5419024d1606276"
+checksum = "08597e7152fcd306f41838ed3e37be9eaeed2b61c42e2117266a554fab4662f9"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1117,7 +1123,7 @@ version = "0.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5bb0dc7ee9c15cea6199cde9a127fa16a4c5819af85395457ad72d68edc85a38"
 dependencies = [
- "heck",
+ "heck 0.3.3",
  "proc-macro2",
  "quote",
  "rustversion",

--- a/cargo-espflash/Cargo.toml
+++ b/cargo-espflash/Cargo.toml
@@ -26,14 +26,14 @@ categories = [
 
 [dependencies]
 cargo_metadata = "0.14"
-cargo_toml = "0.10"
-clap = { version = "3.0.0-rc.1", features = ["derive"] }
+cargo_toml = "0.11"
+clap = { version = "3.0", features = ["derive"] }
 crossterm = "0.22"
 espflash = { version = "1", path = "../espflash" }
 miette = { version = "3", features = ["fancy"] }
 serde = { version = "1", features = ["derive"] }
+thiserror = "1.0"
 toml = "0.5"
-thiserror = "1"
 
 [package.metadata.binstall]
 pkg-url = "{ repo }/releases/download/v{ version }/{ name }"

--- a/espflash/Cargo.toml
+++ b/espflash/Cargo.toml
@@ -20,7 +20,7 @@ binread = "2"
 bytemuck = { version = "1", features = ["derive"] }
 indicatif = "0.16"
 md5 = "0.7"
-clap = { version = "3.0.0-rc.1", features = ["derive"] }
+clap = { version = "3.0", features = ["derive"] }
 serialport = "4"
 sha2 = "0.10"
 slip-codec = "0.3"

--- a/espflash/src/cli/monitor.rs
+++ b/espflash/src/cli/monitor.rs
@@ -84,6 +84,7 @@ pub fn monitor(mut serial: Box<dyn SerialPort>) -> serialport::Result<()> {
     println!();
 
     let mut buff = [0; 128];
+    serial.set_baud_rate(115_200)?;
     serial.set_timeout(Duration::from_millis(5))?;
 
     let _raw_mode = RawModeGuard::new();


### PR DESCRIPTION
- Move off of the `clap` release candidate to the stable release
- Reset the serial port's baud to 115,200 prior to starting the serial monitor, allowing the use of `--speed` and `--monitor` together