### PR TITLE
Add `raspberry` feature checks in CI.

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -24,38 +24,30 @@ jobs:
       fail-fast: false
       matrix:
         crate: ["espflash", "cargo-espflash"]
-
     steps:
       - uses: actions/checkout@v2
-
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
           target: ${{ inputs.target }}
           override: true
-
       - uses: Swatinem/rust-cache@v1
-
       - name: Build dependencies for other ubuntu targets
         if: inputs.runs_on == 'ubuntu-latest'
         run: |
           sudo sed -i 's/azure.archive.ubuntu.com/archive.ubuntu.com/' /etc/apt/sources.list
           sudo apt-get update
           sudo apt-get install musl-tools libudev-dev
-
       - uses: actions-rs/cargo@v1
         with:
           command: build
           args: --release --all --target ${{ inputs.target }}
-
       - name: Compress (Unix)
         if: ${{ inputs.runs_on != 'windows-latest' }}
         run: zip -j ${{ matrix.crate }}-${{ inputs.target }}.zip target/${{ inputs.target }}/release/${{ matrix.crate }}${{ inputs.extension }}
-
       - name: Compress (Windows)
         if: ${{ inputs.runs_on == 'windows-latest' }}
         run: Compress-Archive target/${{ inputs.target }}/release/${{ matrix.crate }}${{ inputs.extension }} ${{ matrix.crate }}-${{ inputs.target }}.zip
-
       - uses: svenstaro/upload-release-action@v2
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -13,10 +13,6 @@ on:
         required: false
         default: ""
         type: string
-      arch:
-        required: false
-        default: ""
-        type: string
 
 env:
   CARGO_TERM_COLOR: always
@@ -40,56 +36,17 @@ jobs:
 
       - uses: Swatinem/rust-cache@v1
 
-      - name: Replace target string
-        if: inputs.arch != ''
-        uses: mad9000/actions-find-and-replace-string@1
-        id: findandreplace
-        with:
-          source: ${{ inputs.target }}
-          find: "unknown-"
-          replace: ""
-
-      - name: Build dependencies raspberry targets
-        if: inputs.runs_on == 'ubuntu-latest' && inputs.arch != ''
-        run: |
-          sudo sed -i 's/azure\.//' /etc/apt/sources.list
-          sudo apt-get update
-          echo "deb [arch=${{ inputs.arch }}] http://ports.ubuntu.com/ubuntu-ports focal main universe" | sudo tee -a /etc/apt/sources.list
-          echo "deb [arch=${{ inputs.arch }}] http://ports.ubuntu.com/ubuntu-ports focal-updates main universe" | sudo tee -a /etc/apt/sources.list
-          sudo apt update
-          sudo dpkg --add-architecture ${{ inputs.arch }}
-          sudo apt-get install -y curl git libudev-dev musl-tools pkg-config "libudev1:${{ inputs.arch }}" "libgcc-s1:${{ inputs.arch }}" "libc6:${{ inputs.arch }}" "libudev-dev:${{ inputs.arch }}" gcc-arm-linux-gnueabihf pkg-config-arm-linux-gnueabihf gcc-aarch64-linux-gnu pkg-config-aarch64-linux-gnu
-          echo "PKG_CONFIG_ALLOW_SYSTEM_LIBS=0" >> $GITHUB_ENV
-          echo "PKG_CONFIG_DIR=/opt/" >> $GITHUB_ENV
-          echo "PKG_CONFIG_LIBDIR=/opt/usr/lib/pkgconfig:/opt/usr/share/pkgconfig" >> $GITHUB_ENV
-          echo "PKG_CONFIG_ALLOW_CROSS=1" >> $GITHUB_ENV
-          if [[ ${{ inputs.arch }} == arm64 ]]; then
-            echo "PKG_CONFIG_PATH=/usr/lib/${{ steps.findandreplace.outputs.value }}/pkgconfig" >> $GITHUB_ENV
-            echo "CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=${{ steps.findandreplace.outputs.value }}-gcc" >> $GITHUB_ENV
-          fi
-          if [[ ${{ inputs.arch }} == armhf ]]; then
-            echo "PKG_CONFIG_PATH=/usr/lib/arm-linux-gnueabihf/pkgconfig" >> $GITHUB_ENV
-            echo "CARGO_TARGET_ARMV7_UNKNOWN_LINUX_GNUEABIHF_LINKER=arm-linux-gnueabihf-gcc" >> $GITHUB_ENV
-          fi
-
       - name: Build dependencies for other ubuntu targets
