### PR TITLE
Refactor: rename image format modules to allow for future expansion

### DIFF
--- a/espflash/src/elf.rs
+++ b/espflash/src/elf.rs
@@ -244,29 +244,3 @@ impl<'a> From<CodeSegment<'a>> for RomSegment<'a> {
         }
     }
 }
-
-pub fn update_checksum(data: &[u8], mut checksum: u8) -> u8 {
-    for byte in data {
-        checksum ^= *byte;
-    }
-
-    checksum
-}
-
-pub fn merge_adjacent_segments(mut segments: Vec<CodeSegment>) -> Vec<CodeSegment> {
-    segments.sort();
-
-    let mut merged: Vec<CodeSegment> = Vec::with_capacity(segments.len());
-    for segment in segments {
-        match merged.last_mut() {
-            Some(last) if last.addr + last.size() == segment.addr => {
-                *last += segment.data();
-            }
-            _ => {
-                merged.push(segment);
-            }
-        }
-    }
-
-    merged
-}

--- a/espflash/src/image_format/direct_boot.rs
+++ b/espflash/src/image_format/direct_boot.rs
@@ -1,35 +1,37 @@
-use crate::elf::CodeSegment;
-use crate::{
-    elf::{FirmwareImage, RomSegment},
-    error::Error,
-    image_format::ImageFormat,
-};
 use std::iter::once;
 
-/// Image format for esp32 family chips not using a 2nd stage bootloader
-pub struct Esp32DirectBootFormat<'a> {
+use super::ImageFormat;
+use crate::{
+    elf::{CodeSegment, FirmwareImage, RomSegment},
+    error::Error,
+};
+
+const DIRECT_BOOT_MAGIC: &[u8] = &[0x1d, 0x04, 0xdb, 0xae, 0x1d, 0x04, 0xdb, 0xae];
+
+/// Image format for ESP32 family chips not using a second-stage bootloader
+pub struct DirectBootFormat<'a> {
     segment: RomSegment<'a>,
 }
 
-impl<'a> Esp32DirectBootFormat<'a> {
+impl<'a> DirectBootFormat<'a> {
     pub fn new(image: &'a dyn FirmwareImage<'a>, magic_offset: usize) -> Result<Self, Error> {
         let mut segment = image
             .segments_with_load_addresses()
             .map(|mut segment| {
-                // map address to the first 4MB
-                segment.addr %= 0x400000;
+                // Map the address to the first 4MB of address space
+                segment.addr %= 0x40_0000;
                 segment
             })
             .fold(CodeSegment::default(), |mut a, b| {
                 a += &b;
                 a
             });
+
         segment.pad_align(4);
 
         if segment.addr != 0
             || (segment.data().len() >= magic_offset + 8
-                && segment.data()[magic_offset..][..8]
-                    != [0x1d, 0x04, 0xdb, 0xae, 0x1d, 0x04, 0xdb, 0xae])
+                && &segment.data()[magic_offset..][..8] != DIRECT_BOOT_MAGIC)
         {
             return Err(Error::InvalidDirectBootBinary);
         }
@@ -40,7 +42,7 @@ impl<'a> Esp32DirectBootFormat<'a> {
     }
 }
 
-impl<'a> ImageFormat<'a> for Esp32DirectBootFormat<'a> {
+impl<'a> ImageFormat<'a> for DirectBootFormat<'a> {
     fn flash_segments<'b>(&'b self) -> Box<dyn Iterator<Item = RomSegment<'b>> + 'b>
     where
         'a: 'b,

--- a/espflash/src/image_format/idf_bootloader.rs
+++ b/espflash/src/image_format/idf_bootloader.rs
@@ -4,27 +4,43 @@ use bytemuck::{bytes_of, from_bytes, Pod, Zeroable};
 use esp_idf_part::{Partition, PartitionTable, Type};
 use sha2::{Digest, Sha256};
 
