### PR TITLE
Correct path extension checks for cargo package metadata

### DIFF
--- a/cargo-espflash/src/package_metadata.rs
+++ b/cargo-espflash/src/package_metadata.rs
@@ -1,4 +1,5 @@
 use std::{
+    ffi::OsStr,
     fs::read_to_string,
     path::{Path, PathBuf},
 };
@@ -23,35 +24,42 @@ pub struct Meta {
 }
 
 impl CargoEspFlashMeta {
-    pub fn load<P: AsRef<Path>>(path: P) -> Result<CargoEspFlashMeta> {
-        let path = path.as_ref();
-        if !path.exists() {
+    pub fn load<P>(manifest: P) -> Result<CargoEspFlashMeta>
+    where
+        P: AsRef<Path>,
+    {
+        let manifest = manifest.as_ref();
+        if !manifest.exists() {
             return Err(Error::NoProject.into());
         }
-        let toml = read_to_string(path)
+
+        let toml = read_to_string(manifest)
             .into_diagnostic()
             .wrap_err("Failed to read Cargo.toml")?;
+
         let manifest = Manifest::<Meta>::from_slice_with_metadata(toml.as_bytes())
             .map_err(move |e| TomlError::new(e, toml))
             .wrap_err("Failed to parse Cargo.toml")?;
+
         let meta = manifest
             .package
             .and_then(|pkg| pkg.metadata)
             .unwrap_or_default()
             .espflash
             .unwrap_or_default();
-        match meta.partition_table {
-            Some(table) if !table.ends_with(".csv") => {
-                return Err(Error::InvalidPartitionTablePath.into())
+
+        if let Some(table) = &meta.partition_table {
+            if table.extension() != Some(OsStr::new("csv")) {
+                return Err(Error::InvalidPartitionTablePath.into());
             }
-            _ => {}
         }
-        match meta.bootloader {
-            Some(table) if !table.ends_with(".bin") => {
-                return Err(Error::InvalidBootloaderPath.into())
+
+        if let Some(bootloader) = &meta.bootloader {
+            if bootloader.extension() != Some(OsStr::new("bin")) {
+                return Err(Error::InvalidBootloaderPath.into());
             }
-            _ => {}
         }
+
         Ok(meta)
     }
 }


### PR DESCRIPTION
This was accidentally broken (by me) in a previous refactor.

The fields for these paths were originally `String` but were changed to `PathBuf`. Unfortunately both types have an `ends_with` function (but they behave differently), so this was not caught by the compiler.

See https://github.com/esp-rs/espflash/issues/156 for further context.