### PR TITLE
Update `crossterm` and remove the temporary bugfix from our monitor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -275,7 +275,7 @@ version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "121d8a5b0346092c18a4b2fd6f620d7a06f0eb7ac0a45860939a0884bc579c56"
 dependencies = [
- "crossterm",
+ "crossterm 0.23.2",
  "strum",
  "strum_macros",
  "unicode-width",
@@ -328,6 +328,22 @@ name = "crossterm"
 version = "0.23.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2102ea4f781910f8a5b98dd061f4c2023f479ce7bb1236330099ceb5a93cf17"
+dependencies = [
+ "bitflags",
+ "crossterm_winapi",
+ "libc",
+ "mio",
+ "parking_lot",
+ "signal-hook",
+ "signal-hook-mio",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab9f7409c70a38a56216480fba371ee460207dd8926ccf5b4160591759559170"
 dependencies = [
  "bitflags",
  "crossterm_winapi",
@@ -442,7 +458,7 @@ dependencies = [
  "bytemuck",
  "clap",
  "comfy-table",
- "crossterm",
+ "crossterm 0.24.0",
  "csv",
  "dialoguer",
  "directories-next",
@@ -474,7 +490,7 @@ checksum = "a73907f3778412c532cb4bbe8b0d04f0a4356ef547948e8c99b0ef79647b5c8c"
 dependencies = [
  "addr2line",
  "clap",
- "crossterm",
+ "crossterm 0.23.2",
  "gimli",
  "lazy_static",
  "nix",

--- a/espflash/Cargo.toml
+++ b/espflash/Cargo.toml
@@ -37,7 +37,7 @@ binread = "2.2"
 bytemuck = { version = "1.9", features = ["derive"] }
 clap = { version = "3.2", features = ["derive"] }
 comfy-table = "6.0"
-crossterm = "0.23"
+crossterm = "0.24"
 csv = "1.1"
 dialoguer = "0.10"
 directories-next = "2.0"

--- a/espflash/src/cli/monitor.rs
+++ b/espflash/src/cli/monitor.rs
@@ -120,12 +120,8 @@ pub fn monitor(mut serial: Box<dyn SerialPort>, elf: &[u8], pid: u16) -> serialp
             if let Event::Key(key) = read()? {
                 if key.modifiers.contains(KeyModifiers::CONTROL) {
                     match key.code {
-                        // NOTE: Both the lower- and upper-case variants shouldn't
-                        //       need to be matched normally, but there is a bug in
-                        //       crossterm 0.23 which requires this fix. See:
-                        //       https://github.com/crossterm-rs/crossterm/pull/629
-                        KeyCode::Char('c') | KeyCode::Char('C') => break,
-                        KeyCode::Char('r') | KeyCode::Char('R') => {
+                        KeyCode::Char('c') => break,
+                        KeyCode::Char('r') => {
                             reset_after_flash(&mut *serial, pid)?;
                             continue;
                         }


### PR DESCRIPTION
Confirmed that the monitor still works on macOS after these changes. @bjoernQ would you be able to test this out on Windows when you get a chance please? (No rush)