### PR TITLE
Update to `clap@4.0.x`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -212,7 +212,7 @@ version = "2.0.0-dev"
 dependencies = [
  "cargo_metadata",
  "cargo_toml",
- "clap",
+ "clap 4.0.8",
  "env_logger",
  "espflash",
  "log",
@@ -281,13 +281,28 @@ checksum = "86447ad904c7fb335a790c9d7fe3d0d971dc523b8ccd1561a520de9a85302750"
 dependencies = [
  "atty",
  "bitflags",
- "clap_derive",
- "clap_lex",
+ "clap_derive 3.2.18",
+ "clap_lex 0.2.4",
  "indexmap",
  "once_cell",
  "strsim",
  "termcolor",
  "textwrap",
+]
+
+[[package]]
+name = "clap"
+version = "4.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5840cd9093aabeabf7fd932754c435b7674520fc3ddc935c397837050f0f1e4b"
+dependencies = [
+ "atty",
+ "bitflags",
+ "clap_derive 4.0.8",
+ "clap_lex 0.3.0",
+ "once_cell",
+ "strsim",
+ "termcolor",
 ]
 
 [[package]]
@@ -304,10 +319,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap_derive"
+version = "4.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92289ffc6fb4a85d85c246ddb874c05a87a2e540fb6ad52f7ca07c8c1e1840b1"
+dependencies = [
+ "heck",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "clap_lex"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
+dependencies = [
+ "os_str_bytes",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d4198f73e42b4936b35b5bb248d81d2b595ecb170da0bac7655c54eedfa8da8"
 dependencies = [
  "os_str_bytes",
 ]
@@ -607,7 +644,7 @@ dependencies = [
  "base64",
  "binread",
  "bytemuck",
- "clap",
+ "clap 4.0.8",
  "comfy-table",
  "crossterm 0.25.0",
  "dialoguer",
@@ -641,7 +678,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02d8108f9eddda1613b8c558a3bf0a363187e743f9b4825613dd924b9f422e6d"
 dependencies = [
  "addr2line",
- "clap",
+ "clap 3.2.22",
  "crossterm 0.23.2",
  "gimli",
  "lazy_static",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -34,7 +34,7 @@ dependencies = [
  "gimli",
  "object 0.27.1",
  "rustc-demangle",
- "smallvec 1.9.0",
+ "smallvec 1.10.0",
 ]
 
 [[package]]
@@ -247,12 +247,11 @@ dependencies = [
 
 [[package]]
 name = "cargo_toml"
-version = "0.11.8"
+version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e72c3ff59e3b7d24630206bb63a73af65da4ed5df1f76ee84dfafb9fee2ba60e"
+checksum = "6a621d5d6d6c8d086dbaf1fe659981da41a1b63c6bdbba30b4dbb592c6d3bd49"
 dependencies = [
  "serde",
- "serde_derive",
  "toml",
 ]
 
@@ -327,13 +326,13 @@ dependencies = [
 
 [[package]]
 name = "console"
-version = "0.15.1"
+version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89eab4d20ce20cea182308bca13088fecea9c05f6776cf287205d41a0ed3c847"
+checksum = "c050367d967ced717c04b65d8c619d863ef9292ce0c5760028655a2fb298718c"
 dependencies = [
  "encode_unicode",
+ "lazy_static",
  "libc",
- "once_cell",
  "terminal_size",
  "unicode-width",
  "winapi",
@@ -850,9 +849,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.133"
+version = "0.2.134"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0f80d65747a3e43d1596c7c5492d95d5edddaabd45a7fcdb02b95f644164966"
+checksum = "329c933548736bc49fd575ee68c89e8be4d260064184389a5b77517cddd99ffb"
 
 [[package]]
 name = "libudev"
@@ -1079,7 +1078,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "redox_syscall",
- "smallvec 1.9.0",
+ "smallvec 1.10.0",
  "windows-sys",
 ]
 
@@ -1141,9 +1140,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.44"
+version = "1.0.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7bd7356a8122b6c4a24a82b278680c73357984ca2fc79a0f9fa6dea7dced7c58"
+checksum = "94e2ef8dbfc347b10c094890f778ee2e36ca9bb4262e86dc99cd217e35f3470b"
 dependencies = [
  "unicode-ident",
 ]
@@ -1463,9 +1462,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.9.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fd0db749597d91ff862fd1d55ea87f7855a744a8425a64695b6fca237d1dad1"
+checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
 
 [[package]]
 name = "smawk"
@@ -1613,18 +1612,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.36"
+version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a99cb8c4b9a8ef0e7907cd3b617cc8dc04d571c4e73c8ae403d80ac160bb122"
+checksum = "10deb33631e3c9018b9baf9dcbbc4f737320d2b576bac10f6aefa048fa407e3e"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.36"
+version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a891860d3c8d66fec8e73ddb3765f90082374dbaaa833407b904a94f1a7eb43"
+checksum = "982d17546b47146b28f7c22e3d08465f6b8903d0ea13c1660d9d84a6e7adcdbb"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1675,9 +1674,9 @@ checksum = "dcc811dc4066ac62f84f11307873c4850cb653bfa9b1719cee2bd2204a4bc5dd"
 
 [[package]]
 name = "unicode-linebreak"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba853b89cad55680dd3cf06f2798cb1ad8d483f0e2dfa14138d7e789ecee5c4e"
+checksum = "c5faade31a542b8b35855fff6e8def199853b2da8da256da52f52f1316ee3137"
 dependencies = [
  "hashbrown",
  "regex",

--- a/cargo-espflash/Cargo.toml
+++ b/cargo-espflash/Cargo.toml
@@ -32,7 +32,7 @@ pkg-fmt = "zip"
 [dependencies]
 cargo_metadata = "0.15.0"
 cargo_toml = "0.12.2"
-clap = { version = "3.2.22", features = ["derive", "env"] }
+clap = { version = "4.0.8", features = ["derive"] }
 env_logger = "0.9.1"
 espflash = { version = "=2.0.0-dev", path = "../espflash" }
 log = "0.4.17"

--- a/cargo-espflash/Cargo.toml
+++ b/cargo-espflash/Cargo.toml
@@ -31,13 +31,13 @@ pkg-fmt = "zip"
 
 [dependencies]
 cargo_metadata = "0.15.0"
-cargo_toml = "0.11.6"
+cargo_toml = "0.12.2"
 clap = { version = "3.2.22", features = ["derive", "env"] }
-env_logger = "0.9.0"
+env_logger = "0.9.1"
 espflash = { version = "=2.0.0-dev", path = "../espflash" }
 log = "0.4.17"
 miette = { version = "5.3.0", features = ["fancy"] }
-serde = { version = "1.0.144", features = ["derive"] }
+serde = { version = "1.0.145", features = ["derive"] }
 strum = "0.24.1"
-thiserror = "1.0.35"
+thiserror = "1.0.37"
 toml = "0.5.9"

--- a/cargo-espflash/src/error.rs
+++ b/cargo-espflash/src/error.rs
@@ -62,14 +62,17 @@ pub struct TomlError {
 #[derive(Debug)]
 pub enum MaybeTomlError {
     Toml(toml::de::Error),
-    Other(std::io::Error),
+    Io(std::io::Error),
+    Other(&'static str),
 }
 
 impl From<cargo_toml::Error> for MaybeTomlError {
     fn from(e: cargo_toml::Error) -> Self {
         match e {
             cargo_toml::Error::Parse(e) => MaybeTomlError::Toml(e),
-            cargo_toml::Error::Io(e) => MaybeTomlError::Other(e),
+            cargo_toml::Error::Io(e) => MaybeTomlError::Io(e),
+            cargo_toml::Error::Other(e) => MaybeTomlError::Other(e),
+            _ => todo!(), // `cargo_toml::Error` is marked as non-exhaustive
         }
     }
 }

--- a/cargo-espflash/src/main.rs
+++ b/cargo-espflash/src/main.rs
@@ -63,34 +63,34 @@ enum Commands {
 #[derive(Debug, Args)]
 struct BuildArgs {
     /// Binary to build and flash
-    #[clap(long)]
+    #[arg(long)]
     pub bin: Option<String>,
     /// Example to build and flash
-    #[clap(long)]
+    #[arg(long)]
     pub example: Option<String>,
     /// Comma delimited list of build features
-    #[clap(long, use_value_delimiter = true)]
+    #[arg(long, use_value_delimiter = true)]
     pub features: Option<Vec<String>>,
     /// Require Cargo.lock and cache are up to date
-    #[clap(long)]
+    #[arg(long)]
     pub frozen: bool,
     /// Require Cargo.lock is up to date
-    #[clap(long)]
+    #[arg(long)]
     pub locked: bool,
     /// Specify a (binary) package within a workspace to be built
-    #[clap(long)]
+    #[arg(long)]
     pub package: Option<String>,
     /// Build the application using the release profile
-    #[clap(long)]
+    #[arg(long)]
     pub release: bool,
     /// Target to build for
-    #[clap(long)]
+    #[arg(long)]
     pub target: Option<String>,
     /// Directory for all generated artifacts
-    #[clap(long)]
+    #[arg(long)]
     pub target_dir: Option<String>,
     /// Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for details
-    #[clap(short = 'Z')]
+    #[arg(short = 'Z')]
     pub unstable: Option<Vec<String>>,
 
     #[clap(flatten)]
@@ -111,7 +111,7 @@ struct FlashArgs {
 #[derive(Debug, Args)]
 struct SaveImageArgs {
     /// Image format to flash
-    #[clap(long, value_parser = clap_enum_variants!(ImageFormatType))]
+    #[arg(long, value_parser = clap_enum_variants!(ImageFormatType))]
     pub format: Option<String>,
 
     #[clap(flatten)]

--- a/cargo-espflash/src/main.rs
+++ b/cargo-espflash/src/main.rs
@@ -9,10 +9,9 @@ use cargo_metadata::Message;
 use clap::{Args, Parser, Subcommand};
 use espflash::{
     cli::{
-        board_info, clap_enum_variants, config::Config, connect, flash_elf_image, monitor::monitor,
-        partition_table, save_elf_as_image, serial_monitor, ConnectArgs,
-        FlashArgs as BaseFlashArgs, FlashConfigArgs, PartitionTableArgs,
-        SaveImageArgs as BaseSaveImageArgs,
+        self, board_info, clap_enum_variants, config::Config, connect, flash_elf_image,
+        monitor::monitor, partition_table, save_elf_as_image, serial_monitor, ConnectArgs,
+        FlashConfigArgs, PartitionTableArgs,
     },
     image_format::{ImageFormatId, ImageFormatType},
     logging::initialize_logger,
@@ -106,7 +105,7 @@ struct FlashArgs {
     #[clap(flatten)]
     connect_args: ConnectArgs,
     #[clap(flatten)]
-    flash_args: BaseFlashArgs,
+    flash_args: cli::FlashArgs,
 }
 
 #[derive(Debug, Args)]
@@ -118,7 +117,7 @@ struct SaveImageArgs {
     #[clap(flatten)]
     build_args: BuildArgs,
     #[clap(flatten)]
-    save_image_args: BaseSaveImageArgs,
+    save_image_args: cli::SaveImageArgs,
 }
 
 fn main() -> Result<()> {
@@ -227,7 +226,7 @@ fn flash(
             flasher.into_interface(),
             Some(&elf_data),
             pid,
-            args.connect_args.monitor_baud.unwrap_or(115_200),
+            args.flash_args.monitor_baud.unwrap_or(115_200),
         )
         .into_diagnostic()?;
     }

--- a/espflash/Cargo.toml
+++ b/espflash/Cargo.toml
@@ -37,7 +37,7 @@ required-features = ["cli"]
 base64 = "0.13.0"
 binread = "2.2.0"
 bytemuck = { version = "1.12.1", features = ["derive"] }
-clap = { version = "3.2.22", features = ["derive", "env"], optional = true }
+clap = { version = "4.0.8", features = ["derive"], optional = true }
 comfy-table = "6.1.0"
 crossterm = { version = "0.25.0", optional = true }
 dialoguer = { version = "0.10.2", optional = true }

--- a/espflash/Cargo.toml
+++ b/espflash/Cargo.toml
@@ -44,26 +44,26 @@ dialoguer = { version = "0.10.2", optional = true }
 directories-next = "2.0.0"
 esp-idf-part = "0.1.0"
 espmonitor = "0.10.0"
-env_logger = "0.9.0"
+env_logger = "0.9.1"
 flate2 = "1.0.24"
 indicatif = "0.17.1"
 log = "0.4.17"
 miette = { version = "5.3.0", features = ["fancy"] }
 parse_int = "0.6.0"
-rppal = { version = "0.13", optional = true }
-serde = { version = "1.0.144", features = ["derive"] }
+rppal = { version = "0.13.1", optional = true }
+serde = { version = "1.0.145", features = ["derive"] }
 serde-hex = "0.1.0"
 serde_json = "1.0.85"
 serialport = "4.2.0"
 sha2 = "0.10.6"
 slip-codec = "0.3.3"
 strum = { version = "0.24.1", features = ["derive"] }
-thiserror = "1.0.35"
+thiserror = "1.0.37"
 toml = "0.5.9"
 update-informer = { version = "0.5.0", optional = true }
 xmas-elf = "0.8.0"
 
 [features]
 default = ["cli"]
-cli = ["clap", "crossterm", "dialoguer", "update-informer"]
-raspberry = ["rppal"]
+cli = ["dep:clap", "dep:crossterm", "dep:dialoguer", "dep:update-informer"]
+raspberry = ["dep:rppal"]

--- a/espflash/src/bin/espflash.rs
+++ b/espflash/src/bin/espflash.rs
@@ -9,10 +9,9 @@ use std::{
 use clap::{Args, Parser, Subcommand};
 use espflash::{
     cli::{
-        board_info, clap_enum_variants, config::Config, connect, flash_elf_image, monitor::monitor,
-        partition_table, save_elf_as_image, serial_monitor, ConnectArgs,
-        FlashArgs as BaseFlashArgs, FlashConfigArgs, PartitionTableArgs,
-        SaveImageArgs as BaseSaveImageArgs,
+        self, board_info, clap_enum_variants, config::Config, connect, flash_elf_image,
+        monitor::monitor, partition_table, save_elf_as_image, serial_monitor, ConnectArgs,
+        FlashConfigArgs, PartitionTableArgs,
     },
     image_format::{ImageFormatId, ImageFormatType},
     logging::initialize_logger,
@@ -52,7 +51,7 @@ struct FlashArgs {
     #[clap(flatten)]
     pub flash_config_args: FlashConfigArgs,
     #[clap(flatten)]
-    flash_args: BaseFlashArgs,
+    flash_args: cli::FlashArgs,
 }
 
 #[derive(Debug, Args)]
@@ -64,7 +63,7 @@ struct SaveImageArgs {
     #[clap(flatten)]
     pub flash_config_args: FlashConfigArgs,
     #[clap(flatten)]
-    save_image_args: BaseSaveImageArgs,
+    save_image_args: cli::SaveImageArgs,
 
     /// ELF image to flash
     image: PathBuf,
@@ -162,7 +161,7 @@ fn flash(mut args: FlashArgs, config: &Config) -> Result<()> {
             flasher.into_interface(),
             Some(&elf_data),
             pid,
-            args.connect_args.monitor_baud.unwrap_or(115_200),
+            args.flash_args.monitor_baud.unwrap_or(115_200),
         )
         .into_diagnostic()?;
     }

--- a/espflash/src/bin/espflash.rs
+++ b/espflash/src/bin/espflash.rs
@@ -9,9 +9,10 @@ use std::{
 use clap::{Args, Parser, Subcommand};
 use espflash::{
     cli::{
-        board_info, config::Config, connect, flash_elf_image, monitor::monitor, partition_table,
-        save_elf_as_image, serial_monitor, ConnectArgs, FlashArgs as BaseFlashArgs,
-        FlashConfigArgs, PartitionTableArgs, SaveImageArgs as BaseSaveImageArgs,
+        board_info, clap_enum_variants, config::Config, connect, flash_elf_image, monitor::monitor,
+        partition_table, save_elf_as_image, serial_monitor, ConnectArgs,
+        FlashArgs as BaseFlashArgs, FlashConfigArgs, PartitionTableArgs,
+        SaveImageArgs as BaseSaveImageArgs,
     },
     image_format::{ImageFormatId, ImageFormatType},
     logging::initialize_logger,
@@ -22,7 +23,7 @@ use miette::{IntoDiagnostic, Result, WrapErr};
 use strum::VariantNames;
 
 #[derive(Debug, Parser)]
-#[clap(about, propagate_version = true, version)]
+#[clap(about, version, propagate_version = true)]
 struct Cli {
     #[clap(subcommand)]
     subcommand: Commands,
@@ -57,7 +58,7 @@ struct FlashArgs {
 #[derive(Debug, Args)]
 struct SaveImageArgs {
     /// Image format to flash
-    #[clap(long, possible_values = ImageFormatType::VARIANTS)]
+    #[clap(long, value_parser = clap_enum_variants!(ImageFormatType))]
     format: Option<String>,
 
     #[clap(flatten)]

--- a/espflash/src/bin/espflash.rs
+++ b/espflash/src/bin/espflash.rs
@@ -57,7 +57,7 @@ struct FlashArgs {
 #[derive(Debug, Args)]
 struct SaveImageArgs {
     /// Image format to flash
-    #[clap(long, value_parser = clap_enum_variants!(ImageFormatType))]
+    #[arg(long, value_parser = clap_enum_variants!(ImageFormatType))]
     format: Option<String>,
 
     #[clap(flatten)]
@@ -73,7 +73,7 @@ struct SaveImageArgs {
 #[derive(Debug, Args)]
 struct WriteBinArgs {
     /// Address at which to write the binary file
-    #[clap(value_parser = parse_uint32)]
+    #[arg(value_parser = parse_uint32)]
     pub addr: u32,
     /// File containing the binary data to write
     pub bin_file: String,

--- a/espflash/src/cli/mod.rs
+++ b/espflash/src/cli/mod.rs
@@ -54,9 +54,6 @@ pub struct ConnectArgs {
     /// Baud rate at which to communicate with target device
     #[clap(short = 'b', long)]
     pub baud: Option<u32>,
-    /// Baud rate at which to read console output
-    #[clap(long, value_name = "BAUD")]
-    pub monitor_baud: Option<u32>,
     /// Serial port connected to target device
     #[clap(short = 'p', long)]
     pub port: Option<String>,
@@ -90,7 +87,7 @@ pub struct FlashConfigArgs {
 #[group(skip)]
 pub struct FlashArgs {
     /// Path to a binary (.bin) bootloader file
-    #[clap(long)]
+    #[clap(long, value_name = "FILE")]
     pub bootloader: Option<PathBuf>,
     /// Erase the OTA data partition
     /// This is useful when using multiple OTA partitions and still wanting to
@@ -103,8 +100,11 @@ pub struct FlashArgs {
     /// Open a serial monitor after flashing
     #[clap(long)]
     pub monitor: bool,
+    /// Baud rate at which to read console output
+    #[clap(long, requires = "monitor", value_name = "BAUD")]
+    pub monitor_baud: Option<u32>,
     /// Path to a CSV file containing partition table
-    #[clap(long)]
+    #[clap(long, value_name = "FILE")]
     pub partition_table: Option<PathBuf>,
     /// Load the application to RAM instead of Flash
     #[clap(long)]
@@ -118,6 +118,7 @@ pub struct PartitionTableArgs {
     #[clap(short = 'o', long, value_name = "FILE")]
     output: Option<PathBuf>,
     /// Input partition table
+    #[clap(value_name = "FILE")]
     partition_table: PathBuf,
     /// Convert CSV parition table to binary representation
     #[clap(long, conflicts_with = "to_csv")]
@@ -132,7 +133,7 @@ pub struct PartitionTableArgs {
 #[group(skip)]
 pub struct SaveImageArgs {
     /// Custom bootloader for merging
-    #[clap(long)]
+    #[clap(long, value_name = "FILE")]
     pub bootloader: Option<PathBuf>,
     /// Chip to create an image for
     #[clap(long, value_parser = clap_enum_variants!(Chip))]
@@ -143,7 +144,7 @@ pub struct SaveImageArgs {
     #[clap(long)]
     pub merge: bool,
     /// Custom partition table for merging
-    #[clap(long, short = 'T', requires = "merge")]
+    #[clap(long, short = 'T', requires = "merge", value_name = "FILE")]
     pub partition_table: Option<PathBuf>,
     /// Don't pad the image to the flash size
     #[clap(long, short = 'P', requires = "merge")]
@@ -200,7 +201,7 @@ pub fn serial_monitor(args: ConnectArgs, config: &Config) -> Result<()> {
         flasher.into_interface(),
         None,
         pid,
-        args.monitor_baud.unwrap_or(115_200),
+        args.baud.unwrap_or(115_200),
     )
     .into_diagnostic()?;
 

--- a/espflash/src/cli/mod.rs
+++ b/espflash/src/cli/mod.rs
@@ -52,10 +52,10 @@ pub use clap_enum_variants;
 #[derive(Debug, Args)]
 pub struct ConnectArgs {
     /// Baud rate at which to communicate with target device
-    #[clap(short = 'b', long)]
+    #[arg(short = 'b', long)]
     pub baud: Option<u32>,
     /// Serial port connected to target device
-    #[clap(short = 'p', long)]
+    #[arg(short = 'p', long)]
     pub port: Option<String>,
     /// DTR pin to use for the internal UART hardware. Uses BCM numbering.
     #[cfg(feature = "raspberry")]
@@ -66,20 +66,20 @@ pub struct ConnectArgs {
     #[cfg_attr(feature = "raspberry", clap(long))]
     pub rts: Option<u8>,
     /// Use RAM stub for loading
-    #[clap(long)]
+    #[arg(long)]
     pub use_stub: bool,
 }
 
 #[derive(Debug, Args)]
 pub struct FlashConfigArgs {
     /// Flash frequency
-    #[clap(short = 'f', long, value_name = "FREQ", value_parser = clap_enum_variants!(FlashFrequency))]
+    #[arg(short = 'f', long, value_name = "FREQ", value_parser = clap_enum_variants!(FlashFrequency))]
     pub flash_freq: Option<FlashFrequency>,
     /// Flash mode to use
-    #[clap(short = 'm', long, value_name = "MODE", value_parser = clap_enum_variants!(FlashMode))]
+    #[arg(short = 'm', long, value_name = "MODE", value_parser = clap_enum_variants!(FlashMode))]
     pub flash_mode: Option<FlashMode>,
     /// Flash size of the target
-    #[clap(short = 's', long, value_name = "SIZE", value_parser = clap_enum_variants!(FlashSize))]
+    #[arg(short = 's', long, value_name = "SIZE", value_parser = clap_enum_variants!(FlashSize))]
     pub flash_size: Option<FlashSize>,
 }
 
@@ -87,27 +87,27 @@ pub struct FlashConfigArgs {
 #[group(skip)]
 pub struct FlashArgs {
     /// Path to a binary (.bin) bootloader file
-    #[clap(long, value_name = "FILE")]
+    #[arg(long, value_name = "FILE")]
     pub bootloader: Option<PathBuf>,
     /// Erase the OTA data partition
     /// This is useful when using multiple OTA partitions and still wanting to
     /// be able to reflash via cargo-espflash or espflash
-    #[clap(long)]
+    #[arg(long)]
     pub erase_otadata: bool,
     /// Image format to flash
-    #[clap(long, value_parser = clap_enum_variants!(ImageFormatType))]
+    #[arg(long, value_parser = clap_enum_variants!(ImageFormatType))]
     pub format: Option<String>,
     /// Open a serial monitor after flashing
-    #[clap(long)]
+    #[arg(long)]
     pub monitor: bool,
     /// Baud rate at which to read console output
-    #[clap(long, requires = "monitor", value_name = "BAUD")]
+    #[arg(long, requires = "monitor", value_name = "BAUD")]
     pub monitor_baud: Option<u32>,
     /// Path to a CSV file containing partition table
-    #[clap(long, value_name = "FILE")]
+    #[arg(long, value_name = "FILE")]
     pub partition_table: Option<PathBuf>,
     /// Load the application to RAM instead of Flash
-    #[clap(long)]
+    #[arg(long)]
     pub ram: bool,
 }
 
@@ -115,16 +115,16 @@ pub struct FlashArgs {
 #[derive(Debug, Args)]
 pub struct PartitionTableArgs {
     /// Optional output file name, if unset will output to stdout
-    #[clap(short = 'o', long, value_name = "FILE")]
+    #[arg(short = 'o', long, value_name = "FILE")]
     output: Option<PathBuf>,
     /// Input partition table
-    #[clap(value_name = "FILE")]
+    #[arg(value_name = "FILE")]
     partition_table: PathBuf,
     /// Convert CSV parition table to binary representation
-    #[clap(long, conflicts_with = "to_csv")]
+    #[arg(long, conflicts_with = "to_csv")]
     to_binary: bool,
     /// Convert binary partition table to CSV representation
-    #[clap(long, conflicts_with = "to_binary")]
+    #[arg(long, conflicts_with = "to_binary")]
     to_csv: bool,
 }
 
@@ -133,21 +133,21 @@ pub struct PartitionTableArgs {
 #[group(skip)]
 pub struct SaveImageArgs {
     /// Custom bootloader for merging
-    #[clap(long, value_name = "FILE")]
+    #[arg(long, value_name = "FILE")]
     pub bootloader: Option<PathBuf>,
     /// Chip to create an image for
-    #[clap(long, value_parser = clap_enum_variants!(Chip))]
+    #[arg(long, value_parser = clap_enum_variants!(Chip))]
     pub chip: Chip,
     /// File name to save the generated image to
     pub file: PathBuf,
     /// Boolean flag to merge binaries into single binary
-    #[clap(long)]
+    #[arg(long)]
     pub merge: bool,
     /// Custom partition table for merging
-    #[clap(long, short = 'T', requires = "merge", value_name = "FILE")]
+    #[arg(long, short = 'T', requires = "merge", value_name = "FILE")]
     pub partition_table: Option<PathBuf>,
     /// Don't pad the image to the flash size
-    #[clap(long, short = 'P', requires = "merge")]
+    #[arg(long, short = 'P', requires = "merge")]
     pub skip_padding: bool,
 }
 

--- a/espflash/src/flasher/mod.rs
+++ b/espflash/src/flasher/mod.rs
@@ -82,7 +82,7 @@ impl FromStr for FlashFrequency {
 }
 
 #[derive(Copy, Clone, Debug, EnumVariantNames)]
-#[strum(serialize_all = "UPPERCASE")]
+#[strum(serialize_all = "lowercase")]
 pub enum FlashMode {
     Qio,
     Qout,
@@ -94,11 +94,11 @@ impl FromStr for FlashMode {
     type Err = Error;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let mode = match s.to_uppercase().as_str() {
-            "QIO" => FlashMode::Qio,
-            "QOUT" => FlashMode::Qout,
-            "DIO" => FlashMode::Dio,
-            "DOUT" => FlashMode::Dout,
+        let mode = match s.to_lowercase().as_str() {
+            "qio" => FlashMode::Qio,
+            "qout" => FlashMode::Qout,
+            "dio" => FlashMode::Dio,
+            "dout" => FlashMode::Dout,
             _ => return Err(Error::InvalidFlashMode(s.to_string())),
         };
 
@@ -109,25 +109,25 @@ impl FromStr for FlashMode {
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Display, EnumVariantNames)]
 #[repr(u8)]
 pub enum FlashSize {
-    #[strum(serialize = "256KB")]
+    #[strum(serialize = "256K")]
     Flash256Kb = 0x12,
-    #[strum(serialize = "512KB")]
+    #[strum(serialize = "512K")]
     Flash512Kb = 0x13,
-    #[strum(serialize = "1MB")]
+    #[strum(serialize = "1M")]
     Flash1Mb = 0x14,
-    #[strum(serialize = "2MB")]
+    #[strum(serialize = "2M")]
     Flash2Mb = 0x15,
-    #[strum(serialize = "4MB")]
+    #[strum(serialize = "4M")]
     Flash4Mb = 0x16,
-    #[strum(serialize = "8MB")]
+    #[strum(serialize = "8M")]
     Flash8Mb = 0x17,
-    #[strum(serialize = "16MB")]
+    #[strum(serialize = "16M")]
     Flash16Mb = 0x18,
-    #[strum(serialize = "32MB")]
+    #[strum(serialize = "32M")]
     Flash32Mb = 0x19,
-    #[strum(serialize = "64MB")]
+    #[strum(serialize = "64M")]
     Flash64Mb = 0x1a,
-    #[strum(serialize = "128MB")]
+    #[strum(serialize = "128M")]
     Flash128Mb = 0x21,
 }
 

--- a/espflash/src/targets/mod.rs
+++ b/espflash/src/targets/mod.rs
@@ -30,18 +30,13 @@ mod esp8266;
 mod flash_target;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Display, EnumIter, EnumVariantNames)]
+#[strum(serialize_all = "lowercase")]
 pub enum Chip {
-    #[strum(serialize = "ESP32")]
     Esp32,
-    #[strum(serialize = "ESP32-C2")]
     Esp32c2,
-    #[strum(serialize = "ESP32-C3")]
     Esp32c3,
-    #[strum(serialize = "ESP32-S2")]
     Esp32s2,
-    #[strum(serialize = "ESP32-S3")]
     Esp32s3,
-    #[strum(serialize = "ESP8266")]
     Esp8266,
 }
 


### PR DESCRIPTION
Of course, almost immediately after reworking the CLI they had to publish a new major version on us 😁 `cargo_toml` published an update requiring changes as well, so I've updated it and any other dependencies with new versions.

Unfortunately in this new version of `clap` they've taken away the `possible_values` attribute, so I've had to add a simple macro to replace it. This is incredibly unfortunate, but also not the end of the world.

There were also some small issues with our existing structures for the CLI arguments, so I had to address those as well. The `--monitor-baud` arg should not have been added to `ConnectArgs` (this was my bad) so I moved it out. Addressed some visual stuff too, just lowercasing options, etc.

Closes #248 