### PR TITLE
Update README.md

### DIFF
--- a/cargo-espflash/README.md
+++ b/cargo-espflash/README.md
@@ -98,7 +98,7 @@ An example configuration file may look as follows (note that TOML does _not_ sup
 [connection]
 serial = "/dev/ttyUSB0"
 
-[usb_device]
+[[usb_device]]
 vid = "303A"
 pid = "8000"
 ```


### PR DESCRIPTION
Typo, getting "Error: × invalid type: map, expected a sequence for key `usb_device` at line 4 column 1" otherwise