### PR TITLE
Allow skipping the padding for image files

### DIFF
--- a/cargo-espflash/src/main.rs
+++ b/cargo-espflash/src/main.rs
@@ -124,6 +124,9 @@ pub struct SaveImageOpts {
     /// Custom partition table for merging
     #[clap(long, short = 'T')]
     pub partition_table: Option<PathBuf>,
+    /// Don't pad the image to the flash size
+    #[clap(long, short = 'P')]
+    pub skip_padding: bool,
 }
 
 fn main() -> Result<()> {
@@ -423,6 +426,7 @@ fn save_image(
         opts.merge,
         bootloader,
         partition_table,
+        opts.skip_padding,
     )?;
 
     Ok(())

--- a/espflash/src/main.rs
+++ b/espflash/src/main.rs
@@ -79,6 +79,9 @@ pub struct SaveImageOpts {
     /// Custom partition table for merging
     #[clap(long, short = 'T')]
     pub partition_table: Option<PathBuf>,
+    /// Don't pad the image to the flash size
+    #[clap(long, short = 'P')]
+    pub skip_padding: bool,
 }
 
 fn main() -> Result<()> {
@@ -197,6 +200,7 @@ fn save_image(opts: SaveImageOpts) -> Result<()> {
         opts.merge,
         opts.bootloader,
         opts.partition_table,
+        opts.skip_padding,
     )?;
 
     Ok(())


### PR DESCRIPTION
Currently `espflash` creates a 16MB image when specifying a flash size of 16MB. When mass producing devices a flash size of 16MB significantly slows down the flashing process without any benefit.

In order to not break backwards compatibility and expectations a new command line switch has been introduced `--skip-padding`, which reduces the image size to only what is really used.