### PR TITLE
Fix direct-boot image check for ESP32-S3

### DIFF
--- a/espflash/src/chip/esp32/esp32c2.rs
+++ b/espflash/src/chip/esp32/esp32c2.rs
@@ -84,7 +84,7 @@ impl ChipType for Esp32c2 {
                 flash_size,
                 flash_freq,
             )?)),
-            ImageFormatId::DirectBoot => Ok(Box::new(Esp32DirectBootFormat::new(image)?)),
+            ImageFormatId::DirectBoot => Ok(Box::new(Esp32DirectBootFormat::new(image, 0)?)),
         }
     }
 

--- a/espflash/src/chip/esp32/esp32c3.rs
+++ b/espflash/src/chip/esp32/esp32c3.rs
@@ -84,7 +84,7 @@ impl ChipType for Esp32c3 {
                 flash_freq,
             )?)),
             (ImageFormatId::DirectBoot, None | Some(3..)) => {
-                Ok(Box::new(Esp32DirectBootFormat::new(image)?))
+                Ok(Box::new(Esp32DirectBootFormat::new(image, 0)?))
             }
             _ => Err(
                 UnsupportedImageFormatError::new(image_format, Chip::Esp32c3, chip_revision).into(),

--- a/espflash/src/chip/esp32/esp32s3.rs
+++ b/espflash/src/chip/esp32/esp32s3.rs
@@ -76,7 +76,7 @@ impl ChipType for Esp32s3 {
                 flash_size,
                 flash_freq,
             )?)),
-            ImageFormatId::DirectBoot => Ok(Box::new(Esp32DirectBootFormat::new(image)?)),
+            ImageFormatId::DirectBoot => Ok(Box::new(Esp32DirectBootFormat::new(image, 0x400)?)),
         }
     }
 }

--- a/espflash/src/image_format/esp32directboot.rs
+++ b/espflash/src/image_format/esp32directboot.rs
@@ -12,7 +12,7 @@ pub struct Esp32DirectBootFormat<'a> {
 }
 
 impl<'a> Esp32DirectBootFormat<'a> {
-    pub fn new(image: &'a dyn FirmwareImage<'a>) -> Result<Self, Error> {
+    pub fn new(image: &'a dyn FirmwareImage<'a>, magic_position: usize) -> Result<Self, Error> {
         let mut segment = image
             .segments_with_load_addresses()
             .map(|mut segment| {
@@ -26,8 +26,10 @@ impl<'a> Esp32DirectBootFormat<'a> {
             });
         segment.pad_align(4);
 
+        // TODO different for ESP32-S3 - this is only for C3!
         if segment.addr != 0
-            || segment.data()[0..8] != [0x1d, 0x04, 0xdb, 0xae, 0x1d, 0x04, 0xdb, 0xae]
+            || segment.data()[magic_position..][..8]
+                != [0x1d, 0x04, 0xdb, 0xae, 0x1d, 0x04, 0xdb, 0xae]
         {
             return Err(Error::InvalidDirectBootBinary);
         }


### PR DESCRIPTION
Unlike the ESP32-C3 the magic bytes to identify a direct-boot image is at offset 0x400.