-use super::encode_flash_frequency;
+use super::{
+    encode_flash_frequency, update_checksum, EspCommonHeader, ImageFormat, SegmentHeader,
+    ESP_MAGIC, WP_PIN_DISABLED,
+};
 use crate::{
-    elf::{
-        merge_adjacent_segments, update_checksum, CodeSegment, FirmwareImage, RomSegment,
-        ESP_CHECKSUM_MAGIC,
-    },
+    elf::{CodeSegment, FirmwareImage, RomSegment, ESP_CHECKSUM_MAGIC},
     error::{Error, FlashDetectError},
     flasher::{FlashFrequency, FlashMode, FlashSize},
-    image_format::{EspCommonHeader, ImageFormat, SegmentHeader, ESP_MAGIC, WP_PIN_DISABLED},
     targets::{Chip, Esp32Params},
 };
 
-/// Image format for esp32 family chips using a 2nd stage bootloader
-pub struct Esp32BootloaderFormat<'a> {
+const IROM_ALIGN: u32 = 0x10000;
+const SEG_HEADER_LEN: u32 = 8;
+
+#[derive(Debug, Default, Clone, Copy, Pod, Zeroable)]
+#[repr(C)]
+struct ExtendedHeader {
+    wp_pin: u8,
+    clk_q_drv: u8,
+    d_cs_drv: u8,
+    gd_wp_drv: u8,
+    chip_id: u16,
+    min_rev: u8,
+    padding: [u8; 8],
+    append_digest: u8,
+}
+
+/// Image format for ESP32 family chips using the second-stage bootloader from
+/// ESP-IDF
+pub struct IdfBootloaderFormat<'a> {
     params: Esp32Params,
     bootloader: Cow<'a, [u8]>,
     partition_table: PartitionTable,
     flash_segment: RomSegment<'a>,
 }
 
-impl<'a> Esp32BootloaderFormat<'a> {
+impl<'a> IdfBootloaderFormat<'a> {
     pub fn new(
         image: &'a dyn FirmwareImage<'a>,
         chip: Chip,
@@ -56,6 +72,7 @@ impl<'a> Esp32BootloaderFormat<'a> {
             header.flash_mode = mode as u8;
             bootloader.to_mut()[2] = bytes_of(&header)[2];
         }
+
         match (flash_size, flash_freq) {
             (Some(s), Some(f)) => {
                 header.flash_config = encode_flash_size(s)? + encode_flash_frequency(chip, f)?;
@@ -81,21 +98,18 @@ impl<'a> Esp32BootloaderFormat<'a> {
 
         let extended_header = ExtendedHeader {
             wp_pin: WP_PIN_DISABLED,
-            clk_q_drv: 0,
-            d_cs_drv: 0,
-            gd_wp_drv: 0,
             chip_id: params.chip_id,
-            min_rev: 0,
-            padding: [0; 8],
             append_digest: 1,
-        };
-        data.write_all(bytes_of(&extended_header))?;
 
-        let mut checksum = ESP_CHECKSUM_MAGIC;
+            ..ExtendedHeader::default()
+        };
+
+        data.write_all(bytes_of(&extended_header))?;
 
         let flash_segments: Vec<_> = merge_adjacent_segments(image.rom_segments(chip).collect());
         let mut ram_segments: Vec<_> = merge_adjacent_segments(image.ram_segments(chip).collect());
 
+        let mut checksum = ESP_CHECKSUM_MAGIC;
         let mut segment_count = 0;
 
         for segment in flash_segments {
@@ -115,19 +129,23 @@ impl<'a> Esp32BootloaderFormat<'a> {
                             continue;
                         }
                     }
+
                     let pad_header = SegmentHeader {
                         addr: 0,
                         length: pad_len as u32,
                     };
                     data.write_all(bytes_of(&pad_header))?;
+
                     for _ in 0..pad_len {
                         data.write_all(&[0])?;
                     }
+
                     segment_count += 1;
                 } else {
                     break;
                 }
             }
+
             checksum = save_flash_segment(&mut data, segment, checksum)?;
             segment_count += 1;
         }
@@ -160,7 +178,7 @@ impl<'a> Esp32BootloaderFormat<'a> {
             .or_else(|| partition_table.find_by_type(Type::App))
             .unwrap();
 
-        Self::check_partition_stats(factory_partition, &data)?;
+        check_partition_stats(factory_partition, &data)?;
 
         let flash_segment = RomSegment {
             addr: factory_partition.offset(),
@@ -174,25 +192,9 @@ impl<'a> Esp32BootloaderFormat<'a> {
             flash_segment,
         })
     }
-
-    fn check_partition_stats(part: &Partition, data: &Vec<u8>) -> Result<(), Error> {
-        let perc = data.len() as f32 / part.size() as f32 * 100.0;
-        println!(
-            "App/part. size:    {}/{} bytes, {:.2}%",
-            data.len(),
-            part.size(),
-            perc
-        );
-
-        if perc > 100.0 {
-            return Err(Error::ElfTooBig);
-        }
-
-        Ok(())
-    }
 }
 
-impl<'a> ImageFormat<'a> for Esp32BootloaderFormat<'a> {
+impl<'a> ImageFormat<'a> for IdfBootloaderFormat<'a> {
     fn flash_segments<'b>(&'b self) -> Box<dyn Iterator<Item = RomSegment<'b>> + 'b>
     where
         'a: 'b,
