### PR TITLE
Support using the built-in UART peripherials of a Raspberry Pi

### DIFF
--- a/.github/workflows/rpi.yml
+++ b/.github/workflows/rpi.yml
@@ -67,7 +67,7 @@ jobs:
           echo "CARGO_TARGET_ARMV7_UNKNOWN_LINUX_GNUEABIHF_LINKER=arm-linux-gnueabihf-gcc" >> $GITHUB_ENV
 
       - name: Build binary
-        run: cargo build --release --all --target=${{ inputs.target }}
+        run: cargo build --release --all --target=${{ inputs.target }} --features=raspberry
 
       - uses: papeloto/action-zip@v1
         with:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -526,6 +526,7 @@ dependencies = [
  "miette",
  "parse_int",
  "regex",
+ "rppal",
  "serde",
  "serde-hex",
  "serde_json",
@@ -1102,6 +1103,16 @@ dependencies = [
  "untrusted",
  "web-sys",
  "winapi",
+]
+
+[[package]]
+name = "rppal"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c88c9c6248de4d337747b619d8f671055ef48a87dc21b97998833f189a0bbd4f"
+dependencies = [
+ "lazy_static",
+ "libc",
 ]
 
 [[package]]

--- a/cargo-espflash/src/main.rs
+++ b/cargo-espflash/src/main.rs
@@ -222,7 +222,7 @@ fn flash(
     if args.flash_args.monitor {
         let pid = flasher.get_usb_pid()?;
         monitor(
-            flasher.into_serial(),
+            flasher.into_interface(),
             Some(&elf_data),
             pid,
             args.connect_args.monitor_baud.unwrap_or(115_200),

--- a/espflash/Cargo.toml
+++ b/espflash/Cargo.toml
@@ -53,6 +53,7 @@ md5 = "0.7.0"
 miette = { version = "5.3.0", features = ["fancy"] }
 parse_int = "0.6.0"
 regex = "1.6.0"
+rppal = { version = "0.13", optional = true }
 serde = { version = "1.0.144", features = ["derive"] }
 serde-hex = "0.1.0"
 serde_json = "1.0.85"
@@ -70,3 +71,4 @@ xmas-elf = "0.8.0"
 [features]
 default = ["cli"]
 cli = ["clap", "crossterm", "dialoguer", "update-informer"]
+raspberry = ["rppal"]

--- a/espflash/README.md
+++ b/espflash/README.md
@@ -43,6 +43,12 @@ SUBCOMMANDS:
     write-bin          Writes a binary file to a specific address in the chip's flash
 ```
 
+## Compile-time features
+
+ - `raspberry`: enables configuring DTR and RTS GPIOs which are necessary to use a Raspberry Pi's
+   internal UART peripherals. This feature is optional (external USB <-> UART converters work
+   without it) and adds a dependency on [`rppal`](https://crates.io/crates/rppal).
+
 ## Configuration
 
 You can also specify the serial port and/or expected VID/PID values by setting them in the configuration file. This file is in different locations depending on your operating system:

--- a/espflash/src/bin/espflash.rs
+++ b/espflash/src/bin/espflash.rs
@@ -159,7 +159,7 @@ fn flash(mut args: FlashArgs, config: &Config) -> Result<()> {
         let pid = flasher.get_usb_pid()?;
 
         monitor(
-            flasher.into_serial(),
+            flasher.into_interface(),
             Some(&elf_data),
             pid,
             args.connect_args.monitor_baud.unwrap_or(115_200),

--- a/espflash/src/cli/config.rs
+++ b/espflash/src/cli/config.rs
@@ -19,6 +19,10 @@ pub struct Config {
 #[derive(Debug, Deserialize, Serialize, Default, Clone)]
 pub struct Connection {
     pub serial: Option<String>,
+    #[cfg(feature = "raspberry")]
+    pub rts: Option<u8>,
+    #[cfg(feature = "raspberry")]
+    pub dtr: Option<u8>,
 }
 
 #[derive(Debug, Deserialize, Serialize, Default, Clone)]

--- a/espflash/src/error.rs
+++ b/espflash/src/error.rs
@@ -12,6 +12,7 @@ use crate::{
     command::CommandType,
     flasher::{FlashFrequency, FlashMode, FlashSize},
     image_format::ImageFormatId,
+    interface::SerialConfigError,
     partition_table::{CoreType, SubType, Type},
     Chip,
 };
@@ -90,6 +91,12 @@ https://github.com/espressif/esp32c3-direct-boot-example"
         help("Make sure the correct device is connected to the host system")
     )]
     SerialNotFound(String),
+    #[error("Incorrect serial port configuration")]
+    #[diagnostic(
+        code(espflash::serial_config),
+        help("Make sure you have specified the DTR signal if you are using an internal UART peripherial")
+    )]
+    SerialConfiguration(SerialConfigError),
     #[error("Canceled by user")]
     Canceled,
     #[error("The flash mode '{0}' is not valid")]
@@ -242,6 +249,12 @@ impl From<binread::Error> for ConnectionError {
 impl From<binread::Error> for Error {
     fn from(err: binread::Error) -> Self {
         Self::Connection(err.into())
+    }
+}
+
+impl From<SerialConfigError> for Error {
+    fn from(err: SerialConfigError) -> Self {
+        Self::SerialConfiguration(err)
     }
 }
 

--- a/espflash/src/flasher.rs
+++ b/espflash/src/flasher.rs
@@ -2,7 +2,7 @@ use std::{borrow::Cow, str::FromStr, thread::sleep};
 
 use bytemuck::{Pod, Zeroable, __core::time::Duration};
 use log::debug;
-use serialport::{SerialPort, UsbPortInfo};
+use serialport::UsbPortInfo;
 use strum_macros::{Display, EnumVariantNames};
 
 use crate::{
@@ -12,6 +12,7 @@ use crate::{
     elf::{ElfFirmwareImage, FirmwareImage, RomSegment},
     error::{ConnectionError, FlashDetectError, ResultExt},
     image_format::ImageFormatId,
+    interface::Interface,
     stubs::FlashStub,
     Error, PartitionTable,
 };
@@ -277,7 +278,7 @@ pub struct Flasher {
 
 impl Flasher {
     pub fn connect(
-        serial: Box<dyn SerialPort>,
+        serial: Interface,
         port_info: UsbPortInfo,
         speed: Option<u32>,
         use_stub: bool,
@@ -709,10 +710,6 @@ impl Flasher {
         Ok(())
     }
 
-    pub fn into_serial(self) -> Box<dyn SerialPort> {
-        self.connection.into_serial()
-    }
-
     pub fn get_usb_pid(&self) -> Result<u16, Error> {
         self.connection.get_usb_pid()
     }
@@ -727,6 +724,10 @@ impl Flasher {
         std::thread::sleep(Duration::from_secs_f32(0.05));
         self.connection.flush()?;
         Ok(())
+    }
+
+    pub fn into_interface(self) -> Interface {
+        self.connection.into_interface()
     }
 }
 

--- a/espflash/src/interface.rs
+++ b/espflash/src/interface.rs
@@ -1,0 +1,141 @@
+use std::io::Read;
+
+use crate::{cli::ConnectArgs, Config, Error};
+use miette::{Context, Result};
+use serialport::{FlowControl, SerialPort, SerialPortInfo};
+
+#[cfg(feature = "raspberry")]
+use rppal::gpio::{Gpio, OutputPin};
+
+#[derive(thiserror::Error, Debug)]
+pub enum SerialConfigError {
+    #[cfg(feature = "raspberry")]
+    #[error("You need to specify both DTR and RTS pins when using an internal UART peripheral")]
+    MissingDtrRtsForInternalUart,
+
+    #[cfg(feature = "raspberry")]
+    #[error("GPIO {0} is not available")]
+    GpioUnavailable(u8),
+}
+
+/// Wrapper around SerialPort where platform-specific modifications can be implemented.
+pub struct Interface {
+    pub serial_port: Box<dyn SerialPort>,
+    #[cfg(feature = "raspberry")]
+    pub dtr: Option<OutputPin>,
+    #[cfg(feature = "raspberry")]
+    pub rts: Option<OutputPin>,
+}
+
+#[cfg(feature = "raspberry")]
+fn write_gpio(gpio: &mut OutputPin, level: bool) {
+    if level {
+        gpio.set_high();
+    } else {
+        gpio.set_low();
+    }
+}
+
+fn open_port(port_info: &SerialPortInfo) -> Result<Box<dyn SerialPort>> {
+    serialport::new(&port_info.port_name, 115_200)
+        .flow_control(FlowControl::None)
+        .open()
+        .map_err(Error::from)
+        .wrap_err_with(|| format!("Failed to open serial port {}", port_info.port_name))
+}
+
+impl Interface {
+    #[cfg(feature = "raspberry")]
+    pub(crate) fn new(
+        port_info: &SerialPortInfo,
+        args: &ConnectArgs,
+        config: &Config,
+    ) -> Result<Self> {
+        let rts_gpio = args.rts.or(config.connection.rts);
+        let dtr_gpio = args.dtr.or(config.connection.dtr);
+
+        if port_info.port_type == serialport::SerialPortType::Unknown
+            && (dtr_gpio.is_none() || rts_gpio.is_none())
+        {
+            // Assume internal UART, which has no DTR pin and usually no RTS either.
+            return Err(Error::from(SerialConfigError::MissingDtrRtsForInternalUart).into());
+        }
+
+        let gpios = Gpio::new().unwrap();
+
+        let rts = if let Some(gpio) = rts_gpio {
+            match gpios.get(gpio) {
+                Ok(pin) => Some(pin.into_output()),
+                Err(_) => return Err(Error::from(SerialConfigError::GpioUnavailable(gpio)).into()),
+            }
+        } else {
+            None
+        };
+
+        let dtr = if let Some(gpio) = dtr_gpio {
+            match gpios.get(gpio) {
+                Ok(pin) => Some(pin.into_output()),
+                Err(_) => return Err(Error::from(SerialConfigError::GpioUnavailable(gpio)).into()),
+            }
+        } else {
+            None
+        };
+
+        Ok(Self {
+            serial_port: open_port(port_info)?,
+            rts,
+            dtr,
+        })
+    }
+
+    #[cfg(not(feature = "raspberry"))]
+    pub(crate) fn new(
+        port_info: &SerialPortInfo,
+        _args: &ConnectArgs,
+        _config: &Config,
+    ) -> Result<Self> {
+        Ok(Self {
+            serial_port: open_port(port_info)?,
+        })
+    }
+
+    pub fn write_data_terminal_ready(&mut self, pin_state: bool) -> serialport::Result<()> {
+        #[cfg(feature = "raspberry")]
+        if let Some(gpio) = self.dtr.as_mut() {
+            write_gpio(gpio, pin_state);
+            return Ok(());
+        }
+
+        self.serial_port.write_data_terminal_ready(pin_state)
+    }
+
+    pub fn write_request_to_send(&mut self, pin_state: bool) -> serialport::Result<()> {
+        #[cfg(feature = "raspberry")]
+        if let Some(gpio) = self.rts.as_mut() {
+            write_gpio(gpio, pin_state);
+            return Ok(());
+        }
+
+        self.serial_port.write_request_to_send(pin_state)
+    }
+
+    pub fn into_serial(self) -> Box<dyn SerialPort> {
+        self.serial_port
+    }
+
+    pub fn serial_port(&self) -> &dyn SerialPort {
+        self.serial_port.as_ref()
+    }
+
+    pub fn serial_port_mut(&mut self) -> &mut dyn SerialPort {
+        self.serial_port.as_mut()
+    }
+}
+
+// Note(dbuga): this impl is necessary because using `dyn SerialPort` as `dyn Read`
+// requires trait_upcasting which isn't stable yet.
+impl Read for Interface {
+    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        self.serial_port.read(buf)
+    }
+}

--- a/espflash/src/lib.rs
+++ b/espflash/src/lib.rs
@@ -19,6 +19,7 @@ pub mod error;
 pub mod flash_target;
 pub mod flasher;
 pub mod image_format;
+pub mod interface;
 pub mod partition_table;
 pub mod stubs;
 


### PR DESCRIPTION
This PR is heavily in the draft state, especially because ~it requires a nightly compiler at its current state and~ it's currently untested.

Raspberry Pis don't have hardware support for DTR, so their internal UART peripherials can't direcly be used in espflash. This PR adds `rppal` to manage two user-configurable GPIOs as RTS/DTR. This requires some platform-specific code, for which I have introduced the `Interface` struct (name pending), and a cargo feature called `raspberry`.

Some follow up work:
 - [x] I need to actually test if this works
 - [x] espflash now reports an error if 
   - GPIO isn't available (used or doesn't exist)
   - or if DTR is not set for `Unknown` serial ports (assuming internal peripherial is covered here)
 - [x] README has not yet been updated with the RPi-specific input params.
 
~Implementation depends on `trait_upcasting` because of https://github.com/esp-rs/espflash/pull/234/files#diff-9b8216d416248667f4612fb114829cb89c5754ca818d5784b3b0d879ec0d4ee6R266-R267 but the feature has been proposed to be stabilized in https://github.com/rust-lang/rust/pull/101718 I'm open to suggestions if there is a way to avoid this feature requirement.~ See 5a25044 for my solution