### PR TITLE
Wait for FlashDeflateEnd ack

### DIFF
--- a/espflash/src/flash_target/esp32.rs
+++ b/espflash/src/flash_target/esp32.rs
@@ -159,7 +159,7 @@ impl FlashTarget for Esp32Target {
 
     fn finish(&mut self, connection: &mut Connection, reboot: bool) -> Result<(), Error> {
         connection.with_timeout(CommandType::FlashDeflateEnd.timeout(), |connection| {
-            connection.write_command(Command::FlashDeflateEnd { reboot: false })
+            connection.command(Command::FlashDeflateEnd { reboot: false })
         })?;
         if reboot {
             connection.reset()


### PR DESCRIPTION
When using the stub, the data sent in FlashDeflateData is not actually
written to flash until after the ack is sent by the stub. Waiting for
FlashDeflateEnd ensures that all data sent during with FlashDeflateData
has been fully written.