### PR TITLE
cargo-espflash: disable build-std check to allow users of cmdline -Zbuild-std

### DIFF
--- a/cargo-espflash/src/cargo_config.rs
+++ b/cargo-espflash/src/cargo_config.rs
@@ -7,26 +7,13 @@ use std::path::{Path, PathBuf};
 #[derive(Debug, Deserialize, Default)]
 pub struct CargoConfig {
     #[serde(default)]
-    unstable: Unstable,
-    #[serde(default)]
     build: Build,
 }
 
 impl CargoConfig {
-    pub fn has_build_std(&self) -> bool {
-        !self.unstable.build_std.is_empty()
-    }
-
     pub fn target(&self) -> Option<&str> {
         self.build.target.as_deref()
     }
-}
-
-#[derive(Debug, Default, Deserialize)]
-#[serde(rename_all = "kebab-case")]
-pub struct Unstable {
-    #[serde(default)]
-    build_std: Vec<String>,
 }
 
 #[derive(Debug, Default, Deserialize)]

--- a/cargo-espflash/src/error.rs
+++ b/cargo-espflash/src/error.rs
@@ -17,16 +17,6 @@ pub enum Error {
               or if you're in a cargo workspace, specify the binary package with `--package`.")
     )]
     NoArtifact,
-    #[error("'build-std' not configured")]
-    #[diagnostic(
-        code(cargo_espflash::build_std),
-        help(
-            "cargo currently requires the unstable 'build-std' feature, ensure \
-            that .cargo/config{{.toml}} has the appropriate options.\n  \
-            \tSee: https://doc.rust-lang.org/cargo/reference/unstable.html#build-std"
-        )
-    )]
-    NoBuildStd,
     #[error("Multiple build artifacts found")]
     #[diagnostic(
         code(cargo_espflash::multiple_artifacts),

--- a/cargo-espflash/src/main.rs
+++ b/cargo-espflash/src/main.rs
@@ -267,14 +267,6 @@ fn build(
         return Err(Error::UnsupportedTarget(UnsupportedTargetError::new(target, chip)).into());
     }
 
-    // The 'build-std' unstable cargo feature is required to enable
-    // cross-compilation for xtensa targets.
-    // If it has not been set then we cannot build the
-    // application.
-    if !cargo_config.has_build_std() && target.starts_with("xtensa-") {
-        return Err(Error::NoBuildStd.into());
-    };
-
     // Build the list of arguments to pass to 'cargo build'. We will always
     // explicitly state the target, as it must be provided as either a command-line
     // argument or in the cargo config file.


### PR DESCRIPTION
Fixes #221

This check does not examine the cmdline arguments, resulting it in improperly blocking use of `cargo-espflash` in some cases for xtensa based esp's.