### PR TITLE
Make all library modules public

### DIFF
--- a/espflash/src/cli/mod.rs
+++ b/espflash/src/cli/mod.rs
@@ -112,6 +112,7 @@ pub fn board_info(opts: ConnectOpts, config: Config) -> Result<()> {
     Ok(())
 }
 
+#[allow(clippy::too_many_arguments)]
 pub fn save_elf_as_image(
     chip: Chip,
     elf_data: &[u8],
@@ -209,6 +210,7 @@ pub fn save_elf_as_image(
     Ok(())
 }
 
+#[allow(clippy::too_many_arguments)]
 pub fn flash_elf_image(
     flasher: &mut Flasher,
     elf_data: &[u8],

--- a/espflash/src/flash_target/esp8266.rs
+++ b/espflash/src/flash_target/esp8266.rs
@@ -14,6 +14,12 @@ impl Esp8266Target {
     }
 }
 
+impl Default for Esp8266Target {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl FlashTarget for Esp8266Target {
     fn begin(&mut self, connection: &mut Connection, _image: &FirmwareImage) -> Result<(), Error> {
         connection.command(Command::FlashBegin {

--- a/espflash/src/flash_target/ram.rs
+++ b/espflash/src/flash_target/ram.rs
@@ -22,6 +22,12 @@ impl RamTarget {
     }
 }
 
+impl Default for RamTarget {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl FlashTarget for RamTarget {
     fn begin(&mut self, _connection: &mut Connection, image: &FirmwareImage) -> Result<(), Error> {
         self.entry = Some(image.entry());

--- a/espflash/src/flasher.rs
+++ b/espflash/src/flasher.rs
@@ -443,6 +443,7 @@ impl Flasher {
     }
 
     /// Load an elf image to flash and execute it
+    #[allow(clippy::too_many_arguments)]
     pub fn load_elf_to_flash_with_format(
         &mut self,
         elf_data: &[u8],

--- a/espflash/src/image_format/mod.rs
+++ b/espflash/src/image_format/mod.rs
@@ -33,7 +33,7 @@ struct SegmentHeader {
     length: u32,
 }
 
-pub trait ImageFormat<'a> {
+pub trait ImageFormat<'a>: Send {
     /// Get the rom segments needed when flashing to device
     fn flash_segments<'b>(&'b self) -> Box<dyn Iterator<Item = RomSegment<'b>> + 'b>
     where

--- a/espflash/src/lib.rs
+++ b/espflash/src/lib.rs
@@ -6,16 +6,16 @@ pub use flasher::{FlashSize, Flasher};
 pub use image_format::ImageFormatId;
 pub use partition_table::PartitionTable;
 
-mod chip;
-mod command;
-mod connection;
-mod elf;
-mod encoder;
-mod error;
-mod flash_target;
-mod flasher;
-mod image_format;
-mod partition_table;
+pub mod chip;
+pub mod command;
+pub mod connection;
+pub mod elf;
+pub mod encoder;
+pub mod error;
+pub mod flash_target;
+pub mod flasher;
+pub mod image_format;
+pub mod partition_table;
 
 #[doc(hidden)]
 pub mod cli;


### PR DESCRIPTION
I'm trying to use espflash as library and needed to open up espflash a lil bit :D. Is there any reason not to do this? 

Also snuck in a trait bound on `ImageFormat` to make `dyn ImageFormat` `Send`able across threads, happy to open another PR if that's more suitable!

Edit: If this seems like a reasonable idea lmk and I'll fix the clippy issues.