### PR TITLE
Correctly declare some arguments as requiring --merge

### DIFF
--- a/cargo-espflash/src/main.rs
+++ b/cargo-espflash/src/main.rs
@@ -125,10 +125,10 @@ pub struct SaveImageOpts {
     #[clap(long, short = 'B')]
     pub bootloader: Option<PathBuf>,
     /// Custom partition table for merging
-    #[clap(long, short = 'T')]
+    #[clap(long, short = 'T', requires = "merge")]
     pub partition_table: Option<PathBuf>,
     /// Don't pad the image to the flash size
-    #[clap(long, short = 'P')]
+    #[clap(long, short = 'P', requires = "merge")]
     pub skip_padding: bool,
 }
 

--- a/espflash/src/main.rs
+++ b/espflash/src/main.rs
@@ -77,10 +77,10 @@ pub struct SaveImageOpts {
     #[clap(long, short = 'B')]
     pub bootloader: Option<PathBuf>,
     /// Custom partition table for merging
-    #[clap(long, short = 'T')]
+    #[clap(long, short = 'T', requires = "merge")]
     pub partition_table: Option<PathBuf>,
     /// Don't pad the image to the flash size
-    #[clap(long, short = 'P')]
+    #[clap(long, short = 'P', requires = "merge")]
     pub skip_padding: bool,
 }
 


### PR DESCRIPTION
In the context of `save image`, the `partition_table` and `skip_padding` arguments currently are only consumed inside a conditional block that's behind `if merge`. As such, we should declare this here as well to make it less surprising for users.