### PR TITLE
Support the riscv32imac target, which can be used via atomic emulation

### DIFF
--- a/espflash/src/chip/esp32/esp32c3.rs
+++ b/espflash/src/chip/esp32/esp32c3.rs
@@ -54,8 +54,11 @@ impl ChipType for Esp32c3 {
     const SUPPORTED_IMAGE_FORMATS: &'static [ImageFormatId] =
         &[ImageFormatId::Bootloader, ImageFormatId::DirectBoot];
 
-    const SUPPORTED_TARGETS: &'static [&'static str] =
-        &["riscv32imc-unknown-none-elf", "riscv32imc-esp-espidf"];
+    const SUPPORTED_TARGETS: &'static [&'static str] = &[
+        "riscv32imac-unknown-none-elf",
+        "riscv32imc-esp-espidf",
+        "riscv32imc-unknown-none-elf",
+    ];
 
     fn chip_features(&self, _connection: &mut Connection) -> Result<Vec<&str>, Error> {
         Ok(vec!["WiFi"])


### PR DESCRIPTION
We're able to perform atomic emulation for the C3:  
https://github.com/esp-rs/riscv-atomic-emulation-trap

However trying to use the `riscv32imac-unknown-none-elf` target results in an error saying it's unsupported.