### PR TITLE
Scale the app partition based on flash size.

### DIFF
--- a/espflash/src/chip/esp32/mod.rs
+++ b/espflash/src/chip/esp32/mod.rs
@@ -35,8 +35,7 @@ impl Esp32Params {
             self.phy_init_data_addr,
             self.phy_init_data_size,
             self.app_addr,
-            flash_size.map_or(self.app_size, 
-                |size| size - self.app_addr),
+            flash_size.map_or(self.app_size, |size| size - self.app_addr),
         )
     }
 }

--- a/espflash/src/chip/esp32/mod.rs
+++ b/espflash/src/chip/esp32/mod.rs
@@ -26,14 +26,17 @@ pub struct Esp32Params {
 }
 
 impl Esp32Params {
-    pub fn default_partition_table(&self) -> PartitionTable {
+    /// Generates a default partition table.
+    /// `flash_size` is used to scale app partition when present, otherwise the param defaults are used.
+    pub fn default_partition_table(&self, flash_size: Option<u32>) -> PartitionTable {
         PartitionTable::basic(
             self.nvs_addr,
             self.nvs_size,
             self.phy_init_data_addr,
             self.phy_init_data_size,
             self.app_addr,
-            self.app_size,
+            flash_size.map_or(self.app_size, 
+                |size| size - self.app_addr),
         )
     }
 }

--- a/espflash/src/flasher.rs
+++ b/espflash/src/flasher.rs
@@ -65,6 +65,22 @@ impl FlashSize {
             _ => Err(Error::UnsupportedFlash(FlashDetectError::from(value))),
         }
     }
+
+    /// Returns the flash size in bytes
+    pub fn size(self) -> u32 {
+        match self {
+            FlashSize::Flash256Kb => 0x0040000,
+            FlashSize::Flash512Kb => 0x0080000,
+            FlashSize::Flash1Mb   => 0x0100000,
+            FlashSize::Flash2Mb   => 0x0200000,
+            FlashSize::Flash4Mb   => 0x0400000,
+            FlashSize::Flash8Mb   => 0x0800000,
+            FlashSize::Flash16Mb  => 0x1000000,
+            FlashSize::Flash32Mb  => 0x2000000,
+            FlashSize::Flash64Mb  => 0x4000000,
+            FlashSize::Flash128Mb => 0x8000000,
+        }
+    }
 }
 
 impl FromStr for FlashSize {

--- a/espflash/src/flasher.rs
+++ b/espflash/src/flasher.rs
@@ -71,13 +71,13 @@ impl FlashSize {
         match self {
             FlashSize::Flash256Kb => 0x0040000,
             FlashSize::Flash512Kb => 0x0080000,
-            FlashSize::Flash1Mb   => 0x0100000,
-            FlashSize::Flash2Mb   => 0x0200000,
-            FlashSize::Flash4Mb   => 0x0400000,
-            FlashSize::Flash8Mb   => 0x0800000,
-            FlashSize::Flash16Mb  => 0x1000000,
-            FlashSize::Flash32Mb  => 0x2000000,
-            FlashSize::Flash64Mb  => 0x4000000,
+            FlashSize::Flash1Mb => 0x0100000,
+            FlashSize::Flash2Mb => 0x0200000,
+            FlashSize::Flash4Mb => 0x0400000,
+            FlashSize::Flash8Mb => 0x0800000,
+            FlashSize::Flash16Mb => 0x1000000,
+            FlashSize::Flash32Mb => 0x2000000,
+            FlashSize::Flash64Mb => 0x4000000,
             FlashSize::Flash128Mb => 0x8000000,
         }
     }

--- a/espflash/src/image_format/esp32bootloader.rs
+++ b/espflash/src/image_format/esp32bootloader.rs
@@ -32,8 +32,8 @@ impl<'a> Esp32BootloaderFormat<'a> {
         partition_table: Option<PartitionTable>,
         bootloader: Option<Vec<u8>>,
     ) -> Result<Self, Error> {
-        let partition_table = partition_table.unwrap_or_else(|| 
-            params.default_partition_table(image.flash_size.map(|v| v.size())));
+        let partition_table = partition_table
+            .unwrap_or_else(|| params.default_partition_table(image.flash_size.map(|v| v.size())));
         let mut bootloader = if let Some(bytes) = bootloader {
             Cow::Owned(bytes)
         } else {

--- a/espflash/src/image_format/esp32bootloader.rs
+++ b/espflash/src/image_format/esp32bootloader.rs
@@ -32,7 +32,8 @@ impl<'a> Esp32BootloaderFormat<'a> {
         partition_table: Option<PartitionTable>,
         bootloader: Option<Vec<u8>>,
     ) -> Result<Self, Error> {
-        let partition_table = partition_table.unwrap_or_else(|| params.default_partition_table());
+        let partition_table = partition_table.unwrap_or_else(|| 
+            params.default_partition_table(image.flash_size.map(|v| v.size())));
         let mut bootloader = if let Some(bytes) = bootloader {
             Cow::Owned(bytes)
         } else {


### PR DESCRIPTION
The pre-defined `app_sizes` for the various `Esp32Param` assume a flash size which is not necessarily correct, e.g. there are esp32-c3 chips with 2MB. 

This pull request removes the need to supply a custom partition-table for those chips.