-        if: inputs.runs_on == 'ubuntu-latest' && inputs.arch == ''
+        if: inputs.runs_on == 'ubuntu-latest'
         run: |
           sudo sed -i 's/azure.archive.ubuntu.com/archive.ubuntu.com/' /etc/apt/sources.list
           sudo apt-get update
           sudo apt-get install musl-tools libudev-dev
 
       - uses: actions-rs/cargo@v1
-        if: ${{ inputs.arch == '' }}
         with:
           command: build
           args: --release --all --target ${{ inputs.target }}
-
-      - uses: actions-rs/cargo@v1
-        if: ${{ inputs.arch != '' }}
-        with:
-          command: build
-          args: --release --all --target ${{ inputs.target }} --features=raspberry
 
       - name: Compress (Unix)
         if: ${{ inputs.runs_on != 'windows-latest' }}

--- a/.github/workflows/raspberry.yml
+++ b/.github/workflows/raspberry.yml
@@ -1,0 +1,153 @@
+name: Rasberry Pi
+
+on:
+  pull_request:
+    branches:
+      - master
+  push:
+  workflow_dispatch:
+  workflow_call:
+    inputs:
+      target:
+        required: true
+        type: string
+      arch:
+        required: false
+        default: ""
+        type: string
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  publish-release:
+    if: github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        crate: ["espflash", "cargo-espflash"]
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          target: ${{ inputs.target }}
+          override: true
+      - uses: Swatinem/rust-cache@v1
+      - name: Replace target string
+        uses: mad9000/actions-find-and-replace-string@1
+        id: findandreplace
+        with:
+          source: ${{ inputs.target }}
+          find: "unknown-"
+          replace: ""
+      - name: Build dependencies
+        run: |
+          sudo sed -i 's/azure\.//' /etc/apt/sources.list
+          sudo apt-get update
+          echo "deb [arch=${{ inputs.arch }}] http://ports.ubuntu.com/ubuntu-ports focal main universe" | sudo tee -a /etc/apt/sources.list
+          echo "deb [arch=${{ inputs.arch }}] http://ports.ubuntu.com/ubuntu-ports focal-updates main universe" | sudo tee -a /etc/apt/sources.list
+          sudo apt update
+          sudo dpkg --add-architecture ${{ inputs.arch }}
+          sudo apt-get install -y curl git libudev-dev musl-tools pkg-config "libudev1:${{ inputs.arch }}" "libgcc-s1:${{ inputs.arch }}" "libc6:${{ inputs.arch }}" "libudev-dev:${{ inputs.arch }}" gcc-arm-linux-gnueabihf pkg-config-arm-linux-gnueabihf gcc-aarch64-linux-gnu pkg-config-aarch64-linux-gnu
+          echo "PKG_CONFIG_ALLOW_SYSTEM_LIBS=0" >> $GITHUB_ENV
+          echo "PKG_CONFIG_DIR=/opt/" >> $GITHUB_ENV
+          echo "PKG_CONFIG_LIBDIR=/opt/usr/lib/pkgconfig:/opt/usr/share/pkgconfig" >> $GITHUB_ENV
+          echo "PKG_CONFIG_ALLOW_CROSS=1" >> $GITHUB_ENV
+          if [[ ${{ inputs.arch }} == arm64 ]]; then
+            echo "PKG_CONFIG_PATH=/usr/lib/${{ steps.findandreplace.outputs.value }}/pkgconfig" >> $GITHUB_ENV
+            echo "CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=${{ steps.findandreplace.outputs.value }}-gcc" >> $GITHUB_ENV
+          fi
+          if [[ ${{ inputs.arch }} == armhf ]]; then
+            echo "PKG_CONFIG_PATH=/usr/lib/arm-linux-gnueabihf/pkgconfig" >> $GITHUB_ENV
+            echo "CARGO_TARGET_ARMV7_UNKNOWN_LINUX_GNUEABIHF_LINKER=arm-linux-gnueabihf-gcc" >> $GITHUB_ENV
+          fi
+      - uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: --release --all --target ${{ inputs.target }} --features=raspberry
+      - name: Compress
+        run: zip -j ${{ matrix.crate }}-${{ inputs.target }}.zip target/${{ inputs.target }}/release/${{ matrix.crate }}${{ inputs.extension }}
+      - uses: svenstaro/upload-release-action@v2
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: ${{ matrix.crate }}-${{ inputs.target }}.zip
+          tag: ${{ github.ref }}
+
+  rust-ci:
+    if: github.event_name != 'workflow_dispatch'
+    name: "Rust CI: ${{ matrix.job.name }} - ${{ matrix.board.target }}"
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        board:
+          - target: armv7-unknown-linux-gnueabihf
+            arch: armhf
+          - target: aarch64-unknown-linux-gnu
+            arch: arm64
+        job:
+          - name: Check
+            toolchain: stable
+            cargo-command: check
+          - name: Check MSRV
+            toolchain: "1.60"
+            cargo-command: check
+          - name: Unit Test
+            toolchain: stable
+            cargo-command: test
+            args: --lib
+          - name: Rustfmt
+            toolchain: stable
+            components: rustfmt
+            cargo-command: fmt
+            args: --all -- --check
+          - name: Clippy
+            toolchain: stable
+            components: clippy
+            cargo-command: clippy
+            args: -- -A clippy::too_many_arguments
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: ${{ matrix.job.toolchain }}
+          target: ${{ matrix.board.target }}
+          components: ${{ matrix.job.components }}
+          override: true
+      - uses: Swatinem/rust-cache@v1
+      - name: Replace target string
+        uses: mad9000/actions-find-and-replace-string@1
+        id: findandreplace
+        with:
+          source: ${{ matrix.board.target }}
+          find: "unknown-"
+          replace: ""
+      - name: Build dependencies
+        if: matrix.job.cargo-command  != 'fmt'
+        run: |
+          sudo sed -i 's/azure\.//' /etc/apt/sources.list
+          sudo apt-get update
+          echo "deb [arch=${{ matrix.board.arch }} http://ports.ubuntu.com/ubuntu-ports focal main universe" | sudo tee -a /etc/apt/sources.list
+          echo "deb [arch=${{ matrix.board.arch }}] http://ports.ubuntu.com/ubuntu-ports focal-updates main universe" | sudo tee -a /etc/apt/sources.list
+          sudo apt update
+          sudo dpkg --add-architecture ${{ matrix.board.arch }}
+          sudo apt-get install -y curl git libudev-dev musl-tools pkg-config "libudev1:${{ matrix.board.arch }}" "libgcc-s1:${{ matrix.board.arch }}" "libc6:${{ matrix.board.arch }}" "libudev-dev:${{ matrix.board.arch }}" gcc-arm-linux-gnueabihf pkg-config-arm-linux-gnueabihf gcc-aarch64-linux-gnu pkg-config-aarch64-linux-gnu
+          echo "PKG_CONFIG_ALLOW_SYSTEM_LIBS=0" >> $GITHUB_ENV
+          echo "PKG_CONFIG_DIR=/opt/" >> $GITHUB_ENV
+          echo "PKG_CONFIG_LIBDIR=/opt/usr/lib/pkgconfig:/opt/usr/share/pkgconfig" >> $GITHUB_ENV
+          echo "PKG_CONFIG_ALLOW_CROSS=1" >> $GITHUB_ENV
+          if [[ ${{ matrix.board.arch }} == arm64 ]]; then
+            echo "PKG_CONFIG_PATH=/usr/lib/${{ steps.findandreplace.outputs.value }}/pkgconfig" >> $GITHUB_ENV
+            echo "CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=${{ steps.findandreplace.outputs.value }}-gcc" >> $GITHUB_ENV
+          fi
+          if [[ ${{ matrix.board.arch }} == armhf ]]; then
+            echo "PKG_CONFIG_PATH=/usr/lib/arm-linux-gnueabihf/pkgconfig" >> $GITHUB_ENV
+            echo "CARGO_TARGET_ARMV7_UNKNOWN_LINUX_GNUEABIHF_LINKER=arm-linux-gnueabihf-gcc" >> $GITHUB_ENV
+          fi
+      - uses: actions-rs/cargo@v1
+        with:
+          command: ${{ matrix.job.cargo-command }}
+          args: ${{ matrix.job.args }} --features=raspberry

