### PR TITLE
Add support for erasing otadata

### DIFF
--- a/cargo-espflash/src/main.rs
+++ b/cargo-espflash/src/main.rs
@@ -140,9 +140,14 @@ fn main() -> Result<()> {
         .init();
 
     // Extract subcommand
-    let CargoSubCommand::Espflash(opts) = opts.subcommand;
+    let CargoSubCommand::Espflash(mut opts) = opts.subcommand;
 
     debug!("subcommand options: {:?}", opts);
+
+    // `erase_otadata` requires `use_stub`
+    if opts.flash_opts.erase_otadata {
+        opts.connect_opts.use_stub = true;
+    }
 
     // Load configuration and metadata
     let config = Config::load()?;
@@ -223,6 +228,7 @@ fn flash(
             opts.build_opts.flash_config_opts.flash_mode,
             opts.build_opts.flash_config_opts.flash_size,
             opts.build_opts.flash_config_opts.flash_freq,
+            opts.flash_opts.erase_otadata,
         )?;
     }
 

--- a/espflash/src/error.rs
+++ b/espflash/src/error.rs
@@ -366,6 +366,9 @@ pub enum PartitionTableError {
     #[error(transparent)]
     #[diagnostic(transparent)]
     InvalidPartitionTable(#[from] InvalidPartitionTable),
+    #[error(transparent)]
+    #[diagnostic(transparent)]
+    MissingPartitionTable(#[from] MissingPartitionTable),
 }
 
 #[derive(Debug, Error, Diagnostic)]
@@ -536,7 +539,14 @@ impl NoAppError {
         }
     }
 }
+#[derive(Debug, Error, Diagnostic)]
+#[error("No otadata partition was found")]
+#[diagnostic(
+    code(espflash::partition_table::no_otadata),
+    help("Partition table must contain an otadata partition when trying to erase it")
+)]
 
+pub struct NoOtadataError;
 #[derive(Debug, Error, Diagnostic)]
 #[error("Unaligned partition")]
 #[diagnostic(code(espflash::partition_table::unaligned))]
@@ -575,6 +585,11 @@ pub struct NoEndMarker;
 #[error("Invalid partition table")]
 #[diagnostic(code(espflash::partition_table::invalid_partition_table))]
 pub struct InvalidPartitionTable;
+
+#[derive(Debug, Error, Diagnostic)]
+#[error("Missing partition table")]
+#[diagnostic(code(espflash::partition_table::missing_partition_table))]
+pub struct MissingPartitionTable;
 
 #[derive(Debug, Error)]
 #[error("{0}")]

--- a/espflash/src/flasher.rs
+++ b/espflash/src/flasher.rs
@@ -635,6 +635,18 @@ impl Flasher {
     pub fn get_usb_pid(&self) -> Result<u16, Error> {
         self.connection.get_usb_pid()
     }
+
+    pub fn erase_region(&mut self, offset: u32, size: u32) -> Result<(), Error> {
+        debug!("Erasing region of 0x{:x}B at 0x{:08x}", size, offset);
+
+        self.connection
+            .with_timeout(CommandType::EraseRegion.timeout(), |connection| {
+                connection.command(Command::EraseRegion { offset, size, })
+            })?;
+        std::thread::sleep(Duration::from_secs_f32(0.05));
+        self.connection.flush()?;
+        Ok(())
+    }
 }
 
 pub(crate) fn get_erase_size(offset: usize, size: usize) -> usize {

--- a/espflash/src/lib.rs
+++ b/espflash/src/lib.rs
@@ -1,7 +1,7 @@
 pub use chip::Chip;
 pub use cli::config::Config;
 pub use elf::{FlashFrequency, FlashMode};
-pub use error::{Error, InvalidPartitionTable};
+pub use error::{Error, InvalidPartitionTable, MissingPartitionTable};
 pub use flasher::{FlashSize, Flasher};
 pub use image_format::ImageFormatId;
 pub use partition_table::PartitionTable;

--- a/espflash/src/main.rs
+++ b/espflash/src/main.rs
@@ -92,6 +92,10 @@ fn main() -> Result<()> {
 
     debug!("options: {:?}", opts);
 
+    if opts.flash_opts.erase_otadata {
+        opts.connect_opts.use_stub = true;
+    }
+
     // Setup logging
     tracing_subscriber::fmt()
         .with_env_filter(EnvFilter::from_default_env().add_directive(opts.log_level.into()))
@@ -164,6 +168,7 @@ fn flash(opts: Opts, config: Config) -> Result<()> {
             opts.flash_config_opts.flash_mode,
             opts.flash_config_opts.flash_size,
             opts.flash_config_opts.flash_freq,
+            opts.flash_opts.erase_otadata,
         )?;
     }
 

--- a/espflash/src/partition_table.rs
+++ b/espflash/src/partition_table.rs
@@ -662,6 +662,10 @@ impl Partition {
         self.offset
     }
 
+    pub fn size(&self) -> u32 {
+        self.size
+    }
+
     pub fn flags(&self) -> Option<Flags> {
         self.flags
     }


### PR DESCRIPTION
Closes #119

This PR adds a `--erase-otadata` argument when flashing.

This will force using stub since it's using the `ERASE_REGION` command.
I also implemented the `ERASE_FLASH` command but didn't do any particular test nor did I implement an argument switch to use it.

I guess implementing two other commands for both `ERASE_REGION` and `ERASE_FLASH` would make sense, but having a first support for erasing the otadata partition thus allowing to reflash the chip after an OTA update seems more of a priority.