### PR TITLE
Add option --bin for choosing one binary when there are more than one binaries

### DIFF
--- a/cargo-espflash/src/main.rs
+++ b/cargo-espflash/src/main.rs
@@ -84,6 +84,9 @@ pub struct BuildOpts {
     /// Example to build and flash
     #[clap(long)]
     pub example: Option<String>,
+    /// Binary to build and flash
+    #[clap(long)]
+    pub bin: Option<String>,
     /// Specify a (binary) package within a workspace to be built
     #[clap(long)]
     pub package: Option<String>,
@@ -285,6 +288,11 @@ fn build(
     if let Some(example) = &build_options.example {
         args.push("--example".to_string());
         args.push(example.to_string());
+    }
+
+    if let Some(bin) = &build_options.bin {
+        args.push("--bin".to_string());
+        args.push(bin.to_string());
     }
 
     if let Some(package) = &build_options.package {


### PR DESCRIPTION
A beginner in esp decided to build several slightly different binaries by placing the source codes in `src/bin` in the same project. The following error message is produced when the binary to flash is not specified:

```
 Error: cargo_espflash::multiple_artifacts
 
   × Failed to build project
   ╰─▶ Multiple build artifacts found
  help: Please specify which artifact to flash using --bin
```

Running `cargo espflash --bin myapp1 /dev/ttyACM0` doesn't seem to solve it, though, with this message:

```
error: Found argument '--bin' which wasn't expected, or isn't valid in this context

      If you tried to supply `--bin` as a value rather than a flag, use `-- --bin`
```

This commit adds the option `--bin` to build_options, which has worked in my case.