--- a/.github/workflows/raspberry.yml
+++ b/.github/workflows/raspberry.yml
@@ -150,4 +150,4 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: ${{ matrix.job.cargo-command }}
-          args: ${{ matrix.job.args }} --features=raspberry
+          args: --features=raspberry ${{ matrix.job.args }}

--- a/.github/workflows/raspberry.yml
+++ b/.github/workflows/raspberry.yml
@@ -130,7 +130,7 @@ jobs:
         run: |
           sudo sed -i 's/azure\.//' /etc/apt/sources.list
           sudo apt-get update
-          echo "deb [arch=${{ matrix.board.arch }} http://ports.ubuntu.com/ubuntu-ports focal main universe" | sudo tee -a /etc/apt/sources.list
+          echo "deb [arch=${{ matrix.board.arch }}] http://ports.ubuntu.com/ubuntu-ports focal main universe" | sudo tee -a /etc/apt/sources.list
           echo "deb [arch=${{ matrix.board.arch }}] http://ports.ubuntu.com/ubuntu-ports focal-updates main universe" | sudo tee -a /etc/apt/sources.list
           sudo apt update
           sudo dpkg --add-architecture ${{ matrix.board.arch }}

--- a/.github/workflows/raspberry.yml
+++ b/.github/workflows/raspberry.yml
@@ -91,13 +91,15 @@ jobs:
           - name: Check
             toolchain: stable
             cargo-command: check
