### PR TITLE
Add support for custom partition types and sub-types

### DIFF
--- a/espflash/src/error.rs
+++ b/espflash/src/error.rs
@@ -13,7 +13,7 @@ use crate::{
     elf::{FlashFrequency, FlashMode},
     flasher::FlashSize,
     image_format::ImageFormatId,
-    partition_table::{SubType, Type},
+    partition_table::{CoreType, SubType, Type},
     Chip,
 };
 
@@ -413,9 +413,10 @@ impl CSVError {
             help = format!(
                 "the following sub-types are supported:
     {} for data partitions
-    {} for app partitions\n\n",
-                Type::Data.subtype_hint(),
-                Type::App.subtype_hint()
+    {} for app partitions
+    0x00-0xFE for custom partitions\n\n",
+                CoreType::Data.subtype_hint(),
+                CoreType::App.subtype_hint()
             )
         }
 

--- a/espflash/src/image_format/esp32bootloader.rs
+++ b/espflash/src/image_format/esp32bootloader.rs
@@ -13,7 +13,7 @@ use crate::{
     error::{Error, FlashDetectError},
     flasher::FlashSize,
     image_format::{EspCommonHeader, ImageFormat, SegmentHeader, ESP_MAGIC, WP_PIN_DISABLED},
-    partition_table::Type,
+    partition_table::{CoreType, Type},
     Chip, PartitionTable,
 };
 
@@ -158,7 +158,7 @@ impl<'a> Esp32BootloaderFormat<'a> {
         // partition, and use any available "app" partitions if not present.
         let factory_partition = partition_table
             .find("factory")
-            .or_else(|| partition_table.find_by_type(Type::App))
+            .or_else(|| partition_table.find_by_type(Type::CoreType(CoreType::App)))
             .unwrap();
 
         let flash_segment = RomSegment {


### PR DESCRIPTION
Adds support for custom partition types and sub-types. Refer to the ESP-IDF partition table documentation for more information on these:  
https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/partition-tables.html

@ollpu would you be able to test out this PR and confirm it is working for you, please?

Closes #219 