### PR TITLE
Customize firmware image header

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -115,7 +115,8 @@ jobs:
         with:
           command: clippy
           # `identity_op` and `or_fun_call` leads to false positives
-          args: -- -D warnings -A clippy::identity_op -A clippy::or_fun_call
+          # `too-many-arguments` is relatively arbitrary
+          args: -- -D warnings -A clippy::identity_op -A clippy::or_fun_call -A clippy::too-many-arguments
 
   build:
     name: Build Static Binaries

--- a/cargo-espflash/src/main.rs
+++ b/cargo-espflash/src/main.rs
@@ -10,9 +10,9 @@ use clap::Parser;
 use espflash::{
     cli::{
         board_info, connect, flash_elf_image, monitor::monitor, save_elf_as_image, ConnectOpts,
-        FlashOpts,
+        FlashConfigOpts, FlashOpts,
     },
-    Chip, Config, FlashFrequency, FlashMode, FlashSize, ImageFormatId,
+    Chip, Config, ImageFormatId,
 };
 use miette::{IntoDiagnostic, Result, WrapErr};
 
@@ -81,6 +81,8 @@ pub struct BuildOpts {
     /// Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for details
     #[clap(short = 'Z')]
     pub unstable: Option<Vec<String>>,
+    #[clap(flatten)]
+    pub flash_config_opts: FlashConfigOpts,
 }
 
 #[derive(Parser)]
@@ -154,16 +156,15 @@ fn flash(
             .transpose()?
             .or(metadata.format);
 
-        // FIXME
         flash_elf_image(
             &mut flasher,
             &elf_data,
             bootloader,
             partition_table,
             image_format,
-            None,
-            None,
-            None,
+            opts.build_opts.flash_config_opts.flash_mode,
+            opts.build_opts.flash_config_opts.flash_size,
+            opts.build_opts.flash_config_opts.flash_freq,
         )?;
     }
 
@@ -317,8 +318,15 @@ fn save_image(
         .transpose()?
         .or(metadata.format);
 
-    // FIXME
-    save_elf_as_image(chip, &elf_data, opts.file, image_format, None, None, None)?;
+    save_elf_as_image(
+        chip,
+        &elf_data,
+        opts.file,
+        image_format,
+        opts.build_opts.flash_config_opts.flash_mode,
+        opts.build_opts.flash_config_opts.flash_size,
+        opts.build_opts.flash_config_opts.flash_freq,
+    )?;
 
     Ok(())
 }

