### PR TITLE
Add partition-table subcommand

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -37,7 +37,7 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: 1.56
+          toolchain: 1.58
           override: true
       - uses: Swatinem/rust-cache@v1
       - uses: actions-rs/cargo@v1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -253,7 +253,7 @@ version = "3.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a3aab4734e083b809aaf5794e14e756d1c798d2c69c7f7de7a09a2f5214993c1"
 dependencies = [
- "heck",
+ "heck 0.4.0",
  "proc-macro-error",
  "proc-macro2",
  "quote",
@@ -267,6 +267,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "189ddd3b5d32a70b35e7686054371742a937b0d99128e76dde6340210e966669"
 dependencies = [
  "os_str_bytes",
+]
+
+[[package]]
+name = "comfy-table"
+version = "5.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b103d85ca6e209388771bfb7aa6b68a7aeec4afbf6f0a0264bfbf50360e5212e"
+dependencies = [
+ "crossterm",
+ "strum 0.23.0",
+ "strum_macros 0.23.1",
+ "unicode-width",
 ]
 
 [[package]]
@@ -429,6 +441,7 @@ dependencies = [
  "binread",
  "bytemuck",
  "clap",
+ "comfy-table",
  "crossterm",
  "csv",
  "dialoguer",
@@ -445,8 +458,8 @@ dependencies = [
  "serialport",
  "sha2",
  "slip-codec",
- "strum",
- "strum_macros",
+ "strum 0.24.0",
+ "strum_macros 0.24.0",
  "thiserror",
  "toml",
  "xmas-elf",
@@ -533,6 +546,15 @@ name = "hashbrown"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
+
+[[package]]
+name = "heck"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
+dependencies = [
+ "unicode-segmentation",
+]
 
 [[package]]
 name = "heck"
@@ -1191,9 +1213,28 @@ checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "strum"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cae14b91c7d11c9a851d3fbc80a963198998c2a64eec840477fa92d8ce9b70bb"
+
+[[package]]
+name = "strum"
 version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e96acfc1b70604b8b2f1ffa4c57e59176c7dbb05d556c71ecd2f5498a1dee7f8"
+
+[[package]]
+name = "strum_macros"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5bb0dc7ee9c15cea6199cde9a127fa16a4c5819af85395457ad72d68edc85a38"
+dependencies = [
+ "heck 0.3.3",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn",
+]
 
 [[package]]
 name = "strum_macros"
@@ -1201,7 +1242,7 @@ version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6878079b17446e4d3eba6192bb0a2950d5b14f0ed8424b852310e5a94345d0ef"
 dependencies = [
- "heck",
+ "heck 0.4.0",
  "proc-macro2",
  "quote",
  "rustversion",
@@ -1343,6 +1384,12 @@ checksum = "3a52dcaab0c48d931f7cc8ef826fa51690a08e1ea55117ef26f89864f532383f"
 dependencies = [
  "regex",
 ]
+
+[[package]]
+name = "unicode-segmentation"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e8820f5d777f6224dc4be3632222971ac30164d4a258d595640799554ebfd99"
 
 [[package]]
 name = "unicode-width"

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This repository contains two applications:
 | [cargo-espflash] | Cargo subcommand for espflash                               |
 | [espflash]       | Library and `espflash` binary (_without_ Cargo integration) |
 
-> **NOTE:** requires `rustc >= 1.56.0` in order to build either application
+> **NOTE:** requires `rustc >= 1.58.0` in order to build either application
 
 ## Installation
 

--- a/cargo-espflash/src/main.rs
+++ b/cargo-espflash/src/main.rs
@@ -1,5 +1,6 @@
 use std::{
     fs,
+    io::Write,
     path::PathBuf,
     process::{exit, Command, ExitStatus, Stdio},
     str::FromStr,
@@ -12,7 +13,7 @@ use espflash::{
         board_info, connect, flash_elf_image, monitor::monitor, save_elf_as_image, ConnectOpts,
         FlashConfigOpts, FlashOpts,
     },
-    Chip, Config, ImageFormatId,
+    Chip, Config, ImageFormatId, InvalidPartitionTable, PartitionTable,
 };
 use miette::{IntoDiagnostic, Result, WrapErr};
 
@@ -56,6 +57,8 @@ pub enum SubCommand {
     BoardInfo(ConnectOpts),
     /// Save the image to disk instead of flashing to device
     SaveImage(SaveImageOpts),
+    /// Operations for partitions tables
+    PartitionTable(PartitionTableOpts),
 }
 
 #[derive(Parser)]
@@ -102,6 +105,24 @@ pub struct SaveImageOpts {
     pub partition_table: Option<PathBuf>,
 }
 
+#[derive(Parser)]
+pub struct PartitionTableOpts {
+    /// Convert CSV parition table to binary representation
+    #[clap(long, required_unless_present_any = ["info", "to-csv"])]
+    to_binary: bool,
+    /// Convert binary partition table to CSV representation
+    #[clap(long, required_unless_present_any = ["info", "to-binary"])]
+    to_csv: bool,
+    /// Show information on partition table
+    #[clap(short, long, required_unless_present_any = ["to-binary", "to-csv"])]
+    info: bool,
+    /// Input partition table
+    partition_table: PathBuf,
+    /// Optional output file name, if unset will output to stdout
+    #[clap(short, long)]
+    output: Option<PathBuf>,
+}
+
 fn main() -> Result<()> {
     miette::set_panic_hook();
 
@@ -117,6 +138,7 @@ fn main() -> Result<()> {
         match subcommand {
             BoardInfo(opts) => board_info(opts, config),
             SaveImage(opts) => save_image(opts, metadata, cargo_config),
+            PartitionTable(opts) => partition_table(opts),
         }
     } else {
         flash(opts, config, metadata, cargo_config)
@@ -340,6 +362,53 @@ fn save_image(
         opts.bootloader,
         opts.partition_table,
     )?;
+
+    Ok(())
+}
+
+fn partition_table(opts: PartitionTableOpts) -> Result<()> {
+    if opts.to_binary {
+        let input = fs::read(&opts.partition_table).into_diagnostic()?;
+        let part_table = PartitionTable::try_from_str(String::from_utf8(input).into_diagnostic()?)
+            .into_diagnostic()?;
+
+        // Use either stdout or a file if provided for the output.
+        let mut writer: Box<dyn Write> = if let Some(output) = opts.output {
+            Box::new(fs::File::create(output).into_diagnostic()?)
+        } else {
+            Box::new(std::io::stdout())
+        };
+        part_table.save_bin(&mut writer).into_diagnostic()?;
+    } else if opts.to_csv {
+        let input = fs::read(&opts.partition_table).into_diagnostic()?;
+        let part_table = PartitionTable::try_from_bytes(input).into_diagnostic()?;
+
+        // Use either stdout or a file if provided for the output.
+        let mut writer: Box<dyn Write> = if let Some(output) = opts.output {
+            Box::new(fs::File::create(output).into_diagnostic()?)
+        } else {
+            Box::new(std::io::stdout())
+        };
+        part_table.save_csv(&mut writer).into_diagnostic()?;
+    } else if opts.info {
+        let input = fs::read(&opts.partition_table).into_diagnostic()?;
+
+        // Try getting the partition table from either the csv or the binary representation and
+        // fail otherwise.
+        let part_table = if let Ok(part_table) =
+            PartitionTable::try_from_bytes(input.clone()).into_diagnostic()
+        {
+            part_table
+        } else if let Ok(part_table) =
+            PartitionTable::try_from_str(String::from_utf8(input).into_diagnostic()?)
+        {
+            part_table
+        } else {
+            return Err((InvalidPartitionTable {}).into());
+        };
+
+        part_table.pretty_print();
+    }
 
     Ok(())
 }

--- a/espflash/Cargo.toml
+++ b/espflash/Cargo.toml
@@ -6,7 +6,7 @@ authors = [
     "Jesse Braham <jesse@beta7.io>",
 ]
 edition = "2021"
-rust-version = "1.56"
+rust-version = "1.58"
 description = "A command-line tool for flashing Espressif devices over serial"
 repository = "https://github.com/esp-rs/espflash"
 license = "GPL-2.0"
@@ -35,6 +35,7 @@ path = "src/main.rs"
 binread = "2.2"
 bytemuck = { version = "1.9", features = ["derive"] }
 clap = { version = "3.1", features = ["derive"] }
+comfy-table = "5"
 crossterm = "0.23"
 csv = "1.1"
 dialoguer = "0.10"

--- a/espflash/src/error.rs
+++ b/espflash/src/error.rs
@@ -346,6 +346,18 @@ pub enum PartitionTableError {
     #[error(transparent)]
     #[diagnostic(transparent)]
     UnalignedPartitionError(#[from] UnalignedPartitionError),
+    #[error(transparent)]
+    #[diagnostic(transparent)]
+    LengthNotMultipleOf32(#[from] LengthNotMultipleOf32),
+    #[error(transparent)]
+    #[diagnostic(transparent)]
+    InvalidChecksum(#[from] InvalidChecksum),
+    #[error(transparent)]
+    #[diagnostic(transparent)]
+    NoEndMarker(#[from] NoEndMarker),
+    #[error(transparent)]
+    #[diagnostic(transparent)]
+    InvalidPartitionTable(#[from] InvalidPartitionTable),
 }
 
 #[derive(Debug, Error, Diagnostic)]
@@ -534,6 +546,26 @@ impl UnalignedPartitionError {
         }
     }
 }
+
+#[derive(Debug, Error, Diagnostic)]
+#[error("Partition table length not a multiple of 32")]
+#[diagnostic(code(espflash::partition_table::invalid_length))]
+pub struct LengthNotMultipleOf32;
+
+#[derive(Debug, Error, Diagnostic)]
+#[error("Checksum invalid")]
+#[diagnostic(code(espflash::partition_table::invalid_checksum))]
+pub struct InvalidChecksum;
+
+#[derive(Debug, Error, Diagnostic)]
+#[error("No end marker found")]
+#[diagnostic(code(espflash::partition_table::no_end_marker))]
+pub struct NoEndMarker;
+
+#[derive(Debug, Error, Diagnostic)]
+#[error("Invalid partition table")]
+#[diagnostic(code(espflash::partition_table::invalid_partition_table))]
+pub struct InvalidPartitionTable;
 
 #[derive(Debug, Error)]
 #[error("{0}")]

--- a/espflash/src/lib.rs
+++ b/espflash/src/lib.rs
@@ -1,7 +1,7 @@
 pub use chip::Chip;
 pub use cli::config::Config;
 pub use elf::{FlashFrequency, FlashMode};
-pub use error::Error;
+pub use error::{Error, InvalidPartitionTable};
 pub use flasher::{FlashSize, Flasher};
 pub use image_format::ImageFormatId;
 pub use partition_table::PartitionTable;


### PR DESCRIPTION
Fixes #165 and fixes #163. It's quite pretty too:
![image](https://user-images.githubusercontent.com/1664/166118910-8050a029-be9f-47bb-bd2d-6760e4eec690.png)

This is quite a bit more than I bargained for but I think this makes sense as parsing of the binary stuff is also in esp-idf's `gen_esp32part.py` and that's Python so we can't have that!

I had to bump the MSRV to 1.58 but I hope that's ok.