### PR TITLE
Add `serial-monitor` subcommand 

### DIFF
--- a/cargo-espflash/README.md
+++ b/cargo-espflash/README.md
@@ -81,6 +81,7 @@ SUBCOMMANDS:
     help               Print this message or the help of the given subcommand(s)
     partition-table    Operations for partitions tables
     save-image         Save the image to disk instead of flashing to device
+    serial-monitor     Open the serial monitor without flashing
 ```
 
 ## Configuration

--- a/cargo-espflash/src/main.rs
+++ b/cargo-espflash/src/main.rs
@@ -9,8 +9,8 @@ use cargo_metadata::Message;
 use clap::Parser;
 use espflash::{
     cli::{
-        board_info, connect, flash_elf_image, monitor::monitor, partition_table, save_elf_as_image, serial_monitor,
-        ConnectOpts, FlashConfigOpts, FlashOpts, PartitionTableOpts,
+        board_info, connect, flash_elf_image, monitor::monitor, partition_table, save_elf_as_image,
+        serial_monitor, ConnectOpts, FlashConfigOpts, FlashOpts, PartitionTableOpts,
     },
     Chip, Config, ImageFormatId,
 };

--- a/cargo-espflash/src/main.rs
+++ b/cargo-espflash/src/main.rs
@@ -9,7 +9,7 @@ use cargo_metadata::Message;
 use clap::Parser;
 use espflash::{
     cli::{
-        board_info, connect, flash_elf_image, monitor::monitor, partition_table, save_elf_as_image,
+        board_info, connect, flash_elf_image, monitor::monitor, partition_table, save_elf_as_image, serial_monitor,
         ConnectOpts, FlashConfigOpts, FlashOpts, PartitionTableOpts,
     },
     Chip, Config, ImageFormatId,
@@ -56,6 +56,8 @@ pub enum SubCommand {
     BoardInfo(ConnectOpts),
     /// Save the image to disk instead of flashing to device
     SaveImage(SaveImageOpts),
+    /// Open the serial monitor without flashing
+    SerialMonitor(ConnectOpts),
     /// Operations for partitions tables
     PartitionTable(PartitionTableOpts),
 }
@@ -128,6 +130,7 @@ fn main() -> Result<()> {
         match subcommand {
             BoardInfo(opts) => board_info(opts, config),
             SaveImage(opts) => save_image(opts, metadata, cargo_config),
+            SerialMonitor(opts) => serial_monitor(opts, config),
             PartitionTable(opts) => partition_table(opts),
         }
     } else {
@@ -200,7 +203,7 @@ fn flash(
 
     if opts.flash_opts.monitor {
         let pid = flasher.get_usb_pid()?;
-        monitor(flasher.into_serial(), &elf_data, pid).into_diagnostic()?;
+        monitor(flasher.into_serial(), Some(&elf_data), pid).into_diagnostic()?;
     }
 
     Ok(())

--- a/espflash/README.md
+++ b/espflash/README.md
@@ -64,6 +64,8 @@ SUBCOMMANDS:
     help               Print this message or the help of the given subcommand(s)
     partition-table    Operations for partitions tables
     save-image         Save the image to disk instead of flashing to device
+    serial-monitor     Open the serial monitor without flashing
+    write-bin-to-flash    Writes a binary file to a specific address in the chip's flash
 ```
 
 ## Configuration

--- a/espflash/README.md
+++ b/espflash/README.md
@@ -60,12 +60,12 @@ OPTIONS:
             Print version information
 
 SUBCOMMANDS:
