### PR TITLE
bugfix: flash with wsl2

### DIFF
--- a/cargo-espflash/README.md
+++ b/cargo-espflash/README.md
@@ -104,6 +104,9 @@ vid = "303A"
 pid = "8000"
 ```
 
+## WSL2
+It is not possible to flash `usb-serial-jtag` chips with `WSL2` because the reset also resets `serial-jtag-peripheral` which disconnects the chip from WSL2.
+
 ## Package Metadata
 
 You can specify the bootloader, partition table, or image format for a project in the package metadata in `Cargo.toml`:

--- a/espflash/README.md
+++ b/espflash/README.md
@@ -87,6 +87,9 @@ vid = 12346 # 0x303A
 pid = 32768 # 0x8000
 ```
 
+## WSL2
+It is not possible to flash `usb-serial-jtag` chips with `WSL2` because the reset also resets `serial-jtag-peripheral` which disconnects the chip from WSL2.
+
 ## Use as a Cargo Runner
 
 You can also use `espflash` as a Cargo runner by adding the followin to your project's `.cargo/config` file:

--- a/espflash/src/cli/mod.rs
+++ b/espflash/src/cli/mod.rs
@@ -11,7 +11,7 @@ use std::{
 use clap::Parser;
 use config::Config;
 use miette::{IntoDiagnostic, Result, WrapErr};
-use serialport::{FlowControl, SerialPortType};
+use serialport::{FlowControl, SerialPortType, UsbPortInfo};
 use strum::VariantNames;
 
 use crate::{
@@ -99,6 +99,16 @@ pub fn connect(opts: &ConnectOpts, config: &Config) -> Result<Flasher> {
     //       can just pretend the remaining types don't exist here.
     let port_info = match port_info.port_type {
         SerialPortType::UsbPort(info) => info,
+        SerialPortType::Unknown => {
+            println!("Matched SerialPortType::Unknown");
+            UsbPortInfo {
+                vid: 0,
+                pid: 0,
+                serial_number: None,
+                manufacturer: None,
+                product: None,
+            }
+        }
         _ => unreachable!(),
     };
 

--- a/espflash/src/cli/serial.rs
+++ b/espflash/src/cli/serial.rs
@@ -132,7 +132,12 @@ fn detect_usb_serial_ports() -> Result<Vec<SerialPortInfo>> {
     let ports = available_ports().into_diagnostic()?;
     let ports = ports
         .into_iter()
-        .filter(|port_info| matches!(&port_info.port_type, SerialPortType::UsbPort(..)))
+        .filter(|port_info| {
+            matches!(
+                &port_info.port_type,
+                SerialPortType::UsbPort(..) | SerialPortType::Unknown
+            )
+        })
         .collect::<Vec<_>>();
 
     Ok(ports)
@@ -214,6 +219,13 @@ fn select_serial_port(
         let port_name = port.port_name.clone();
         let port_info = match &port.port_type {
             SerialPortType::UsbPort(info) => info,
+            SerialPortType::Unknown => &UsbPortInfo {
+                vid: 0,
+                pid: 0,
+                serial_number: None,
+                manufacturer: None,
+                product: None,
+            },
             _ => unreachable!(),
         };
 


### PR DESCRIPTION
Closes #166 

Note: It is not possible to flash `usb-serial-jtag` chips with `WSL2` because the reset also resets `serial-jtag-peripheral` which disconnects the chip from WSL2.