### PR TITLE
Hack to disable the rtc watchdog when connecting under the usb-serial-jtag

### DIFF
--- a/espflash/src/connection.rs
+++ b/espflash/src/connection.rs
@@ -16,7 +16,7 @@ use crate::{
 };
 
 const DEFAULT_CONNECT_ATTEMPTS: usize = 7;
-const USB_SERIAL_JTAG_PID: u16 = 0x1001;
+pub const USB_SERIAL_JTAG_PID: u16 = 0x1001;
 
 #[derive(Debug, Copy, Clone, BinRead)]
 pub struct CommandResponse {


### PR DESCRIPTION
When the chip is reset via the USB-SERIAL-JTAG not everything is fully reset, the RTC domain stays active. Therefore, if the RTC watchdog is enabled before being put into download mode it will trigger when flashing, hence resetting the board and interrupting flashing.

The reason it always works on Arduino is that the RTC watchdog is explicitly disabled very early on in the boot process which doesn't seem to be the case for normal esp-idf applications, and therefore Rust applications. 

Closes #154 
