### PR TITLE
Allow passing unstable options to Cargo

### DIFF
--- a/cargo-espflash/src/main.rs
+++ b/cargo-espflash/src/main.rs
@@ -211,6 +211,13 @@ fn build(
         args.extend(features.iter().map(|f| f.as_str()));
     }
 
+    if let Some(unstable) = build_options.unstable.as_deref() {
+        for item in unstable.iter() {
+            args.push("-Z");
+            args.push(item);
+        }
+    }
+
     // Invoke the 'cargo build' command, passing our list of arguments.
     let output = Command::new("cargo")
         .arg("build")

--- a/espflash/src/cli/clap.rs
+++ b/espflash/src/cli/clap.rs
@@ -29,6 +29,9 @@ pub struct BuildArgs {
     /// Target to build for
     #[clap(long)]
     pub target: Option<String>,
+    /// Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for details
+    #[clap(short = 'Z')]
+    pub unstable: Option<Vec<String>>,
 }
 
 #[derive(Parser)]


### PR DESCRIPTION
* I'm working on an [example for `esp-idf-hal`](https://github.com/sirhcel/esp-idf-hal/blob/318233cb54d72bf3457e2e6eb89f52586d7a4747/examples/ledc-simple.rs) whose builds require to set [some unstable options](https://github.com/esp-rs/esp-idf-hal/blob/fb7d886522bdcb757cc6481dbf55b0b8edc228cf/.github/workflows/ci.yml#L32)
* I did not manage to pass these options as `rustflags` via `.cargo/config.toml` as adding them there made `rustc` fail
    ```
    esp-idf-hal % export ESP_IDF_SDKCONFIG_DEFAULTS=$(pwd)/.github/configs/sdkconfig.defaults; cargo build --target riscv32imc-esp-espidf
    error: failed to run `rustc` to learn about target-specific information

    Caused by:
      process didn't exit successfully: `rustc - --crate-name ___ --print=file-names -C default-linker-libraries -Zbuild-std=std,panic_abort -Zbuild-std-features=panic_immediate_abort --target riscv32imc-esp-espidf --crate-type bin --crate-type rlib --crate-type dylib --crate-type cdylib --crate-type staticlib --crate-type proc-macro --print=sysroot --print=cfg` (exit status: 1)
      --- stderr
      error: unknown debugging option: `build-std`
    ```
* This PR adds support for `-Z` to `cargo-espflash` and passes these options to Cargo for building the project
* They can be used as shown in the following example for `esp-idf-hal`
    ```
    esp-idf-hal $ export ESP_IDF_SDKCONFIG_DEFAULTS=$(pwd)/.github/configs/sdkconfig.defaults; cargo espflash --example ledc-simple --target riscv32imc-esp-espidf -Zbuild-std=std,panic_abort -Zbuild-std-features=panic_immediate_abort /dev/ttyUSB0
    ```