### PR TITLE
Remove dependency to FirmwareImage from flash_targets

### DIFF
--- a/espflash/src/chip/mod.rs
+++ b/espflash/src/chip/mod.rs
@@ -254,8 +254,8 @@ impl Chip {
         }
     }
 
-    pub fn ram_target(&self) -> Box<dyn FlashTarget> {
-        Box::new(RamTarget::new())
+    pub fn ram_target(&self, entry: Option<u32>) -> Box<dyn FlashTarget> {
+        Box::new(RamTarget::new(entry))
     }
 
     pub fn flash_target(&self, spi_params: SpiAttachParams) -> Box<dyn FlashTarget> {

--- a/espflash/src/flash_target/esp32.rs
+++ b/espflash/src/flash_target/esp32.rs
@@ -1,6 +1,6 @@
 use crate::command::{Command, CommandType};
 use crate::connection::{Connection, USB_SERIAL_JTAG_PID};
-use crate::elf::{FirmwareImage, RomSegment};
+use crate::elf::RomSegment;
 use crate::error::Error;
 use crate::flash_target::FlashTarget;
 use crate::flasher::{SpiAttachParams, FLASH_SECTOR_SIZE, FLASH_WRITE_SIZE};
@@ -25,7 +25,7 @@ impl Esp32Target {
 }
 
 impl FlashTarget for Esp32Target {
-    fn begin(&mut self, connection: &mut Connection, _image: &FirmwareImage) -> Result<(), Error> {
+    fn begin(&mut self, connection: &mut Connection) -> Result<(), Error> {
         connection.with_timeout(CommandType::SpiAttach.timeout(), |connection| {
             connection.command(Command::SpiAttach {
                 spi_params: self.spi_attach_params,

--- a/espflash/src/flash_target/esp8266.rs
+++ b/espflash/src/flash_target/esp8266.rs
@@ -1,6 +1,6 @@
 use crate::command::{Command, CommandType};
 use crate::connection::Connection;
-use crate::elf::{FirmwareImage, RomSegment};
+use crate::elf::RomSegment;
 use crate::error::Error;
 use crate::flash_target::FlashTarget;
 use crate::flasher::{get_erase_size, FLASH_WRITE_SIZE};
@@ -21,7 +21,7 @@ impl Default for Esp8266Target {
 }
 
 impl FlashTarget for Esp8266Target {
-    fn begin(&mut self, connection: &mut Connection, _image: &FirmwareImage) -> Result<(), Error> {
+    fn begin(&mut self, connection: &mut Connection) -> Result<(), Error> {
         connection.command(Command::FlashBegin {
             size: 0,
             blocks: 0,

--- a/espflash/src/flash_target/mod.rs
+++ b/espflash/src/flash_target/mod.rs
@@ -3,7 +3,7 @@ mod esp8266;
 mod ram;
 
 use crate::connection::Connection;
-use crate::elf::{FirmwareImage, RomSegment};
+use crate::elf::RomSegment;
 use crate::error::Error;
 
 use bytemuck::{Pod, Zeroable};
@@ -12,7 +12,7 @@ pub use esp8266::Esp8266Target;
 pub use ram::RamTarget;
 
 pub trait FlashTarget {
-    fn begin(&mut self, connection: &mut Connection, image: &FirmwareImage) -> Result<(), Error>;
+    fn begin(&mut self, connection: &mut Connection) -> Result<(), Error>;
     fn write_segment(
         &mut self,
         connection: &mut Connection,

--- a/espflash/src/flash_target/ram.rs
+++ b/espflash/src/flash_target/ram.rs
@@ -1,6 +1,6 @@
 use crate::command::{Command, CommandType};
 use crate::connection::Connection;
-use crate::elf::{FirmwareImage, RomSegment};
+use crate::elf::RomSegment;
 use crate::error::Error;
 use crate::flash_target::FlashTarget;
 use bytemuck::{Pod, Zeroable};
@@ -17,20 +17,19 @@ pub struct RamTarget {
 }
 
 impl RamTarget {
-    pub fn new() -> Self {
-        RamTarget { entry: None }
+    pub fn new(entry: Option<u32>) -> Self {
+        RamTarget { entry }
     }
 }
 
 impl Default for RamTarget {
     fn default() -> Self {
-        Self::new()
+        Self::new(None)
     }
 }
 
 impl FlashTarget for RamTarget {
-    fn begin(&mut self, _connection: &mut Connection, image: &FirmwareImage) -> Result<(), Error> {
-        self.entry = Some(image.entry());
+    fn begin(&mut self, _connection: &mut Connection) -> Result<(), Error> {
         Ok(())
     }
 

--- a/espflash/src/flasher.rs
+++ b/espflash/src/flasher.rs
@@ -420,8 +420,8 @@ impl Flasher {
     pub fn load_elf_to_ram(&mut self, elf_data: &[u8]) -> Result<(), Error> {
         let image = FirmwareImageBuilder::new(elf_data).build()?;
 
-        let mut target = self.chip.ram_target();
-        target.begin(&mut self.connection, &image).flashing()?;
+        let mut target = self.chip.ram_target(Some(image.entry()));
+        target.begin(&mut self.connection).flashing()?;
 
         if image.rom_segments(self.chip).next().is_some() {
             return Err(Error::ElfNotRamLoadable);
@@ -465,7 +465,7 @@ impl Flasher {
         let image = builder.build()?;
 
         let mut target = self.chip.flash_target(self.spi_params);
-        target.begin(&mut self.connection, &image).flashing()?;
+        target.begin(&mut self.connection).flashing()?;
 
         let flash_image = self.chip.get_flash_image(
             &image,


### PR DESCRIPTION
I am looking into using espflash as a API to flash single a binary like the phy init data. Currently, the flash_targets depend on a `FirmwareImage` which requires to have loaded a valid ELF file.

The `FlashTarget` is currently only used to get the entrypoint for the `RamTarget`. This PR makes the entrypoint specific to the `RamTarget` and makes the `FlashTarget` trait more generic for other use-cases.