### PR TITLE
Fix a logical error preventing the board-info subcommand from being invoked

### DIFF
--- a/espflash/src/main.rs
+++ b/espflash/src/main.rs
@@ -53,19 +53,21 @@ fn main() -> Result<()> {
     let mut opts = Opts::parse();
     let config = Config::load()?;
 
-    // If neither the IMAGE nor SERIAL arguments have been provided, print the help
-    // message and exit.
-    if opts.image.is_none() && opts.connect_opts.serial.is_none() {
-        Opts::command().print_help().ok();
-        return Ok(());
-    }
+    if !matches!(opts.subcommand, Some(SubCommand::BoardInfo(..))) {
+        // If neither the IMAGE nor SERIAL arguments have been provided, print the
+        // help message and exit.
+        if opts.image.is_none() && opts.connect_opts.serial.is_none() {
+            Opts::command().print_help().ok();
+            return Ok(());
+        }
 
-    // If only a single argument is passed, it *should* always be the ELF file.
-    // In the case that the serial port was not provided as a command-line argument,
-    // we will either load the value specified in the configuration file or do port
-    // auto-detection instead.
-    if opts.image.is_none() && opts.connect_opts.serial.is_some() {
-        swap(&mut opts.image, &mut opts.connect_opts.serial);
+        // If only a single argument is passed, it *should* always be the ELF file. In
+        // the case that the serial port was not provided as a command-line argument, we
+        // will either load the value specified in the configuration file or do port
+        // auto-detection instead.
+        if opts.image.is_none() && opts.connect_opts.serial.is_some() {
+            swap(&mut opts.image, &mut opts.connect_opts.serial);
+        }
     }
 
     if let Some(subcommand) = opts.subcommand {


### PR DESCRIPTION
I messed this up in a previous refactor, my bad. Should work now but please confirm.