--- a/espflash/src/chip/esp32/esp32.rs
+++ b/espflash/src/chip/esp32/esp32.rs
@@ -183,10 +183,12 @@ impl Esp32 {
 fn test_esp32_rom() {
     use std::fs::read;
 
+    use crate::elf::FirmwareImageBuilder;
+
     let input_bytes = read("./tests/data/esp32").unwrap();
     let expected_bin = read("./tests/data/esp32.bin").unwrap();
 
-    let image = FirmwareImage::from_data(&input_bytes).unwrap();
+    let image = FirmwareImageBuilder::new(&input_bytes).build().unwrap();
     let flash_image = Esp32BootloaderFormat::new(&image, Chip::Esp32, PARAMS, None, None).unwrap();
 
     let segments = flash_image.flash_segments().collect::<Vec<_>>();

--- a/espflash/src/chip/esp8266.rs
+++ b/espflash/src/chip/esp8266.rs
@@ -90,10 +90,12 @@ impl ReadEFuse for Esp8266 {
 fn test_esp8266_rom() {
     use std::fs::read;
 
+    use crate::elf::FirmwareImageBuilder;
+
     let input_bytes = read("./tests/data/esp8266").unwrap();
     let expected_bin = read("./tests/data/esp8266.bin").unwrap();
 
-    let image = FirmwareImage::from_data(&input_bytes).unwrap();
+    let image = FirmwareImageBuilder::new(&input_bytes).build().unwrap();
     let flash_image = Esp8266Format::new(&image).unwrap();
 
     let segments = flash_image.flash_segments().collect::<Vec<_>>();

--- a/espflash/src/cli/mod.rs
+++ b/espflash/src/cli/mod.rs
@@ -11,6 +11,7 @@ use clap::Parser;
 use config::Config;
 use miette::{IntoDiagnostic, Result, WrapErr};
 use serialport::{FlowControl, SerialPortType};
+use strum::VariantNames;
 
 use crate::{
     cli::serial::get_serial_port_info,
@@ -49,6 +50,19 @@ pub struct FlashOpts {
     /// Open a serial monitor after flashing
     #[clap(long)]
     pub monitor: bool,
+}
+
+#[derive(Parser)]
+pub struct FlashConfigOpts {
+    /// Flash mode to use
+    #[clap(short = 'm', long, possible_values = FlashMode::VARIANTS, value_name = "MODE")]
+    pub flash_mode: Option<FlashMode>,
+    /// Flash size of the target
+    #[clap(short = 's', long, possible_values = FlashSize::VARIANTS, value_name = "SIZE")]
+    pub flash_size: Option<FlashSize>,
+    /// Flash frequency
+    #[clap(short = 'f', long, possible_values = FlashFrequency::VARIANTS, value_name = "FREQUENCY")]
+    pub flash_freq: Option<FlashFrequency>,
 }
 
 pub fn connect(opts: &ConnectOpts, config: &Config) -> Result<Flasher> {

--- a/espflash/src/elf.rs
+++ b/espflash/src/elf.rs
@@ -79,17 +79,17 @@ impl FromStr for FlashFrequency {
 pub struct FirmwareImage<'a> {
     pub entry: u32,
     pub elf: ElfFile<'a>,
-    pub flash_mode: FlashMode,
-    pub flash_size: FlashSize,
-    pub flash_frequency: FlashFrequency,
+    pub flash_mode: Option<FlashMode>,
+    pub flash_size: Option<FlashSize>,
+    pub flash_frequency: Option<FlashFrequency>,
 }
 
 impl<'a> FirmwareImage<'a> {
     pub fn new(
         elf: ElfFile<'a>,
-        flash_mode: FlashMode,
-        flash_size: FlashSize,
-        flash_frequency: FlashFrequency,
+        flash_mode: Option<FlashMode>,
+        flash_size: Option<FlashSize>,
+        flash_frequency: Option<FlashFrequency>,
     ) -> Self {
         Self {
             entry: elf.header.pt2.entry_point() as u32,
@@ -184,11 +184,7 @@ impl<'a> FirmwareImageBuilder<'a> {
     pub fn build(&self) -> Result<FirmwareImage<'a>, Error> {
         let elf = ElfFile::new(self.data).map_err(ElfError::from)?;
 
-        let flash_mode = self.flash_mode.unwrap_or(FlashMode::Dio);
-        let flash_size = self.flash_size.unwrap_or(FlashSize::Flash4Mb);
-        let flash_freq = self.flash_freq.unwrap_or(FlashFrequency::Flash40M);
-
-        let image = FirmwareImage::new(elf, flash_mode, flash_size, flash_freq);
+        let image = FirmwareImage::new(elf, self.flash_mode, self.flash_size, self.flash_freq);
 
         Ok(image)
     }

--- a/espflash/src/error.rs
+++ b/espflash/src/error.rs
@@ -109,6 +109,8 @@ https://github.com/espressif/esp32c3-direct-boot-example"
         help("The accepted values are: {:?}", FlashSize::VARIANTS)
     )]
     InvalidFlashSize(String),
+    #[error("The provided bootloader binary is not valid")]
+    InvalidBootloader,
 }
 
 #[derive(Error, Debug, Diagnostic)]

--- a/espflash/src/error.rs
+++ b/espflash/src/error.rs
@@ -10,6 +10,8 @@ use thiserror::Error;
 
 use crate::{
     command::CommandType,
+    elf::{FlashFrequency, FlashMode},
+    flasher::FlashSize,
     image_format::ImageFormatId,
     partition_table::{SubType, Type},
     Chip,
@@ -89,6 +91,24 @@ https://github.com/espressif/esp32c3-direct-boot-example"
     SerialNotFound(String),
     #[error("Canceled by user")]
     Canceled,
+    #[error("The flash mode '{0}' is not valid")]
+    #[diagnostic(
+        code(espflash::invalid_flash_mode),
+        help("The accepted values are: {:?}", FlashMode::VARIANTS)
+    )]
+    InvalidFlashMode(String),
+    #[error("The flash frequency '{0}' is not valid")]
+    #[diagnostic(
+        code(espflash::invalid_flash_frequency),
+        help("The accepted values are: {:?}", FlashFrequency::VARIANTS)
+    )]
+    InvalidFlashFrequency(String),
+    #[error("The flash size '{0}' is not valid")]
+    #[diagnostic(
+        code(espflash::invalid_flash_size),
+        help("The accepted values are: {:?}", FlashSize::VARIANTS)
+    )]
+    InvalidFlashSize(String),
 }
 
 #[derive(Error, Debug, Diagnostic)]

