### PR TITLE
Clean up the image format enums

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -284,9 +284,9 @@ checksum = "fff857943da45f546682664a79488be82e69e43c1a7a2307679ab9afb3a66d2e"
 
 [[package]]
 name = "clap"
-version = "4.0.9"
+version = "4.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30607dd93c420c6f1f80b544be522a0238a7db35e6a12968d28910983fee0df0"
+checksum = "6ea54a38e4bce14ff6931c72e5b3c43da7051df056913d4e7e1fcdb1c03df69d"
 dependencies = [
  "atty",
  "bitflags",
@@ -299,9 +299,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.0.9"
+version = "4.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4a307492e1a34939f79d3b6b9650bd2b971513cd775436bf2b78defeb5af00b"
+checksum = "c42f169caba89a7d512b5418b09864543eeb4d497416c917d7137863bd2076ad"
 dependencies = [
  "heck",
  "proc-macro-error",
@@ -784,9 +784,9 @@ checksum = "b71991ff56294aa922b450139ee08b3bfc70982c6b2c7562771375cf73542dd4"
 
 [[package]]
 name = "itoa"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c8af84674fe1f223a982c933a0ee1086ac4d4052aa0fb8060c12c6ad838e754"
+checksum = "4217ad341ebadf8d8e724e264f13e593e0648f5b3e94b3896a5df283be015ecc"
 
 [[package]]
 name = "js-sys"
@@ -805,9 +805,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.134"
+version = "0.2.135"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "329c933548736bc49fd575ee68c89e8be4d260064184389a5b77517cddd99ffb"
+checksum = "68783febc7782c6c5cb401fbda4de5a9898be1762314da0bb2c10ced61f18b0c"
 
 [[package]]
 name = "libudev"
@@ -1264,11 +1264,11 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.85"
+version = "1.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e55a28e3aaef9d5ce0506d0a14dbba8054ddc7e499ef522dd8b26859ec9d4a44"
+checksum = "41feea4228a6f1cd09ec7a3593a682276702cd67b5273544757dae23c096f074"
 dependencies = [
- "itoa 1.0.3",
+ "itoa 1.0.4",
  "ryu",
  "serde",
 ]
@@ -1437,9 +1437,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.101"
+version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e90cde112c4b9690b8cbe810cba9ddd8bc1d7472e2cae317b69e9438c1cba7d2"
+checksum = "3fcd952facd492f9be3ef0d0b7032a6e442ee9b361d4acc2b1d0c4aaa5f613a1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1554,9 +1554,9 @@ checksum = "099b7128301d285f79ddd55b9a83d5e6b9e97c92e0ea0daebee7263e932de992"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.4"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcc811dc4066ac62f84f11307873c4850cb653bfa9b1719cee2bd2204a4bc5dd"
+checksum = "6ceab39d59e4c9499d4e5a8ee0e2735b891bb7308ac83dfb4e80cad195c9f6f3"
 
 [[package]]
 name = "unicode-linebreak"

--- a/cargo-espflash/Cargo.toml
+++ b/cargo-espflash/Cargo.toml
@@ -32,7 +32,7 @@ pkg-fmt = "zip"
 [dependencies]
 cargo_metadata = "0.15.0"
 cargo_toml = "0.12.2"
-clap = { version = "4.0.8", features = ["derive"] }
+clap = { version = "4.0.14", features = ["derive"] }
 env_logger = "0.9.1"
 espflash = { version = "=2.0.0-dev", path = "../espflash" }
 log = "0.4.17"

--- a/cargo-espflash/src/main.rs
+++ b/cargo-espflash/src/main.rs
@@ -12,7 +12,7 @@ use espflash::{
         monitor::monitor, partition_table, save_elf_as_image, serial_monitor, ConnectArgs,
         FlashConfigArgs, PartitionTableArgs,
     },
-    image_format::ImageFormatId,
+    image_format::ImageFormatKind,
     logging::initialize_logger,
     targets::Chip,
     update::check_for_update,
@@ -110,8 +110,8 @@ struct FlashArgs {
 #[derive(Debug, Args)]
 struct SaveImageArgs {
     /// Image format to flash
-    #[arg(long, value_parser = clap_enum_variants!(ImageFormatId))]
-    pub format: Option<ImageFormatId>,
+    #[arg(long, value_parser = clap_enum_variants!(ImageFormatKind))]
+    pub format: Option<ImageFormatKind>,
 
     #[clap(flatten)]
     build_args: BuildArgs,

--- a/cargo-espflash/src/main.rs
+++ b/cargo-espflash/src/main.rs
@@ -2,7 +2,6 @@ use std::{
     fs,
     path::PathBuf,
     process::{exit, Command, ExitStatus, Stdio},
-    str::FromStr,
 };
 
 use cargo_metadata::Message;
@@ -13,7 +12,7 @@ use espflash::{
         monitor::monitor, partition_table, save_elf_as_image, serial_monitor, ConnectArgs,
         FlashConfigArgs, PartitionTableArgs,
     },
-    image_format::{ImageFormatId, ImageFormatType},
+    image_format::ImageFormatId,
     logging::initialize_logger,
     targets::Chip,
     update::check_for_update,
@@ -111,8 +110,8 @@ struct FlashArgs {
 #[derive(Debug, Args)]
 struct SaveImageArgs {
     /// Image format to flash
-    #[arg(long, value_parser = clap_enum_variants!(ImageFormatType))]
-    pub format: Option<String>,
+    #[arg(long, value_parser = clap_enum_variants!(ImageFormatId))]
+    pub format: Option<ImageFormatId>,
 
     #[clap(flatten)]
     build_args: BuildArgs,
@@ -199,20 +198,12 @@ fn flash(
             .or(metadata.partition_table.as_deref())
             .or(build_ctx.partition_table_path.as_deref());
 
-        let image_format = args
-            .flash_args
-            .format
-            .as_deref()
-            .map(ImageFormatId::from_str)
-            .transpose()?
-            .or(metadata.format);
-
         flash_elf_image(
             &mut flasher,
             &elf_data,
             bootloader,
             partition_table,
-            image_format,
+            args.flash_args.format.or(metadata.format),
             args.build_args.flash_config_args.flash_mode,
             args.build_args.flash_config_args.flash_size,
             args.build_args.flash_config_args.flash_freq,
@@ -419,18 +410,11 @@ fn save_image(
         .or(build_ctx.partition_table_path.as_deref())
         .map(|p| p.to_path_buf());
 
-    let image_format = args
-        .format
-        .as_deref()
-        .map(ImageFormatId::from_str)
-        .transpose()?
-        .or(metadata.format);
-
     save_elf_as_image(
         args.save_image_args.chip,
         &elf_data,
         args.save_image_args.file,
-        image_format,
+        args.format.or(metadata.format),
         args.build_args.flash_config_args.flash_mode,
         args.build_args.flash_config_args.flash_size,
         args.build_args.flash_config_args.flash_freq,

--- a/cargo-espflash/src/package_metadata.rs
+++ b/cargo-espflash/src/package_metadata.rs
@@ -5,7 +5,7 @@ use std::{
 };
 
 use cargo_toml::Manifest;
-use espflash::image_format::ImageFormatId;
+use espflash::image_format::ImageFormatKind;
 use miette::{IntoDiagnostic, Result, WrapErr};
 use serde::Deserialize;
 
@@ -15,7 +15,7 @@ use crate::error::{Error, TomlError};
 pub struct CargoEspFlashMeta {
     pub partition_table: Option<PathBuf>,
     pub bootloader: Option<PathBuf>,
-    pub format: Option<ImageFormatId>,
+    pub format: Option<ImageFormatKind>,
 }
 
 #[derive(Clone, Debug, Default, Deserialize)]

--- a/espflash/Cargo.toml
+++ b/espflash/Cargo.toml
@@ -38,7 +38,7 @@ addr2line = "0.18.0"
 base64 = "0.13.0"
 binread = "2.2.0"
 bytemuck = { version = "1.12.1", features = ["derive"] }
-clap = { version = "4.0.8", features = ["derive"], optional = true }
+clap = { version = "4.0.14", features = ["derive"], optional = true }
 comfy-table = "6.1.0"
 crossterm = { version = "0.25.0", optional = true }
 dialoguer = { version = "0.10.2", optional = true }
@@ -55,7 +55,7 @@ regex = "1.6.0"
 rppal = { version = "0.13.1", optional = true }
 serde = { version = "1.0.145", features = ["derive"] }
 serde-hex = "0.1.0"
-serde_json = "1.0.85"
+serde_json = "1.0.86"
 serialport = "4.2.0"
 sha2 = "0.10.6"
 slip-codec = "0.3.3"

--- a/espflash/src/bin/espflash.rs
+++ b/espflash/src/bin/espflash.rs
@@ -12,7 +12,7 @@ use espflash::{
         monitor::monitor, partition_table, save_elf_as_image, serial_monitor, ConnectArgs,
         FlashConfigArgs, PartitionTableArgs,
     },
-    image_format::ImageFormatId,
+    image_format::ImageFormatKind,
     logging::initialize_logger,
     update::check_for_update,
 };
@@ -56,8 +56,8 @@ struct FlashArgs {
 #[derive(Debug, Args)]
 struct SaveImageArgs {
     /// Image format to flash
-    #[arg(long, value_parser = clap_enum_variants!(ImageFormatId))]
-    format: Option<ImageFormatId>,
+    #[arg(long, value_parser = clap_enum_variants!(ImageFormatKind))]
+    format: Option<ImageFormatKind>,
 
     #[clap(flatten)]
     pub flash_config_args: FlashConfigArgs,

--- a/espflash/src/cli/mod.rs
+++ b/espflash/src/cli/mod.rs
@@ -21,7 +21,7 @@ use crate::{
     elf::ElfFirmwareImage,
     error::{MissingPartitionTable, NoOtadataError},
     flasher::{FlashFrequency, FlashMode, FlashSize, Flasher},
-    image_format::{ImageFormatId, ImageFormatType},
+    image_format::ImageFormatId,
     interface::Interface,
     targets::Chip,
 };
@@ -96,8 +96,8 @@ pub struct FlashArgs {
     #[arg(long)]
     pub erase_otadata: bool,
     /// Image format to flash
-    #[arg(long, value_parser = clap_enum_variants!(ImageFormatType))]
-    pub format: Option<String>,
+    #[arg(long, value_parser = clap_enum_variants!(ImageFormatId))]
+    pub format: Option<ImageFormatId>,
     /// Open a serial monitor after flashing
     #[arg(long)]
     pub monitor: bool,

--- a/espflash/src/cli/mod.rs
+++ b/espflash/src/cli/mod.rs
@@ -21,7 +21,7 @@ use crate::{
     elf::ElfFirmwareImage,
     error::{MissingPartitionTable, NoOtadataError},
     flasher::{FlashFrequency, FlashMode, FlashSize, Flasher},
-    image_format::ImageFormatId,
+    image_format::ImageFormatKind,
     interface::Interface,
     targets::Chip,
 };
@@ -96,8 +96,8 @@ pub struct FlashArgs {
     #[arg(long)]
     pub erase_otadata: bool,
     /// Image format to flash
-    #[arg(long, value_parser = clap_enum_variants!(ImageFormatId))]
-    pub format: Option<ImageFormatId>,
+    #[arg(long, value_parser = clap_enum_variants!(ImageFormatKind))]
+    pub format: Option<ImageFormatKind>,
     /// Open a serial monitor after flashing
     #[arg(long)]
     pub monitor: bool,
@@ -213,7 +213,7 @@ pub fn save_elf_as_image(
     chip: Chip,
     elf_data: &[u8],
     image_path: PathBuf,
-    image_format: Option<ImageFormatId>,
+    image_format: Option<ImageFormatKind>,
     flash_mode: Option<FlashMode>,
     flash_size: Option<FlashSize>,
     flash_freq: Option<FlashFrequency>,
@@ -326,7 +326,7 @@ pub fn flash_elf_image(
     elf_data: &[u8],
     bootloader: Option<&Path>,
     partition_table: Option<&Path>,
-    image_format: Option<ImageFormatId>,
+    image_format: Option<ImageFormatKind>,
     flash_mode: Option<FlashMode>,
     flash_size: Option<FlashSize>,
     flash_freq: Option<FlashFrequency>,

--- a/espflash/src/error.rs
+++ b/espflash/src/error.rs
@@ -11,7 +11,7 @@ use thiserror::Error;
 use crate::{
     command::CommandType,
     flasher::{FlashFrequency, FlashMode, FlashSize},
-    image_format::ImageFormatId,
+    image_format::ImageFormatKind,
     interface::SerialConfigError,
     targets::Chip,
 };
@@ -69,7 +69,7 @@ pub enum Error {
     #[error("Unrecognized image format {0}")]
     #[diagnostic(
         code(espflash::unknown_format),
-        help("The following image formats are {}", ImageFormatId::VARIANTS.join(", "))
+        help("The following image formats are {}", ImageFormatKind::VARIANTS.join(", "))
     )]
     UnknownImageFormat(String),
     #[error("binary is not setup correct to support direct boot")]
@@ -396,7 +396,7 @@ impl From<u8> for FlashDetectError {
 
 #[derive(Debug)]
 pub struct UnsupportedImageFormatError {
-    format: ImageFormatId,
+    format: ImageFormatKind,
     chip: Chip,
     revision: Option<u32>,
 }
@@ -423,7 +423,7 @@ impl Diagnostic for UnsupportedImageFormatError {
     }
 
     fn help<'a>(&'a self) -> Option<Box<dyn Display + 'a>> {
-        let str = if self.chip == Chip::Esp32c3 && self.format == ImageFormatId::DirectBoot {
+        let str = if self.chip == Chip::Esp32c3 && self.format == ImageFormatKind::DirectBoot {
             format!(
                 "The {}: only supports direct-boot starting with revision 3",
                 self.chip,
@@ -440,7 +440,7 @@ impl Diagnostic for UnsupportedImageFormatError {
 }
 
 impl UnsupportedImageFormatError {
-    pub fn new(format: ImageFormatId, chip: Chip, revision: Option<u32>) -> Self {
+    pub fn new(format: ImageFormatKind, chip: Chip, revision: Option<u32>) -> Self {
         UnsupportedImageFormatError {
             format,
             chip,

--- a/espflash/src/flasher/mod.rs
+++ b/espflash/src/flasher/mod.rs
@@ -12,7 +12,7 @@ use crate::{
     connection::Connection,
     elf::{ElfFirmwareImage, FirmwareImage, RomSegment},
     error::{ConnectionError, Error, FlashDetectError, ResultExt},
-    image_format::ImageFormatId,
+    image_format::ImageFormatKind,
     interface::Interface,
     targets::Chip,
 };
@@ -630,7 +630,7 @@ impl Flasher {
         elf_data: &[u8],
         bootloader: Option<Vec<u8>>,
         partition_table: Option<PartitionTable>,
-        image_format: Option<ImageFormatId>,
+        image_format: Option<ImageFormatKind>,
         flash_mode: Option<FlashMode>,
         flash_size: Option<FlashSize>,
         flash_freq: Option<FlashFrequency>,

--- a/espflash/src/image_format/mod.rs
+++ b/espflash/src/image_format/mod.rs
@@ -56,7 +56,7 @@ pub trait ImageFormat<'a>: Send {
 #[strum(serialize_all = "kebab-case")]
 #[serde(rename_all = "kebab-case")]
 pub enum ImageFormatKind {
-    Bootloader,
+    EspBootloader,
     DirectBoot,
 }
 
@@ -65,7 +65,7 @@ impl FromStr for ImageFormatKind {
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s {
-            "bootloader" => Ok(Self::Bootloader),
+            "bootloader" => Ok(Self::EspBootloader),
             "direct-boot" => Ok(Self::DirectBoot),
             _ => Err(Error::UnknownImageFormat(s.into())),
         }

--- a/espflash/src/image_format/mod.rs
+++ b/espflash/src/image_format/mod.rs
@@ -55,12 +55,12 @@ pub trait ImageFormat<'a>: Send {
 )]
 #[strum(serialize_all = "kebab-case")]
 #[serde(rename_all = "kebab-case")]
-pub enum ImageFormatId {
+pub enum ImageFormatKind {
     Bootloader,
     DirectBoot,
 }
 
-impl FromStr for ImageFormatId {
+impl FromStr for ImageFormatKind {
     type Err = Error;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {

--- a/espflash/src/image_format/mod.rs
+++ b/espflash/src/image_format/mod.rs
@@ -18,29 +18,6 @@ mod idf_bootloader;
 const ESP_MAGIC: u8 = 0xE9;
 const WP_PIN_DISABLED: u8 = 0xEE;
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Display, EnumVariantNames)]
-#[strum(serialize_all = "kebab-case")]
-pub enum ImageFormatType {
-    Esp8266,
-    IdfBoot,
-    DirectBoot,
-}
-
-impl FromStr for ImageFormatType {
-    type Err = Error;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        use ImageFormatType::*;
-
-        match s.to_lowercase().as_str() {
-            "esp8266" => Ok(Esp8266),
-            "idf-boot" => Ok(IdfBoot),
-            "direct-boot" => Ok(DirectBoot),
-            _ => Err(Error::UnknownImageFormat(s.to_string())),
-        }
-    }
-}
-
 #[derive(Debug, Clone, Copy, Pod, Zeroable)]
 #[repr(C, packed)]
 struct EspCommonHeader {

--- a/espflash/src/targets/esp32.rs
+++ b/espflash/src/targets/esp32.rs
@@ -8,7 +8,7 @@ use crate::{
     elf::FirmwareImage,
     error::{Error, UnsupportedImageFormatError},
     flasher::{FlashFrequency, FlashMode, FlashSize},
-    image_format::{IdfBootloaderFormat, ImageFormat, ImageFormatId},
+    image_format::{IdfBootloaderFormat, ImageFormat, ImageFormatKind},
 };
 
 const CHIP_DETECT_MAGIC_VALUES: &[u32] = &[0x00f0_1d83];
@@ -150,16 +150,16 @@ impl Target for Esp32 {
         image: &'a dyn FirmwareImage<'a>,
         bootloader: Option<Vec<u8>>,
         partition_table: Option<PartitionTable>,
-        image_format: Option<ImageFormatId>,
+        image_format: Option<ImageFormatKind>,
         _chip_revision: Option<u32>,
         flash_mode: Option<FlashMode>,
         flash_size: Option<FlashSize>,
         flash_freq: Option<FlashFrequency>,
     ) -> Result<Box<dyn ImageFormat<'a> + 'a>, Error> {
-        let image_format = image_format.unwrap_or(ImageFormatId::Bootloader);
+        let image_format = image_format.unwrap_or(ImageFormatKind::Bootloader);
 
         match image_format {
-            ImageFormatId::Bootloader => Ok(Box::new(IdfBootloaderFormat::new(
+            ImageFormatKind::Bootloader => Ok(Box::new(IdfBootloaderFormat::new(
                 image,
                 Chip::Esp32,
                 PARAMS,

--- a/espflash/src/targets/esp32.rs
+++ b/espflash/src/targets/esp32.rs
@@ -156,10 +156,10 @@ impl Target for Esp32 {
         flash_size: Option<FlashSize>,
         flash_freq: Option<FlashFrequency>,
     ) -> Result<Box<dyn ImageFormat<'a> + 'a>, Error> {
-        let image_format = image_format.unwrap_or(ImageFormatKind::Bootloader);
+        let image_format = image_format.unwrap_or(ImageFormatKind::EspBootloader);
 
         match image_format {
-            ImageFormatKind::Bootloader => Ok(Box::new(IdfBootloaderFormat::new(
+            ImageFormatKind::EspBootloader => Ok(Box::new(IdfBootloaderFormat::new(
                 image,
                 Chip::Esp32,
                 PARAMS,

--- a/espflash/src/targets/esp32c2.rs
+++ b/espflash/src/targets/esp32c2.rs
@@ -8,7 +8,7 @@ use crate::{
     elf::FirmwareImage,
     error::Error,
     flasher::{FlashFrequency, FlashMode, FlashSize},
-    image_format::{DirectBootFormat, IdfBootloaderFormat, ImageFormat, ImageFormatId},
+    image_format::{DirectBootFormat, IdfBootloaderFormat, ImageFormat, ImageFormatKind},
 };
 
 pub(crate) const CHIP_DETECT_MAGIC_VALUES: &[u32] = &[
@@ -86,16 +86,16 @@ impl Target for Esp32c2 {
         image: &'a dyn FirmwareImage<'a>,
         bootloader: Option<Vec<u8>>,
         partition_table: Option<PartitionTable>,
-        image_format: Option<ImageFormatId>,
+        image_format: Option<ImageFormatKind>,
         _chip_revision: Option<u32>,
         flash_mode: Option<FlashMode>,
         flash_size: Option<FlashSize>,
         flash_freq: Option<FlashFrequency>,
     ) -> Result<Box<dyn ImageFormat<'a> + 'a>, Error> {
-        let image_format = image_format.unwrap_or(ImageFormatId::Bootloader);
+        let image_format = image_format.unwrap_or(ImageFormatKind::Bootloader);
 
         match image_format {
-            ImageFormatId::Bootloader => Ok(Box::new(IdfBootloaderFormat::new(
+            ImageFormatKind::Bootloader => Ok(Box::new(IdfBootloaderFormat::new(
                 image,
                 Chip::Esp32c2,
                 PARAMS,
@@ -105,7 +105,7 @@ impl Target for Esp32c2 {
                 flash_size,
                 flash_freq,
             )?)),
-            ImageFormatId::DirectBoot => Ok(Box::new(DirectBootFormat::new(image, 0)?)),
+            ImageFormatKind::DirectBoot => Ok(Box::new(DirectBootFormat::new(image, 0)?)),
         }
     }
 
@@ -121,8 +121,8 @@ impl Target for Esp32c2 {
         }
     }
 
-    fn supported_image_formats(&self) -> &[ImageFormatId] {
-        &[ImageFormatId::Bootloader, ImageFormatId::DirectBoot]
+    fn supported_image_formats(&self) -> &[ImageFormatKind] {
+        &[ImageFormatKind::Bootloader, ImageFormatKind::DirectBoot]
     }
 
     fn supported_build_targets(&self) -> &[&str] {

--- a/espflash/src/targets/esp32c2.rs
+++ b/espflash/src/targets/esp32c2.rs
@@ -92,10 +92,10 @@ impl Target for Esp32c2 {
         flash_size: Option<FlashSize>,
         flash_freq: Option<FlashFrequency>,
     ) -> Result<Box<dyn ImageFormat<'a> + 'a>, Error> {
-        let image_format = image_format.unwrap_or(ImageFormatKind::Bootloader);
+        let image_format = image_format.unwrap_or(ImageFormatKind::EspBootloader);
 
         match image_format {
-            ImageFormatKind::Bootloader => Ok(Box::new(IdfBootloaderFormat::new(
+            ImageFormatKind::EspBootloader => Ok(Box::new(IdfBootloaderFormat::new(
                 image,
                 Chip::Esp32c2,
                 PARAMS,
@@ -122,7 +122,7 @@ impl Target for Esp32c2 {
     }
 
     fn supported_image_formats(&self) -> &[ImageFormatKind] {
-        &[ImageFormatKind::Bootloader, ImageFormatKind::DirectBoot]
+        &[ImageFormatKind::EspBootloader, ImageFormatKind::DirectBoot]
     }
 
     fn supported_build_targets(&self) -> &[&str] {

--- a/espflash/src/targets/esp32c3.rs
+++ b/espflash/src/targets/esp32c3.rs
@@ -8,7 +8,7 @@ use crate::{
     elf::FirmwareImage,
     error::{Error, UnsupportedImageFormatError},
     flasher::{FlashFrequency, FlashMode, FlashSize},
-    image_format::{DirectBootFormat, IdfBootloaderFormat, ImageFormat, ImageFormatId},
+    image_format::{DirectBootFormat, IdfBootloaderFormat, ImageFormat, ImageFormatKind},
 };
 
 pub(crate) const CHIP_DETECT_MAGIC_VALUES: &[u32] = &[
@@ -73,16 +73,16 @@ impl Target for Esp32c3 {
         image: &'a dyn FirmwareImage<'a>,
         bootloader: Option<Vec<u8>>,
         partition_table: Option<PartitionTable>,
-        image_format: Option<ImageFormatId>,
+        image_format: Option<ImageFormatKind>,
         chip_revision: Option<u32>,
         flash_mode: Option<FlashMode>,
         flash_size: Option<FlashSize>,
         flash_freq: Option<FlashFrequency>,
     ) -> Result<Box<dyn ImageFormat<'a> + 'a>, Error> {
-        let image_format = image_format.unwrap_or(ImageFormatId::Bootloader);
+        let image_format = image_format.unwrap_or(ImageFormatKind::Bootloader);
 
         match (image_format, chip_revision) {
-            (ImageFormatId::Bootloader, _) => Ok(Box::new(IdfBootloaderFormat::new(
+            (ImageFormatKind::Bootloader, _) => Ok(Box::new(IdfBootloaderFormat::new(
                 image,
                 Chip::Esp32c3,
                 PARAMS,
@@ -92,7 +92,7 @@ impl Target for Esp32c3 {
                 flash_size,
                 flash_freq,
             )?)),
-            (ImageFormatId::DirectBoot, None | Some(3..)) => {
+            (ImageFormatKind::DirectBoot, None | Some(3..)) => {
                 Ok(Box::new(DirectBootFormat::new(image, 0)?))
             }
             _ => Err(
@@ -113,8 +113,8 @@ impl Target for Esp32c3 {
         }
     }
 
-    fn supported_image_formats(&self) -> &[ImageFormatId] {
-        &[ImageFormatId::Bootloader, ImageFormatId::DirectBoot]
+    fn supported_image_formats(&self) -> &[ImageFormatKind] {
+        &[ImageFormatKind::Bootloader, ImageFormatKind::DirectBoot]
     }
 
     fn supported_build_targets(&self) -> &[&str] {

--- a/espflash/src/targets/esp32c3.rs
+++ b/espflash/src/targets/esp32c3.rs
@@ -79,10 +79,10 @@ impl Target for Esp32c3 {
         flash_size: Option<FlashSize>,
         flash_freq: Option<FlashFrequency>,
     ) -> Result<Box<dyn ImageFormat<'a> + 'a>, Error> {
-        let image_format = image_format.unwrap_or(ImageFormatKind::Bootloader);
+        let image_format = image_format.unwrap_or(ImageFormatKind::EspBootloader);
 
         match (image_format, chip_revision) {
-            (ImageFormatKind::Bootloader, _) => Ok(Box::new(IdfBootloaderFormat::new(
+            (ImageFormatKind::EspBootloader, _) => Ok(Box::new(IdfBootloaderFormat::new(
                 image,
                 Chip::Esp32c3,
                 PARAMS,
@@ -114,7 +114,7 @@ impl Target for Esp32c3 {
     }
 
     fn supported_image_formats(&self) -> &[ImageFormatKind] {
-        &[ImageFormatKind::Bootloader, ImageFormatKind::DirectBoot]
+        &[ImageFormatKind::EspBootloader, ImageFormatKind::DirectBoot]
     }
 
     fn supported_build_targets(&self) -> &[&str] {

--- a/espflash/src/targets/esp32s2.rs
+++ b/espflash/src/targets/esp32s2.rs
@@ -8,7 +8,7 @@ use crate::{
     elf::FirmwareImage,
     error::{Error, UnsupportedImageFormatError},
     flasher::{FlashFrequency, FlashMode, FlashSize, FLASH_WRITE_SIZE},
-    image_format::{IdfBootloaderFormat, ImageFormat, ImageFormatId},
+    image_format::{IdfBootloaderFormat, ImageFormat, ImageFormatKind},
 };
 
 const CHIP_DETECT_MAGIC_VALUES: &[u32] = &[0x0000_07c6];
@@ -123,16 +123,16 @@ impl Target for Esp32s2 {
         image: &'a dyn FirmwareImage<'a>,
         bootloader: Option<Vec<u8>>,
         partition_table: Option<PartitionTable>,
-        image_format: Option<ImageFormatId>,
+        image_format: Option<ImageFormatKind>,
         _chip_revision: Option<u32>,
         flash_mode: Option<FlashMode>,
         flash_size: Option<FlashSize>,
         flash_freq: Option<FlashFrequency>,
     ) -> Result<Box<dyn ImageFormat<'a> + 'a>, Error> {
-        let image_format = image_format.unwrap_or(ImageFormatId::Bootloader);
+        let image_format = image_format.unwrap_or(ImageFormatKind::Bootloader);
 
         match image_format {
-            ImageFormatId::Bootloader => Ok(Box::new(IdfBootloaderFormat::new(
+            ImageFormatKind::Bootloader => Ok(Box::new(IdfBootloaderFormat::new(
                 image,
                 Chip::Esp32s2,
                 PARAMS,

--- a/espflash/src/targets/esp32s2.rs
+++ b/espflash/src/targets/esp32s2.rs
@@ -129,10 +129,10 @@ impl Target for Esp32s2 {
         flash_size: Option<FlashSize>,
         flash_freq: Option<FlashFrequency>,
     ) -> Result<Box<dyn ImageFormat<'a> + 'a>, Error> {
-        let image_format = image_format.unwrap_or(ImageFormatKind::Bootloader);
+        let image_format = image_format.unwrap_or(ImageFormatKind::EspBootloader);
 
         match image_format {
-            ImageFormatKind::Bootloader => Ok(Box::new(IdfBootloaderFormat::new(
+            ImageFormatKind::EspBootloader => Ok(Box::new(IdfBootloaderFormat::new(
                 image,
                 Chip::Esp32s2,
                 PARAMS,

--- a/espflash/src/targets/esp32s3.rs
+++ b/espflash/src/targets/esp32s3.rs
@@ -65,10 +65,10 @@ impl Target for Esp32s3 {
         flash_size: Option<FlashSize>,
         flash_freq: Option<FlashFrequency>,
     ) -> Result<Box<dyn ImageFormat<'a> + 'a>, Error> {
-        let image_format = image_format.unwrap_or(ImageFormatKind::Bootloader);
+        let image_format = image_format.unwrap_or(ImageFormatKind::EspBootloader);
 
         match image_format {
-            ImageFormatKind::Bootloader => Ok(Box::new(IdfBootloaderFormat::new(
+            ImageFormatKind::EspBootloader => Ok(Box::new(IdfBootloaderFormat::new(
                 image,
                 Chip::Esp32s3,
                 PARAMS,
@@ -106,7 +106,7 @@ impl Target for Esp32s3 {
     }
 
     fn supported_image_formats(&self) -> &[ImageFormatKind] {
-        &[ImageFormatKind::Bootloader, ImageFormatKind::DirectBoot]
+        &[ImageFormatKind::EspBootloader, ImageFormatKind::DirectBoot]
     }
 
     fn supported_build_targets(&self) -> &[&str] {

--- a/espflash/src/targets/esp32s3.rs
+++ b/espflash/src/targets/esp32s3.rs
@@ -8,7 +8,7 @@ use crate::{
     elf::FirmwareImage,
     error::Error,
     flasher::{FlashFrequency, FlashMode, FlashSize},
-    image_format::{DirectBootFormat, IdfBootloaderFormat, ImageFormat, ImageFormatId},
+    image_format::{DirectBootFormat, IdfBootloaderFormat, ImageFormat, ImageFormatKind},
 };
 
 pub(crate) const CHIP_DETECT_MAGIC_VALUES: &[u32] = &[0x9];
@@ -59,16 +59,16 @@ impl Target for Esp32s3 {
         image: &'a dyn FirmwareImage<'a>,
         bootloader: Option<Vec<u8>>,
         partition_table: Option<PartitionTable>,
-        image_format: Option<ImageFormatId>,
+        image_format: Option<ImageFormatKind>,
         _chip_revision: Option<u32>,
         flash_mode: Option<FlashMode>,
         flash_size: Option<FlashSize>,
         flash_freq: Option<FlashFrequency>,
     ) -> Result<Box<dyn ImageFormat<'a> + 'a>, Error> {
-        let image_format = image_format.unwrap_or(ImageFormatId::Bootloader);
+        let image_format = image_format.unwrap_or(ImageFormatKind::Bootloader);
 
         match image_format {
-            ImageFormatId::Bootloader => Ok(Box::new(IdfBootloaderFormat::new(
+            ImageFormatKind::Bootloader => Ok(Box::new(IdfBootloaderFormat::new(
                 image,
                 Chip::Esp32s3,
                 PARAMS,
@@ -78,7 +78,7 @@ impl Target for Esp32s3 {
                 flash_size,
                 flash_freq,
             )?)),
-            ImageFormatId::DirectBoot => Ok(Box::new(DirectBootFormat::new(image, 0x400)?)),
+            ImageFormatKind::DirectBoot => Ok(Box::new(DirectBootFormat::new(image, 0x400)?)),
         }
     }
 
@@ -105,8 +105,8 @@ impl Target for Esp32s3 {
         }
     }
 
-    fn supported_image_formats(&self) -> &[ImageFormatId] {
-        &[ImageFormatId::Bootloader, ImageFormatId::DirectBoot]
+    fn supported_image_formats(&self) -> &[ImageFormatKind] {
+        &[ImageFormatKind::Bootloader, ImageFormatKind::DirectBoot]
     }
 
     fn supported_build_targets(&self) -> &[&str] {

--- a/espflash/src/targets/esp8266.rs
+++ b/espflash/src/targets/esp8266.rs
@@ -8,7 +8,7 @@ use crate::{
     elf::FirmwareImage,
     error::{Error, UnsupportedImageFormatError},
     flasher::{FlashFrequency, FlashMode, FlashSize},
-    image_format::{Esp8266Format, ImageFormat, ImageFormatId},
+    image_format::{Esp8266Format, ImageFormat, ImageFormatKind},
 };
 
 pub(crate) const CHIP_DETECT_MAGIC_VALUES: &[u32] = &[0xfff0_c101];
@@ -58,16 +58,16 @@ impl Target for Esp8266 {
         image: &'a dyn FirmwareImage<'a>,
         _bootloader: Option<Vec<u8>>,
         _partition_table: Option<PartitionTable>,
-        image_format: Option<ImageFormatId>,
+        image_format: Option<ImageFormatKind>,
         _chip_revision: Option<u32>,
         flash_mode: Option<FlashMode>,
         flash_size: Option<FlashSize>,
         flash_freq: Option<FlashFrequency>,
     ) -> Result<Box<dyn ImageFormat<'a> + 'a>, Error> {
-        let image_format = image_format.unwrap_or(ImageFormatId::Bootloader);
+        let image_format = image_format.unwrap_or(ImageFormatKind::Bootloader);
 
         match image_format {
-            ImageFormatId::Bootloader => Ok(Box::new(Esp8266Format::new(
+            ImageFormatKind::Bootloader => Ok(Box::new(Esp8266Format::new(
                 image, flash_mode, flash_size, flash_freq,
             )?)),
             _ => Err(UnsupportedImageFormatError::new(image_format, Chip::Esp8266, None).into()),

--- a/espflash/src/targets/esp8266.rs
+++ b/espflash/src/targets/esp8266.rs
@@ -64,10 +64,10 @@ impl Target for Esp8266 {
         flash_size: Option<FlashSize>,
         flash_freq: Option<FlashFrequency>,
     ) -> Result<Box<dyn ImageFormat<'a> + 'a>, Error> {
-        let image_format = image_format.unwrap_or(ImageFormatKind::Bootloader);
+        let image_format = image_format.unwrap_or(ImageFormatKind::EspBootloader);
 
         match image_format {
-            ImageFormatKind::Bootloader => Ok(Box::new(Esp8266Format::new(
+            ImageFormatKind::EspBootloader => Ok(Box::new(Esp8266Format::new(
                 image, flash_mode, flash_size, flash_freq,
             )?)),
             _ => Err(UnsupportedImageFormatError::new(image_format, Chip::Esp8266, None).into()),

--- a/espflash/src/targets/mod.rs
+++ b/espflash/src/targets/mod.rs
@@ -287,7 +287,7 @@ pub trait Target: ReadEFuse {
     fn spi_registers(&self) -> SpiRegisters;
 
     fn supported_image_formats(&self) -> &[ImageFormatKind] {
-        &[ImageFormatKind::Bootloader]
+        &[ImageFormatKind::EspBootloader]
     }
 
     fn supported_build_targets(&self) -> &[&str];

--- a/espflash/src/targets/mod.rs
+++ b/espflash/src/targets/mod.rs
@@ -18,7 +18,7 @@ use crate::{
     elf::FirmwareImage,
     error::{ChipDetectError, Error},
     flasher::{FlashFrequency, FlashMode, FlashSize, SpiAttachParams, FLASH_WRITE_SIZE},
-    image_format::{ImageFormat, ImageFormatId},
+    image_format::{ImageFormat, ImageFormatKind},
 };
 
 mod esp32;
@@ -262,7 +262,7 @@ pub trait Target: ReadEFuse {
         image: &'a dyn FirmwareImage<'a>,
         bootloader: Option<Vec<u8>>,
         partition_table: Option<PartitionTable>,
-        image_format: Option<ImageFormatId>,
+        image_format: Option<ImageFormatKind>,
         chip_revision: Option<u32>,
         flash_mode: Option<FlashMode>,
         flash_size: Option<FlashSize>,
@@ -286,8 +286,8 @@ pub trait Target: ReadEFuse {
 
     fn spi_registers(&self) -> SpiRegisters;
 
-    fn supported_image_formats(&self) -> &[ImageFormatId] {
-        &[ImageFormatId::Bootloader]
+    fn supported_image_formats(&self) -> &[ImageFormatKind] {
+        &[ImageFormatKind::Bootloader]
     }
 
     fn supported_build_targets(&self) -> &[&str];


### PR DESCRIPTION
We previously had `ImageFormatId` and `ImageFormatType`, which was both confusing and unnecessary. `ImageFormatType` has been eliminated altogether. `ImageFormatId` is now called `ImageFormatKind`, and its variants are better named to allow for future expansion.