### PR TITLE
Feature: add subcommand for merging binaries

### DIFF
--- a/cargo-espflash/src/main.rs
+++ b/cargo-espflash/src/main.rs
@@ -91,6 +91,15 @@ pub struct SaveImageOpts {
     pub build_opts: BuildOpts,
     /// File name to save the generated image to
     pub file: PathBuf,
+    /// Boolean flag to merge binaries into single binary
+    #[clap(long, short = 'M')]
+    pub merge: bool,
+    /// Custom bootloader for merging
+    #[clap(long, short = 'B')]
+    pub bootloader: Option<PathBuf>,
+    /// Custom partition table for merging
+    #[clap(long, short = 'T')]
+    pub partition_table: Option<PathBuf>,
 }
 
 fn main() -> Result<()> {
@@ -326,6 +335,9 @@ fn save_image(
         opts.build_opts.flash_config_opts.flash_mode,
         opts.build_opts.flash_config_opts.flash_size,
         opts.build_opts.flash_config_opts.flash_freq,
+        opts.merge,
+        opts.bootloader,
+        opts.partition_table,
     )?;
 
     Ok(())

--- a/espflash/src/main.rs
+++ b/espflash/src/main.rs
@@ -49,6 +49,15 @@ pub struct SaveImageOpts {
     image: PathBuf,
     /// File name to save the generated image to
     file: PathBuf,
+    /// Boolean flag, if set, bootloader, partition table and application binaries will be merged into single binary
+    #[clap(long, short = 'M')]
+    pub merge: bool,
+    /// Custom bootloader for merging
+    #[clap(long, short = 'B')]
+    pub bootloader: Option<PathBuf>,
+    /// Custom partition table for merging
+    #[clap(long, short = 'T')]
+    pub partition_table: Option<PathBuf>,
 }
 
 fn main() -> Result<()> {
@@ -150,6 +159,9 @@ fn save_image(opts: SaveImageOpts) -> Result<()> {
         opts.flash_config_opts.flash_mode,
         opts.flash_config_opts.flash_size,
         opts.flash_config_opts.flash_freq,
+        opts.merge,
+        opts.bootloader,
+        opts.partition_table,
     )?;
 
     Ok(())


### PR DESCRIPTION
Feature: add the option for merging bootloader, partition-table and application binary into a single binary.
Closes #79 

Note: To get a chip revision, the connection is needed, for simplicity, the revision None is used.