@@ -234,8 +236,21 @@ fn encode_flash_size(size: FlashSize) -> Result<u8, FlashDetectError> {
     }
 }
 
-const IROM_ALIGN: u32 = 65536;
-const SEG_HEADER_LEN: u32 = 8;
+fn check_partition_stats(part: &Partition, data: &Vec<u8>) -> Result<(), Error> {
+    let perc = data.len() as f32 / part.size() as f32 * 100.0;
+    println!(
+        "App/part. size:    {}/{} bytes, {:.2}%",
+        data.len(),
+        part.size(),
+        perc
+    );
+
+    if perc > 100.0 {
+        return Err(Error::ElfTooBig);
+    }
+
+    Ok(())
+}
 
 /// Actual alignment (in data bytes) required for a segment header: positioned
 /// so that after we write the next 8 byte header, file_offs % IROM_ALIGN ==
@@ -246,6 +261,7 @@ const SEG_HEADER_LEN: u32 = 8;
 fn get_segment_padding(offset: usize, segment: &CodeSegment) -> u32 {
     let align_past = (segment.addr - SEG_HEADER_LEN) % IROM_ALIGN;
     let pad_len = ((IROM_ALIGN - ((offset as u32) % IROM_ALIGN)) + align_past) % IROM_ALIGN;
+
     if pad_len == 0 || pad_len == IROM_ALIGN {
         0
     } else if pad_len > SEG_HEADER_LEN {
@@ -253,6 +269,24 @@ fn get_segment_padding(offset: usize, segment: &CodeSegment) -> u32 {
     } else {
         pad_len + IROM_ALIGN - SEG_HEADER_LEN
     }
+}
+
+fn merge_adjacent_segments(mut segments: Vec<CodeSegment>) -> Vec<CodeSegment> {
+    segments.sort();
+
+    let mut merged: Vec<CodeSegment> = Vec::with_capacity(segments.len());
+    for segment in segments {
+        match merged.last_mut() {
+            Some(last) if last.addr + last.size() == segment.addr => {
+                *last += segment.data();
+            }
+            _ => {
+                merged.push(segment);
+            }
+        }
+    }
+
+    merged
 }
 
 fn save_flash_segment(
@@ -279,11 +313,11 @@ fn save_flash_segment(
 
 fn save_segment(data: &mut Vec<u8>, segment: &CodeSegment, checksum: u8) -> Result<u8, Error> {
     let padding = (4 - segment.size() % 4) % 4;
-
     let header = SegmentHeader {
         addr: segment.addr,
         length: segment.size() + padding,
     };
+
     data.write_all(bytes_of(&header))?;
     data.write_all(segment.data())?;
 
@@ -291,17 +325,4 @@ fn save_segment(data: &mut Vec<u8>, segment: &CodeSegment, checksum: u8) -> Resu
     data.write_all(padding)?;
 
     Ok(update_checksum(segment.data(), checksum))
-}
-
-#[derive(Copy, Clone, Zeroable, Pod)]
-#[repr(C)]
-struct ExtendedHeader {
-    wp_pin: u8,
-    clk_q_drv: u8,
-    d_cs_drv: u8,
-    gd_wp_drv: u8,
-    chip_id: u16,
-    min_rev: u8,
-    padding: [u8; 8],
-    append_digest: u8,
 }

--- a/espflash/src/targets/esp32.rs
+++ b/espflash/src/targets/esp32.rs
@@ -8,7 +8,7 @@ use crate::{
     elf::FirmwareImage,
     error::{Error, UnsupportedImageFormatError},
     flasher::{FlashFrequency, FlashMode, FlashSize},
-    image_format::{Esp32BootloaderFormat, ImageFormat, ImageFormatId},
+    image_format::{IdfBootloaderFormat, ImageFormat, ImageFormatId},
 };
 
 const CHIP_DETECT_MAGIC_VALUES: &[u32] = &[0x00f0_1d83];
@@ -159,7 +159,7 @@ impl Target for Esp32 {
         let image_format = image_format.unwrap_or(ImageFormatId::Bootloader);
 
         match image_format {
-            ImageFormatId::Bootloader => Ok(Box::new(Esp32BootloaderFormat::new(
+            ImageFormatId::Bootloader => Ok(Box::new(IdfBootloaderFormat::new(
                 image,
                 Chip::Esp32,
                 PARAMS,

--- a/espflash/src/targets/esp32c2.rs
+++ b/espflash/src/targets/esp32c2.rs
@@ -8,7 +8,7 @@ use crate::{
     elf::FirmwareImage,
     error::Error,
     flasher::{FlashFrequency, FlashMode, FlashSize},
-    image_format::{Esp32BootloaderFormat, Esp32DirectBootFormat, ImageFormat, ImageFormatId},
+    image_format::{DirectBootFormat, IdfBootloaderFormat, ImageFormat, ImageFormatId},
 };
 
 pub(crate) const CHIP_DETECT_MAGIC_VALUES: &[u32] = &[
@@ -95,7 +95,7 @@ impl Target for Esp32c2 {
         let image_format = image_format.unwrap_or(ImageFormatId::Bootloader);
 
         match image_format {
-            ImageFormatId::Bootloader => Ok(Box::new(Esp32BootloaderFormat::new(
+            ImageFormatId::Bootloader => Ok(Box::new(IdfBootloaderFormat::new(
                 image,
                 Chip::Esp32c2,
                 PARAMS,
@@ -105,7 +105,7 @@ impl Target for Esp32c2 {
                 flash_size,
                 flash_freq,
             )?)),
-            ImageFormatId::DirectBoot => Ok(Box::new(Esp32DirectBootFormat::new(image, 0)?)),
+            ImageFormatId::DirectBoot => Ok(Box::new(DirectBootFormat::new(image, 0)?)),
         }
     }
 

--- a/espflash/src/targets/esp32c3.rs
+++ b/espflash/src/targets/esp32c3.rs
@@ -8,7 +8,7 @@ use crate::{
     elf::FirmwareImage,
     error::{Error, UnsupportedImageFormatError},
     flasher::{FlashFrequency, FlashMode, FlashSize},
-    image_format::{Esp32BootloaderFormat, Esp32DirectBootFormat, ImageFormat, ImageFormatId},
+    image_format::{DirectBootFormat, IdfBootloaderFormat, ImageFormat, ImageFormatId},
 };
 
 pub(crate) const CHIP_DETECT_MAGIC_VALUES: &[u32] = &[
@@ -82,7 +82,7 @@ impl Target for Esp32c3 {
         let image_format = image_format.unwrap_or(ImageFormatId::Bootloader);
 
         match (image_format, chip_revision) {
-            (ImageFormatId::Bootloader, _) => Ok(Box::new(Esp32BootloaderFormat::new(
+            (ImageFormatId::Bootloader, _) => Ok(Box::new(IdfBootloaderFormat::new(
                 image,
                 Chip::Esp32c3,
                 PARAMS,
@@ -93,7 +93,7 @@ impl Target for Esp32c3 {
                 flash_freq,
             )?)),
             (ImageFormatId::DirectBoot, None | Some(3..)) => {
-                Ok(Box::new(Esp32DirectBootFormat::new(image, 0)?))
+                Ok(Box::new(DirectBootFormat::new(image, 0)?))
             }
             _ => Err(
                 UnsupportedImageFormatError::new(image_format, Chip::Esp32c3, chip_revision).into(),

--- a/espflash/src/targets/esp32s2.rs
+++ b/espflash/src/targets/esp32s2.rs
@@ -8,7 +8,7 @@ use crate::{
     elf::FirmwareImage,
     error::{Error, UnsupportedImageFormatError},
     flasher::{FlashFrequency, FlashMode, FlashSize, FLASH_WRITE_SIZE},
-    image_format::{Esp32BootloaderFormat, ImageFormat, ImageFormatId},
+    image_format::{IdfBootloaderFormat, ImageFormat, ImageFormatId},
 };
 
 const CHIP_DETECT_MAGIC_VALUES: &[u32] = &[0x0000_07c6];
@@ -132,7 +132,7 @@ impl Target for Esp32s2 {
         let image_format = image_format.unwrap_or(ImageFormatId::Bootloader);
 
         match image_format {
-            ImageFormatId::Bootloader => Ok(Box::new(Esp32BootloaderFormat::new(
+            ImageFormatId::Bootloader => Ok(Box::new(IdfBootloaderFormat::new(
                 image,
                 Chip::Esp32s2,
                 PARAMS,

--- a/espflash/src/targets/esp32s3.rs
+++ b/espflash/src/targets/esp32s3.rs
@@ -8,7 +8,7 @@ use crate::{
     elf::FirmwareImage,
     error::Error,
     flasher::{FlashFrequency, FlashMode, FlashSize},
-    image_format::{Esp32BootloaderFormat, Esp32DirectBootFormat, ImageFormat, ImageFormatId},
+    image_format::{DirectBootFormat, IdfBootloaderFormat, ImageFormat, ImageFormatId},
 };
 
 pub(crate) const CHIP_DETECT_MAGIC_VALUES: &[u32] = &[0x9];
@@ -68,7 +68,7 @@ impl Target for Esp32s3 {
         let image_format = image_format.unwrap_or(ImageFormatId::Bootloader);
 
         match image_format {
-            ImageFormatId::Bootloader => Ok(Box::new(Esp32BootloaderFormat::new(
+            ImageFormatId::Bootloader => Ok(Box::new(IdfBootloaderFormat::new(
                 image,
                 Chip::Esp32s3,
                 PARAMS,
@@ -78,7 +78,7 @@ impl Target for Esp32s3 {
                 flash_size,
                 flash_freq,
             )?)),
-            ImageFormatId::DirectBoot => Ok(Box::new(Esp32DirectBootFormat::new(image, 0x400)?)),
+            ImageFormatId::DirectBoot => Ok(Box::new(DirectBootFormat::new(image, 0x400)?)),
         }
     }
 


### PR DESCRIPTION
This is the third in my series of planned refactors, following #245 and #247. This should be it for now, I hope.

Nothing too crazy here:

- Renamed the image formats to be a bit more specific, paves the way for adding additional image formats in the future
    - This is done in anticipation of eventually adding `mcuboot` support
- Moves a couple functions into the modules they belong in