+            args: --features=raspberry
           - name: Check MSRV
             toolchain: "1.60"
             cargo-command: check
+            args: --features=raspberry
           - name: Unit Test
             toolchain: stable
             cargo-command: test
-            args: --lib
+            args: --lib --features=raspberry
           - name: Rustfmt
             toolchain: stable
             components: rustfmt
@@ -150,4 +152,4 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: ${{ matrix.job.cargo-command }}
-          args: --features=raspberry ${{ matrix.job.args }}
+          args: ${{ matrix.job.args }}

--- a/.github/workflows/raspberry_package.yml
+++ b/.github/workflows/raspberry_package.yml
@@ -1,0 +1,70 @@
+name: Rasberry Pi Package
+
+on:
+  workflow_call:
+    inputs:
+      target:
+        required: true
+        type: string
+      arch:
+        required: false
+        default: ""
+        type: string
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  publish-release:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        crate: ["espflash", "cargo-espflash"]
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          target: ${{ inputs.target }}
+          override: true
+      - uses: Swatinem/rust-cache@v1
+      - name: Replace target string
+        uses: mad9000/actions-find-and-replace-string@1
+        id: findandreplace
+        with:
+          source: ${{ inputs.target }}
+          find: "unknown-"
+          replace: ""
+      - name: Build dependencies
+        run: |
+          sudo sed -i 's/azure\.//' /etc/apt/sources.list
+          sudo apt-get update
+          echo "deb [arch=${{ inputs.arch }}] http://ports.ubuntu.com/ubuntu-ports focal main universe" | sudo tee -a /etc/apt/sources.list
+          echo "deb [arch=${{ inputs.arch }}] http://ports.ubuntu.com/ubuntu-ports focal-updates main universe" | sudo tee -a /etc/apt/sources.list
+          sudo apt update
+          sudo dpkg --add-architecture ${{ inputs.arch }}
+          sudo apt-get install -y curl git libudev-dev musl-tools pkg-config "libudev1:${{ inputs.arch }}" "libgcc-s1:${{ inputs.arch }}" "libc6:${{ inputs.arch }}" "libudev-dev:${{ inputs.arch }}" gcc-arm-linux-gnueabihf pkg-config-arm-linux-gnueabihf gcc-aarch64-linux-gnu pkg-config-aarch64-linux-gnu
+          echo "PKG_CONFIG_ALLOW_SYSTEM_LIBS=0" >> $GITHUB_ENV
+          echo "PKG_CONFIG_DIR=/opt/" >> $GITHUB_ENV
+          echo "PKG_CONFIG_LIBDIR=/opt/usr/lib/pkgconfig:/opt/usr/share/pkgconfig" >> $GITHUB_ENV
+          echo "PKG_CONFIG_ALLOW_CROSS=1" >> $GITHUB_ENV
+          if [[ ${{ inputs.arch }} == arm64 ]]; then
+            echo "PKG_CONFIG_PATH=/usr/lib/${{ steps.findandreplace.outputs.value }}/pkgconfig" >> $GITHUB_ENV
+            echo "CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=${{ steps.findandreplace.outputs.value }}-gcc" >> $GITHUB_ENV
+          fi
+          if [[ ${{ inputs.arch }} == armhf ]]; then
+            echo "PKG_CONFIG_PATH=/usr/lib/arm-linux-gnueabihf/pkgconfig" >> $GITHUB_ENV
+            echo "CARGO_TARGET_ARMV7_UNKNOWN_LINUX_GNUEABIHF_LINKER=arm-linux-gnueabihf-gcc" >> $GITHUB_ENV
+          fi
+      - uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: --release --all --target ${{ inputs.target }} --features=raspberry
+      - name: Compress
+        run: zip -j ${{ matrix.crate }}-${{ inputs.target }}.zip target/${{ inputs.target }}/release/${{ matrix.crate }}${{ inputs.extension }}
+      - uses: svenstaro/upload-release-action@v2
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: ${{ matrix.crate }}-${{ inputs.target }}.zip
+          tag: ${{ github.ref }}