-    board-info         Display information about the connected board and exit without flashing
-    help               Print this message or the help of the given subcommand(s)
-    partition-table    Operations for partitions tables
-    save-image         Save the image to disk instead of flashing to device
-    serial-monitor     Open the serial monitor without flashing
-    write-bin-to-flash    Writes a binary file to a specific address in the chip's flash
+    board-info              Display information about the connected board and exit without flashing
+    help                    Print this message or the help of the given subcommand(s)
+    partition-table         Operations for partitions tables
+    save-image              Save the image to disk instead of flashing to device
+    serial-monitor          Open the serial monitor without flashing
+    write-bin-to-flash      Writes a binary file to a specific address in the chip's flash
 ```
 
 ## Configuration

--- a/espflash/src/cli/mod.rs
+++ b/espflash/src/cli/mod.rs
@@ -16,8 +16,8 @@ use serialport::{FlowControl, SerialPortType, UsbPortInfo};
 use strum::VariantNames;
 
 use crate::{
-    cli::serial::get_serial_port_info,
     cli::monitor::monitor,
+    cli::serial::get_serial_port_info,
     elf::{ElfFirmwareImage, FlashFrequency, FlashMode},
     error::Error,
     flasher::FlashSize,

--- a/espflash/src/cli/mod.rs
+++ b/espflash/src/cli/mod.rs
@@ -17,6 +17,7 @@ use strum::VariantNames;
 
 use crate::{
     cli::serial::get_serial_port_info,
+    cli::monitor::monitor,
     elf::{ElfFirmwareImage, FlashFrequency, FlashMode},
     error::Error,
     flasher::FlashSize,
@@ -134,6 +135,14 @@ pub fn connect(opts: &ConnectOpts, config: &Config) -> Result<Flasher> {
 pub fn board_info(opts: ConnectOpts, config: Config) -> Result<()> {
     let mut flasher = connect(&opts, &config)?;
     flasher.board_info()?;
+
+    Ok(())
+}
+
+pub fn serial_monitor(opts: ConnectOpts, config: Config) -> Result<()> {
+    let flasher = connect(&opts, &config)?;
+    let pid = flasher.get_usb_pid()?;
+    monitor(flasher.into_serial(), None, pid).into_diagnostic()?;
 
     Ok(())
 }

--- a/espflash/src/cli/monitor.rs
+++ b/espflash/src/cli/monitor.rs
@@ -83,7 +83,11 @@ impl Drop for RawModeGuard {
     }
 }
 
-pub fn monitor(mut serial: Box<dyn SerialPort>, elf: Option<&[u8]>, pid: u16) -> serialport::Result<()> {
+pub fn monitor(
+    mut serial: Box<dyn SerialPort>,
+    elf: Option<&[u8]>,
+    pid: u16,
+) -> serialport::Result<()> {
     println!("Commands:");
     println!("    CTRL+R    Reset chip");
     println!("    CTRL+C    Exit");
@@ -102,9 +106,7 @@ pub fn monitor(mut serial: Box<dyn SerialPort>, elf: Option<&[u8]>, pid: u16) ->
     if let Some(elf) = elf {
         let symbols = load_bin_context(elf).ok();
         serial_state = SerialState::new(symbols);
-    }
-    else
-    {
+    } else {
         serial_state = SerialState::new(None);
         reset_after_flash(&mut *serial, pid)?;
     }

--- a/espflash/src/main.rs
+++ b/espflash/src/main.rs
@@ -3,9 +3,9 @@ use std::{fs, mem::swap, path::PathBuf, str::FromStr};
 use clap::{IntoApp, Parser};
 use espflash::{
     cli::{
-        board_info, connect, flash_elf_image, monitor::monitor, partition_table, save_elf_as_image, serial_monitor,
-        write_bin_to_flash, ConnectOpts, FlashConfigOpts, FlashOpts, PartitionTableOpts,
-        WriteBinToFlashOpts,
+        board_info, connect, flash_elf_image, monitor::monitor, partition_table, save_elf_as_image,
+        serial_monitor, write_bin_to_flash, ConnectOpts, FlashConfigOpts, FlashOpts,
+        PartitionTableOpts, WriteBinToFlashOpts,
     },
     Chip, Config, ImageFormatId,
 };

--- a/espflash/src/main.rs
+++ b/espflash/src/main.rs
@@ -3,7 +3,7 @@ use std::{fs, mem::swap, path::PathBuf, str::FromStr};
 use clap::{IntoApp, Parser};
 use espflash::{
     cli::{
-        board_info, connect, flash_elf_image, monitor::monitor, partition_table, save_elf_as_image,
+        board_info, connect, flash_elf_image, monitor::monitor, partition_table, save_elf_as_image, serial_monitor,
         write_bin_to_flash, ConnectOpts, FlashConfigOpts, FlashOpts, PartitionTableOpts,
         WriteBinToFlashOpts,
     },
@@ -35,6 +35,8 @@ pub enum SubCommand {
     BoardInfo(ConnectOpts),
     /// Save the image to disk instead of flashing to device
     SaveImage(SaveImageOpts),
+    /// Open the serial monitor without flashing
+    SerialMonitor(ConnectOpts),
     /// Operations for partitions tables
     PartitionTable(PartitionTableOpts),
     /// Writes a binary file to a specific address in the chip's flash
@@ -94,6 +96,7 @@ fn main() -> Result<()> {
         match subcommand {
             BoardInfo(opts) => board_info(opts, config),
             SaveImage(opts) => save_image(opts),
+            SerialMonitor(opts) => serial_monitor(opts, config),
             PartitionTable(opts) => partition_table(opts),
             WriteBinToFlash(opts) => write_bin_to_flash(opts),
         }
@@ -142,7 +145,7 @@ fn flash(opts: Opts, config: Config) -> Result<()> {
 
     if opts.flash_opts.monitor {
         let pid = flasher.get_usb_pid()?;
-        monitor(flasher.into_serial(), &elf_data, pid).into_diagnostic()?;
+        monitor(flasher.into_serial(), Some(&elf_data), pid).into_diagnostic()?;
     }
 
     Ok(())


### PR DESCRIPTION
Include `serial-monitor` subcommand in `cargo-espflash` and `espflash` to allow monitoring a serial monitor without flashing.
Closes #197 