### PR TITLE
Begin work on improving documentation

### DIFF
--- a/espflash/Cargo.toml
+++ b/espflash/Cargo.toml
@@ -28,6 +28,9 @@ pkg-url = "{ repo }/releases/download/v{ version }/{ name }-{ target }.{ archive
 bin-dir = "{ bin }{ binary-ext }"
 pkg-fmt = "zip"
 
+[package.metadata.docs.rs]
+rustdoc-args = ["--cfg", "docsrs"]
+
 [[bin]]
 name = "espflash"
 path = "./src/bin/espflash.rs"

--- a/espflash/src/cli/config.rs
+++ b/espflash/src/cli/config.rs
@@ -1,3 +1,12 @@
+//! Command-line interface configuration
+//!
+//! Both [cargo-espflash] and [espflash] allow for the use of configuration
+//! files; the [Config] type handles the loading and saving of this
+//! configuration file.
+//!
+//! [cargo-espflash]: https://crates.io/crates/cargo-espflash
+//! [espflash]: https://crates.io/crates/espflash
+
 use directories_next::ProjectDirs;
 use miette::{IntoDiagnostic, Result, WrapErr};
 use serde::{Deserialize, Serialize};

--- a/espflash/src/cli/config.rs
+++ b/espflash/src/cli/config.rs
@@ -7,24 +7,18 @@
 //! [cargo-espflash]: https://crates.io/crates/cargo-espflash
 //! [espflash]: https://crates.io/crates/espflash
 
+use std::{
+    fs::{create_dir_all, read, write},
+    path::PathBuf,
+};
+
 use directories_next::ProjectDirs;
 use miette::{IntoDiagnostic, Result, WrapErr};
 use serde::{Deserialize, Serialize};
 use serde_hex::{Compact, SerHex};
 use serialport::UsbPortInfo;
-use std::fs::{create_dir_all, read, write};
-use std::path::PathBuf;
 