--- a/.github/workflows/raspberry_rust.yml
+++ b/.github/workflows/raspberry_rust.yml
@@ -35,11 +35,6 @@ jobs:
             toolchain: stable
             cargo-command: test
             args: --lib --features=raspberry
-          - name: Rustfmt
-            toolchain: stable
-            components: rustfmt
-            cargo-command: fmt
-            args: --all -- --check
           - name: Clippy
             toolchain: stable
             components: clippy

--- a/.github/workflows/raspberry_rust.yml
+++ b/.github/workflows/raspberry_rust.yml
@@ -1,4 +1,4 @@
-name: Rasberry Pi
+name: Rasberry Pi CI
 
 on:
   pull_request:
@@ -6,77 +6,12 @@ on:
       - master
   push:
   workflow_dispatch:
-  workflow_call:
-    inputs:
-      target:
-        required: true
-        type: string
-      arch:
-        required: false
-        default: ""
-        type: string
 
 env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  publish-release:
-    if: github.event_name == 'workflow_dispatch'
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        crate: ["espflash", "cargo-espflash"]
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          target: ${{ inputs.target }}
-          override: true
-      - uses: Swatinem/rust-cache@v1
-      - name: Replace target string
-        uses: mad9000/actions-find-and-replace-string@1
-        id: findandreplace
-        with:
-          source: ${{ inputs.target }}
-          find: "unknown-"
-          replace: ""
-      - name: Build dependencies
-        run: |
-          sudo sed -i 's/azure\.//' /etc/apt/sources.list
-          sudo apt-get update
-          echo "deb [arch=${{ inputs.arch }}] http://ports.ubuntu.com/ubuntu-ports focal main universe" | sudo tee -a /etc/apt/sources.list
-          echo "deb [arch=${{ inputs.arch }}] http://ports.ubuntu.com/ubuntu-ports focal-updates main universe" | sudo tee -a /etc/apt/sources.list
-          sudo apt update
-          sudo dpkg --add-architecture ${{ inputs.arch }}
-          sudo apt-get install -y curl git libudev-dev musl-tools pkg-config "libudev1:${{ inputs.arch }}" "libgcc-s1:${{ inputs.arch }}" "libc6:${{ inputs.arch }}" "libudev-dev:${{ inputs.arch }}" gcc-arm-linux-gnueabihf pkg-config-arm-linux-gnueabihf gcc-aarch64-linux-gnu pkg-config-aarch64-linux-gnu
-          echo "PKG_CONFIG_ALLOW_SYSTEM_LIBS=0" >> $GITHUB_ENV
-          echo "PKG_CONFIG_DIR=/opt/" >> $GITHUB_ENV
-          echo "PKG_CONFIG_LIBDIR=/opt/usr/lib/pkgconfig:/opt/usr/share/pkgconfig" >> $GITHUB_ENV
-          echo "PKG_CONFIG_ALLOW_CROSS=1" >> $GITHUB_ENV
-          if [[ ${{ inputs.arch }} == arm64 ]]; then
-            echo "PKG_CONFIG_PATH=/usr/lib/${{ steps.findandreplace.outputs.value }}/pkgconfig" >> $GITHUB_ENV
-            echo "CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=${{ steps.findandreplace.outputs.value }}-gcc" >> $GITHUB_ENV
-          fi
-          if [[ ${{ inputs.arch }} == armhf ]]; then
-            echo "PKG_CONFIG_PATH=/usr/lib/arm-linux-gnueabihf/pkgconfig" >> $GITHUB_ENV
-            echo "CARGO_TARGET_ARMV7_UNKNOWN_LINUX_GNUEABIHF_LINKER=arm-linux-gnueabihf-gcc" >> $GITHUB_ENV
-          fi
-      - uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: --release --all --target ${{ inputs.target }} --features=raspberry
-      - name: Compress
-        run: zip -j ${{ matrix.crate }}-${{ inputs.target }}.zip target/${{ inputs.target }}/release/${{ matrix.crate }}${{ inputs.extension }}
-      - uses: svenstaro/upload-release-action@v2
-        with:
-          repo_token: ${{ secrets.GITHUB_TOKEN }}
-          file: ${{ matrix.crate }}-${{ inputs.target }}.zip
-          tag: ${{ github.ref }}
-
   rust-ci:
-    if: github.event_name != 'workflow_dispatch'
     name: "Rust CI: ${{ matrix.job.name }} - ${{ matrix.board.target }}"
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/raspberry_rust.yml
+++ b/.github/workflows/raspberry_rust.yml
@@ -44,7 +44,7 @@ jobs:
             toolchain: stable
             components: clippy
             cargo-command: clippy
-            args: -- -A clippy::too_many_arguments
+            args: --features=raspberry -- -A clippy::too_many_arguments
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,16 +8,14 @@ jobs:
   # Linux
 
   armv7-unknown-linux-gnueabihf:
-    uses: ./.github/workflows/package.yml
+    uses: ./.github/workflows/raspberry.yml
     with:
-      runs_on: ubuntu-latest
       target: armv7-unknown-linux-gnueabihf
       arch: armhf
 
   aarch64-unknown-linux-gnu:
-    uses: ./.github/workflows/package.yml
+    uses: ./.github/workflows/raspberry.yml
     with:
-      runs_on: ubuntu-latest
       target: aarch64-unknown-linux-gnu
       arch: arm64
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,13 +8,13 @@ jobs:
   # Linux
 
   armv7-unknown-linux-gnueabihf:
-    uses: ./.github/workflows/raspberry.yml
+    uses: ./.github/workflows/raspberry_package.yml
     with:
       target: armv7-unknown-linux-gnueabihf
       arch: armhf
 
   aarch64-unknown-linux-gnu:
-    uses: ./.github/workflows/raspberry.yml
+    uses: ./.github/workflows/raspberry_package.yml
     with:
       target: aarch64-unknown-linux-gnu
       arch: arm64

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,3 +1,5 @@
+name: CI
+
 on:
   pull_request:
     branches:
@@ -5,7 +7,8 @@ on:
   push:
   workflow_dispatch:
 
-name: CI
+env:
+  CARGO_TERM_COLOR: always
 
 jobs:
   check:


### PR DESCRIPTION
- Went back to the old approach of having two files for generating release packages: One for raspberry targets, and another for the rest of the targets.
- Added `raspberry_rust.yml` which is the equivalent of `rust.yml` but for raspberry targets (I removed `fmt` check as it does not change between targets AFAIK)

Closes #250 