--- a/espflash/src/image_format/esp32bootloader.rs
+++ b/espflash/src/image_format/esp32bootloader.rs
@@ -1,6 +1,6 @@
 use std::{borrow::Cow, io::Write, iter::once};
 
-use bytemuck::{bytes_of, Pod, Zeroable, from_bytes};
+use bytemuck::{bytes_of, from_bytes, Pod, Zeroable};
 use sha2::{Digest, Sha256};
 
 use crate::{
@@ -41,22 +41,41 @@ impl<'a> Esp32BootloaderFormat<'a> {
 
         let mut data = Vec::new();
 
-        let header = EspCommonHeader {
-            magic: ESP_MAGIC,
-            segment_count: 0,
-            flash_mode: image.flash_mode as u8,
-            flash_config: encode_flash_size(image.flash_size)? + image.flash_frequency as u8,
-            entry: image.entry,
-        };
-
-        // Update the bootloader header
-        let current: EspCommonHeader = *from_bytes(&bootloader[0..8]);
-        if current.magic != ESP_MAGIC {
+        // fetch the generated header from the bootloader
+        let mut header: EspCommonHeader = *from_bytes(&bootloader[0..8]);
+        if header.magic != ESP_MAGIC {
             return Err(Error::InvalidBootloader);
         }
-        bootloader.to_mut()[2..4].copy_from_slice(&bytes_of(&header)[2..4]);
+        // update the header if a user has specified any custom arguments
+        if image.flash_frequency.is_some()
+            || image.flash_mode.is_some()
+            || image.flash_size.is_some()
+        {
+            if let Some(mode) = image.flash_mode {
+                header.flash_mode = mode as u8;
+                bootloader.to_mut()[2] = bytes_of(&header)[2];
+            }
+            match (image.flash_size, image.flash_frequency) {
+                (Some(s), Some(f)) => {
+                    header.flash_config = encode_flash_size(s)? + f as u8;
+                    bootloader.to_mut()[3] = bytes_of(&header)[3];
+                }
+                (Some(s), None) => {
+                    header.flash_config = encode_flash_size(s)? + (header.flash_config & 0x0F);
+                    bootloader.to_mut()[3] = bytes_of(&header)[3];
+                }
+                (None, Some(f)) => {
+                    header.flash_config = (header.flash_config & 0xF0) + f as u8;
+                    bootloader.to_mut()[3] = bytes_of(&header)[3];
+                }
+                (None, None) => {} // nothing to update
+            }
+        }
 
         // write the header of the app
+        // use the same settings as the bootloader
+        // just update the entry point
+        header.entry = image.entry;
         data.write_all(bytes_of(&header))?;
 
         let extended_header = ExtendedHeader {

--- a/espflash/src/image_format/esp8266.rs
+++ b/espflash/src/image_format/esp8266.rs
@@ -7,7 +7,7 @@ use crate::{
     error::{Error, FlashDetectError},
     flasher::FlashSize,
     image_format::{EspCommonHeader, ImageFormat, SegmentHeader, ESP_MAGIC},
-    Chip,
+    Chip, FlashFrequency, FlashMode,
 };
 
 const IROM_MAP_START: u32 = 0x40200000;
@@ -33,8 +33,9 @@ impl<'a> Esp8266Format<'a> {
         let header = EspCommonHeader {
             magic: ESP_MAGIC,
             segment_count: image.ram_segments(Chip::Esp8266).count() as u8,
-            flash_mode: image.flash_mode as u8,
-            flash_config: encode_flash_size(image.flash_size)? + image.flash_frequency as u8,
+            flash_mode: image.flash_mode.unwrap_or(FlashMode::Dio) as u8,
+            flash_config: encode_flash_size(image.flash_size.unwrap_or(FlashSize::Flash4Mb))?
+                + image.flash_frequency.unwrap_or(FlashFrequency::Flash40M) as u8,
             entry: image.entry,
         };
         common_data.write_all(bytes_of(&header))?;

--- a/espflash/src/image_format/mod.rs
+++ b/espflash/src/image_format/mod.rs
@@ -17,7 +17,7 @@ const ESP_MAGIC: u8 = 0xE9;
 const WP_PIN_DISABLED: u8 = 0xEE;
 
 #[derive(Copy, Clone, Zeroable, Pod, Debug)]
-#[repr(C)]
+#[repr(C, packed)]
 struct EspCommonHeader {
     magic: u8,
     segment_count: u8,
@@ -27,7 +27,7 @@ struct EspCommonHeader {
 }
 
 #[derive(Copy, Clone, Zeroable, Pod, Debug)]
-#[repr(C)]
+#[repr(C, packed)]
 struct SegmentHeader {
     addr: u32,
     length: u32,

--- a/espflash/src/lib.rs
+++ b/espflash/src/lib.rs
@@ -1,8 +1,8 @@
 pub use chip::Chip;
 pub use cli::config::Config;
-pub use elf::FirmwareImage;
+pub use elf::{FlashFrequency, FlashMode};
 pub use error::Error;
-pub use flasher::Flasher;
+pub use flasher::{FlashSize, Flasher};
 pub use image_format::ImageFormatId;
 pub use partition_table::PartitionTable;
 

--- a/espflash/src/main.rs
+++ b/espflash/src/main.rs
@@ -6,7 +6,7 @@ use espflash::{
         board_info, connect, flash_elf_image, monitor::monitor, save_elf_as_image, ConnectOpts,
         FlashOpts,
     },
-    Chip, Config, ImageFormatId,
+    Chip, Config, FlashFrequency, FlashMode, FlashSize, ImageFormatId,
 };
 use miette::{IntoDiagnostic, Result, WrapErr};
 
@@ -108,12 +108,16 @@ fn flash(opts: Opts, config: Config) -> Result<()> {
             .map(ImageFormatId::from_str)
             .transpose()?;
 
+        // FIXME
         flash_elf_image(
             &mut flasher,
             &elf_data,
             bootloader,
             partition_table,
             image_format,
+            None,
+            None,
+            None,
         )?;
     }
 
@@ -135,7 +139,16 @@ fn save_image(opts: SaveImageOpts) -> Result<()> {
         .map(ImageFormatId::from_str)
         .transpose()?;
 
-    save_elf_as_image(opts.chip, &elf_data, opts.file, image_format)?;
+    // FIXME
+    save_elf_as_image(
+        opts.chip,
+        &elf_data,
+        opts.file,
+        image_format,
+        None,
+        None,
+        None,
+    )?;
 
     Ok(())
 }


### PR DESCRIPTION
This PR now updates the boot loader header _and_ the app image header only when a user supplies override via the `-s`, `-m` and `-f` flags. 

If no overrides are provided, the header is extracted from the esp-idf bootloader, and the same settings are used for the app header, by doing this we allow esp-idf SDKCONFIG settings to work seamlessly with espflash.

Closes https://github.com/esp-rs/espflash/issues/140