### PR TITLE
Add "write-bin-to-flash" subcommand

### DIFF
--- a/espflash/src/flasher.rs
+++ b/espflash/src/flasher.rs
@@ -480,6 +480,19 @@ impl Flasher {
         Ok(())
     }
 
+    /// Load an bin image to flash at a specific address
+    pub fn write_bin_to_flash(&mut self, addr: u32, data: &[u8]) -> Result<(), Error> {
+        let mut target = self.chip.flash_target(self.spi_params);
+        target.begin(&mut self.connection).flashing()?;
+        let segment = RomSegment {
+            addr,
+            data: Cow::from(data),
+        };
+        target.write_segment(&mut self.connection, segment)?;
+        target.finish(&mut self.connection, true).flashing()?;
+        Ok(())
+    }
+
     /// Load an elf image to flash and execute it
     pub fn load_elf_to_flash(
         &mut self,

--- a/espflash/src/main.rs
+++ b/espflash/src/main.rs
@@ -4,7 +4,8 @@ use clap::{IntoApp, Parser};
 use espflash::{
     cli::{
         board_info, connect, flash_elf_image, monitor::monitor, partition_table, save_elf_as_image,
-        ConnectOpts, FlashConfigOpts, FlashOpts, PartitionTableOpts,
+        write_bin_to_flash, ConnectOpts, FlashConfigOpts, FlashOpts, PartitionTableOpts,
+        WriteBinToFlashOpts,
     },
     Chip, Config, ImageFormatId,
 };
@@ -36,6 +37,8 @@ pub enum SubCommand {
     SaveImage(SaveImageOpts),
     /// Operations for partitions tables
     PartitionTable(PartitionTableOpts),
+    /// Writes a binary file to a specific address in the chip's flash
+    WriteBinToFlash(WriteBinToFlashOpts),
 }
 
 #[derive(Parser)]
@@ -92,6 +95,7 @@ fn main() -> Result<()> {
             BoardInfo(opts) => board_info(opts, config),
             SaveImage(opts) => save_image(opts),
             PartitionTable(opts) => partition_table(opts),
+            WriteBinToFlash(opts) => write_bin_to_flash(opts),
         }
     } else {
         flash(opts, config)


### PR DESCRIPTION
This subcommand adds support for writing a binary file at a specific address in flash.