-#[derive(Debug, Deserialize, Serialize, Default, Clone)]
-pub struct Config {
-    #[serde(default)]
-    pub connection: Connection,
-    #[serde(default)]
-    pub usb_device: Vec<UsbDevice>,
-    #[serde(skip)]
-    save_path: PathBuf,
-}
-
+/// A configured, known serial connection
 #[derive(Debug, Deserialize, Serialize, Default, Clone)]
 pub struct Connection {
     pub serial: Option<String>,
@@ -34,6 +28,7 @@ pub struct Connection {
     pub dtr: Option<u8>,
 }
 
+/// A configured, known USB device
 #[derive(Debug, Deserialize, Serialize, Default, Clone)]
 pub struct UsbDevice {
     #[serde(with = "SerHex::<Compact>")]
@@ -46,6 +41,17 @@ impl UsbDevice {
     pub fn matches(&self, port: &UsbPortInfo) -> bool {
         self.vid == port.vid && self.pid == port.pid
     }
+}
+
+/// Deserialized contents of a configuration file
+#[derive(Debug, Deserialize, Serialize, Default, Clone)]
+pub struct Config {
+    #[serde(default)]
+    pub connection: Connection,
+    #[serde(default)]
+    pub usb_device: Vec<UsbDevice>,
+    #[serde(skip)]
+    save_path: PathBuf,
 }
 
 impl Config {

--- a/espflash/src/cli/mod.rs
+++ b/espflash/src/cli/mod.rs
@@ -1,6 +1,11 @@
-//! CLI utilities shared between espflash and cargo-espflash
+//! Types and functions for the command-line interface
 //!
-//! No stability guaranties apply
+//! The contents of this module are intended for use with the [cargo-espflash]
+//! and [espflash] command-line applications, and are likely not of much use
+//! otherwise.
+//!
+//! [cargo-espflash]: https://crates.io/crates/cargo-espflash
+//! [espflash]: https://crates.io/crates/espflash
 
 use std::{
     fs,

--- a/espflash/src/cli/mod.rs
+++ b/espflash/src/cli/mod.rs
@@ -45,6 +45,7 @@ mod serial;
 //
 // See this comment for details:
 // https://github.com/clap-rs/clap/discussions/4264#discussioncomment-3737696
+#[doc(hidden)]
 #[macro_export]
 macro_rules! clap_enum_variants {
     ($e: ty) => {{
@@ -55,6 +56,7 @@ macro_rules! clap_enum_variants {
 
 pub use clap_enum_variants;
 
+/// Establish a connection with a target device
 #[derive(Debug, Args)]
 pub struct ConnectArgs {
     /// Baud rate at which to communicate with target device
@@ -76,6 +78,7 @@ pub struct ConnectArgs {
     pub use_stub: bool,
 }
 
+/// Configure communication with the target device's flash
 #[derive(Debug, Args)]
 pub struct FlashConfigArgs {
     /// Flash frequency
@@ -89,6 +92,7 @@ pub struct FlashConfigArgs {
     pub flash_size: Option<FlashSize>,
 }
 
+/// Flash an application to a target device
 #[derive(Debug, Args)]
 #[group(skip)]
 pub struct FlashArgs {
@@ -157,6 +161,7 @@ pub struct SaveImageArgs {
     pub skip_padding: bool,
 }
 
+/// Select a serial port and establish a connection with a target device
 pub fn connect(args: &ConnectArgs, config: &Config) -> Result<Flasher> {
     let port_info = get_serial_port_info(args, config)?;
 
@@ -192,6 +197,7 @@ pub fn connect(args: &ConnectArgs, config: &Config) -> Result<Flasher> {
     )?)
 }
 
+/// Connect to a target device and print information about its chip
 pub fn board_info(args: ConnectArgs, config: &Config) -> Result<()> {
     let mut flasher = connect(&args, config)?;
     flasher.board_info()?;
@@ -199,6 +205,7 @@ pub fn board_info(args: ConnectArgs, config: &Config) -> Result<()> {
     Ok(())
 }
 
+/// Open a serial monitor
 pub fn serial_monitor(args: ConnectArgs, config: &Config) -> Result<()> {
     let flasher = connect(&args, config)?;
     let pid = flasher.get_usb_pid()?;
@@ -214,6 +221,7 @@ pub fn serial_monitor(args: ConnectArgs, config: &Config) -> Result<()> {
     Ok(())
 }
 
+/// Convert the provided firmware image from ELF to binary
 pub fn save_elf_as_image(
     chip: Chip,
     elf_data: &[u8],
@@ -326,6 +334,7 @@ pub fn save_elf_as_image(
     Ok(())
 }
 
+/// Write an ELF image to a target device's flash
 pub fn flash_elf_image(
     flasher: &mut Flasher,
     elf_data: &[u8],
@@ -397,6 +406,7 @@ pub fn flash_elf_image(
     Ok(())
 }
 
+/// Convert and display CSV and binary partition tables
 pub fn partition_table(args: PartitionTableArgs) -> Result<()> {
     if args.to_binary {
         let input = fs::read_to_string(&args.partition_table).into_diagnostic()?;

--- a/espflash/src/cli/monitor/mod.rs
+++ b/espflash/src/cli/monitor/mod.rs
@@ -70,6 +70,7 @@ impl Drop for RawModeGuard {
     }
 }
 
+/// Open a serial monitor on the given interface
 pub fn monitor(
     mut serial: Interface,
     elf: Option<&[u8]>,

--- a/espflash/src/cli/monitor/mod.rs
+++ b/espflash/src/cli/monitor/mod.rs
@@ -1,3 +1,15 @@
+//! Serial monitor utility
+//!
+//! While simple, this serial monitor does provide some nice features such as:
+//!
+//! - Keyboard shortcut for resetting the device (Ctrl-R)
+//! - Decoding of function addresses in serial output
+//!
+//! While some serial monitors buffer output until a newline is encountered,
+//! that is not the case here. With other monitors the output of a `print!()`
+//! call are not displayed until `println!()` is subsequently called, where as
+//! in our monitor the output is displayed immediately upon reading.
+
 use std::{
     io::{stdout, ErrorKind, Write},
     time::Duration,

--- a/espflash/src/connection.rs
+++ b/espflash/src/connection.rs
@@ -22,6 +22,7 @@ use crate::{
 const DEFAULT_CONNECT_ATTEMPTS: usize = 7;
 pub(crate) const USB_SERIAL_JTAG_PID: u16 = 0x1001;
 
+/// A response from a target device following a command
 #[derive(Debug, Copy, Clone, BinRead)]
 pub struct CommandResponse {
     pub resp: u8,
@@ -32,6 +33,7 @@ pub struct CommandResponse {
     pub error: u8,
 }
 
+/// An established connection with a target device
 pub struct Connection {
     serial: Interface,
     port_info: UsbPortInfo,
@@ -284,6 +286,7 @@ impl Connection {
     }
 }
 
+/// Reset the target device when flashing has completed
 pub fn reset_after_flash(serial: &mut Interface, pid: u16) -> Result<(), serialport::Error> {
     sleep(Duration::from_millis(100));
 

--- a/espflash/src/connection.rs
+++ b/espflash/src/connection.rs
@@ -1,3 +1,9 @@
+//! Establish a connection with a target device
+//!
+//! The [Connection] struct abstracts over the serial connection and
+//! sending/decoding of commands, and provides higher-level operations with the
+//! device.
+
 use std::{io::BufWriter, thread::sleep, time::Duration};
 
 use binread::{io::Cursor, BinRead, BinReaderExt};

--- a/espflash/src/elf.rs
+++ b/espflash/src/elf.rs
@@ -1,3 +1,5 @@
+//! ELF (Executable and Linkable Format) file operations
+
 use std::{
     borrow::Cow,
     cmp::Ordering,

--- a/espflash/src/error.rs
+++ b/espflash/src/error.rs
@@ -1,3 +1,5 @@
+//! Library and application errors
+
 use std::{
     fmt::{Display, Formatter},
     io,

--- a/espflash/src/flasher/mod.rs
+++ b/espflash/src/flasher/mod.rs
@@ -1,3 +1,9 @@
+//! Write a binary application to a target device
+//!
+//! The [Flasher] struct abstracts over various operations for writing a binary
+//! application to a target device. It additionally provides some operations to
+//! read information from the target device.
+
 use std::{borrow::Cow, str::FromStr, thread::sleep};
 
 use bytemuck::{Pod, Zeroable, __core::time::Duration};

--- a/espflash/src/flasher/mod.rs
+++ b/espflash/src/flasher/mod.rs
@@ -37,6 +37,9 @@ const CHIP_DETECT_MAGIC_REG_ADDR: u32 = 0x40001000;
 
 const EXPECTED_STUB_HANDSHAKE: &str = "OHAI";
 
+/// Supported flash frequencies
+///
+/// Note that not all frequencies are supported by each target device.
 #[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, Display, EnumVariantNames)]
 #[repr(u8)]
 pub enum FlashFrequency {
@@ -87,6 +90,7 @@ impl FromStr for FlashFrequency {
     }
 }
 
+/// Supported flash modes
 #[derive(Copy, Clone, Debug, EnumVariantNames)]
 #[strum(serialize_all = "lowercase")]
 pub enum FlashMode {
@@ -112,6 +116,9 @@ impl FromStr for FlashMode {
     }
 }
 
+/// Supported flash sizes
+///
+/// Note that not all sizes are supported by each target device.
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Display, EnumVariantNames)]
 #[repr(u8)]
 pub enum FlashSize {
@@ -193,6 +200,7 @@ impl FromStr for FlashSize {
     }
 }
 
+/// Parameters for attaching to a target devices SPI flash
 #[derive(Copy, Clone, Debug)]
 #[repr(C)]
 pub struct SpiAttachParams {
@@ -271,6 +279,7 @@ struct EntryParams {
     entry: u32,
 }
 
+/// Connect to and flash a target device
 pub struct Flasher {
     /// Connection for flash operations
     connection: Connection,

--- a/espflash/src/image_format/mod.rs
+++ b/espflash/src/image_format/mod.rs
@@ -1,4 +1,9 @@
 //! Supported binary image formats
+//!
+//! Since the ESP8266 is not supported by ESP-IDF, it has its own image format
+//! which must be used. All other devices support the ESP-IDF bootloader format.
+//! Certain devices additionall support direct boot, which needs its own unique
+//! image format.
 
 use std::str::FromStr;
 

--- a/espflash/src/lib.rs
+++ b/espflash/src/lib.rs
@@ -1,3 +1,49 @@
+//! A library and application for flashing Espressif devices over Serial
+//!
+//! ## As an application
+//!
+//! [espflash] can be installed using `cargo install`, and additionally supports installation via [cargo-binstall]:
+//!
+//! ```bash
+//! $ cargo install espflash
+//! $ cargo binstall espflash
+//! ```
+//!
+//! Flashing via a Raspberry Pi's internal UART is also possible, however this
+//! functionality is gated behind the `raspberry` feature; if you would like to
+//! enable this simply enable the feature when installing:
+//!
+//! ```bash
+//! $ cargo install espflash --feature=raspberry
+//! ```
+//!
+//! Note that this feature can only be enabled on a Raspberry Pi, as it depends
+//! on the [rppal] package which will not build on most systems.
+//!
+//! ## As a library
+//!
+//! [espflash] can also be used as a library:
+//!
+//! ```toml
+//! espflash = { version = "2.0", default-features = false }
+//! ```
+//!
+//! We add `default-features` here to disable the `cli` feature, which is
+//! enabled by default; you likely will not need any of these types or functions
+//! in your application so there's no use pulling in the extra dependencies.
+//!
+//! Just like when using [espflash] as an application, you can enable the
+//! `raspberry` feature to allow your dependent application to use the Raspberry
+//! Pi's built-in UART:
+//!
+//! ```toml
+//! espflash = { version = "2.0", default-features = false, features = ["raspberry"] }
+//! ```
+//!
+//! [espflash]: https://crates.io/crates/espflash
+//! [cargo-binstall]: https://github.com/cargo-bins/cargo-binstall
+//! [rppal]: https://docs.rs/rppal/latest/rppal/
+
 #[cfg(feature = "cli")]
 pub mod cli;
 pub mod connection;
@@ -10,6 +56,7 @@ pub mod targets;
 mod command;
 mod interface;
 
+/// Logging utilties
 pub mod logging {
     use env_logger::Env;
     use log::LevelFilter;
@@ -21,6 +68,7 @@ pub mod logging {
     }
 }
 
+/// Check for updates
 #[cfg(feature = "cli")]
 pub mod update {
     use std::time::Duration;

--- a/espflash/src/lib.rs
+++ b/espflash/src/lib.rs
@@ -66,6 +66,7 @@ pub mod logging {
     use env_logger::Env;
     use log::LevelFilter;
 
+    /// Initialize the logger with the given [LevelFilter]
     pub fn initialize_logger(filter: LevelFilter) {
         env_logger::Builder::from_env(Env::default().default_filter_or(filter.as_str()))
             .format_target(false)
@@ -82,6 +83,7 @@ pub mod update {
     use log::info;
     use update_informer::{registry, Check};
 
+    /// Check crates.io for a new version of the application
     pub fn check_for_update(name: &str, version: &str) {
         // By setting the interval to 0 seconds we invalidate the cache with each
         // invocation and ensure we're getting up-to-date results

--- a/espflash/src/lib.rs
+++ b/espflash/src/lib.rs
@@ -44,7 +44,10 @@
 //! [cargo-binstall]: https://github.com/cargo-bins/cargo-binstall
 //! [rppal]: https://docs.rs/rppal/latest/rppal/
 
+#![cfg_attr(docsrs, feature(doc_cfg))]
+
 #[cfg(feature = "cli")]
+#[cfg_attr(docsrs, doc(cfg(feature = "cli")))]
 pub mod cli;
 pub mod connection;
 pub mod elf;
@@ -57,6 +60,8 @@ mod command;
 mod interface;
 
 /// Logging utilties
+#[cfg(feature = "cli")]
+#[cfg_attr(docsrs, doc(cfg(feature = "cli")))]
 pub mod logging {
     use env_logger::Env;
     use log::LevelFilter;
@@ -70,6 +75,7 @@ pub mod logging {
 
 /// Check for updates
 #[cfg(feature = "cli")]
+#[cfg_attr(docsrs, doc(cfg(feature = "cli")))]
 pub mod update {
     use std::time::Duration;
 

--- a/espflash/src/targets/mod.rs
+++ b/espflash/src/targets/mod.rs
@@ -1,3 +1,11 @@
+//! Flashable target devices
+//!
+//! Different devices support different boot options; the ESP8266 does not use a
+//! second-stage bootloader, nor does direct boot (only supported by certain
+//! devices). All ESP32* devices support booting via the ESP-IDF bootloader.
+//! It's also possible to write an application to and boot from RAM, where a
+//! bootloader is obviously not required either.
+
 use std::{collections::HashMap, str::FromStr};
 
 use esp_idf_part::{AppType, DataType, Partition, PartitionTable, SubType, Type};


### PR DESCRIPTION
This is just a first-pass, still a lot of room for improvement. This, at the very least, ensures that the top-level documentation shows something useful, and that each module has at least _some_ description. A good number of types and functions have documentation, but again it can definitely be better.

You can build locally and see the feature gates by running:

```bash
$ cargo rustdoc --open -- --cfg docsrs
```