### PR TITLE
Re-write all the READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,90 +1,31 @@
 # espflash
 
-[![Actions Status](https://github.com/esp-rs/espflash/workflows/CI/badge.svg)](https://github.com/esp-rs/espflash/actions?query=workflow%3A"CI")
-![Crates.io](https://img.shields.io/crates/l/espflash)
+![GitHub Workflow Status](https://img.shields.io/github/workflow/status/esp-rs/espflash/CI?label=CI&labelColor=1C2C2E&logo=github&style=flat-square)
+![Crates.io](https://img.shields.io/crates/l/espflash?labelColor=1C2C2E&style=flat-square)
+[![Matrix](https://img.shields.io/matrix/esp-rs:matrix.org?label=join%20matrix&color=BEC5C9&labelColor=1C2C2E&logo=matrix&style=flat-square)](https://matrix.to/#/#esp-rs:matrix.org)
 
-Serial flasher utility for Espressif SoCs and modules based on [esptool.py].
+Serial flasher utilities for Espressif devices, based loosely on [esptool.py](https://github.com/espressif/esptool/).
 
-Currently supports the **ESP32**, **ESP32-C3**, **ESP32-S2**, **ESP32-S3**, and **ESP8266**.
+Supports the **ESP32**, **ESP32-C2**, **ESP32-C3**, **ESP32-S2**, **ESP32-S3**, and **ESP8266**.
 
-### cargo-espflash
+## [cargo-espflash](./cargo-espflash/)
 
-[cargo-espflash] is a subcommand for Cargo which utilizes the [espflash] library. This tool integrates with your Cargo projects and handles compilation, flashing, and monitoring of target devices.
+A cargo extension for flashing Espressif devices.
 
-Please see the [cargo-espflash README] for more information.
+For more information and installation instructions, please refer to the `cargo-espflash` package's [README](./cargo-espflash/README.md).
 
-#### Example
+## [espflash](./espflash/)
 
-```shell
-$ cargo espflash --release --example=blinky /dev/ttyUSB0
-```
+A library and command-line tool for flashing Espressif devices.
 
-[cargo-espflash readme]: https://github.com/esp-rs/espflash/blob/main/cargo-espflash/README.md
-
-### espflash
-
-[espflash] is a standalone binary and library contained within the same crate. This tool does not integrate with Cargo, but supports all of the same features as [cargo-espflash] which are not related to compilation.
-
-Please see the [espflash README] for more information.
-
-#### Example
-
-```shell
-$ espflash /dev/ttyUSB0 target/xtensa-esp32-none-elf/release/examples/blinky
-```
-
-[espflash readme]: https://github.com/esp-rs/espflash/blob/main/espflash/README.md
-[esptool.py]: https://github.com/espressif/esptool
-[cargo-espflash]: https://github.com/esp-rs/espflash/tree/main/cargo-espflash
-[espflash]: https://github.com/esp-rs/espflash/tree/main/espflash
-
-## Installation
-
-Either application can be installed using `cargo` as you normally would:
-
-```shell
-$ cargo install cargo-espflash
-$ cargo install espflash
-```
-
-Alternatively, you can use [cargo-binstall] to install pre-compiled binaries on any supported system. Please check the [releases] to see which architectures and operating systems have pre-compiled binaries.
-
-```shell
-$ cargo binstall cargo-espflash
-$ cargo binstall espflash
-```
-
-[cargo-binstall]: https://github.com/ryankurte/cargo-binstall
-[releases]: https://github.com/esp-rs/espflash/releases
-
-## Notes on Building
-
-Requires `rustc >= 1.60.0` in order to build either application from source. In addition to the Rust toolchain [libuv](https://libuv.org/) must also be present on your system; this can be installed via most popular package managers.
-
-#### macOS
-
-```bash
-$ brew install libuv
-```
-
-#### Ubuntu
-
-```bash
-$ sudo apt-get install libuv-dev
-```
-
-#### Fedora
-
-```bash
-$ dnf install systemd-devel
-```
+For more information and installation instructions, please refer to the `espflash` package's [README](./espflash/README.md).
 
 ## License
 
 Licensed under either of:
 
-- Apache License, Version 2.0 ([LICENSE-APACHE](LICENSE-APACHE) or http://www.apache.org/licenses/LICENSE-2.0)
-- MIT license ([LICENSE-MIT](LICENSE-MIT) or http://opensource.org/licenses/MIT)
+- Apache License, Version 2.0 ([LICENSE-APACHE](./LICENSE-APACHE) or http://www.apache.org/licenses/LICENSE-2.0)
+- MIT license ([LICENSE-MIT](./LICENSE-MIT) or http://opensource.org/licenses/MIT)
 
 at your option.
 

--- a/cargo-espflash/README.md
+++ b/cargo-espflash/README.md
@@ -1,86 +1,92 @@
 # cargo-espflash
 
-Cross-compiler and serial flasher cargo subcommand for Espressif SoCs and modules.
+[![Crates.io](https://img.shields.io/crates/v/cargo-espflash?labelColor=1C2C2E&color=C96329&logo=Rust&style=flat-square)](https://crates.io/crates/cargo-espflash)
+![MSRV](https://img.shields.io/badge/MSRV-1.60-blue?labelColor=1C2C2E&logo=Rust&style=flat-square)
+![Crates.io](https://img.shields.io/crates/l/cargo-espflash?labelColor=1C2C2E&style=flat-square)
 
-Currently supports the **ESP32**, **ESP32-C3**, **ESP32-S2**, **ESP32-S3**, and **ESP8266**.
+Cross-compiler and Cargo extension for flashing Espressif devices over serial.
 
-Prior to flashing, the project is built using the `build-std` unstable Cargo feature. Please refer to the [cargo documentation] for more information.
-
-[cargo documentation]: https://doc.rust-lang.org/cargo/reference/unstable.html#build-std
+Supports the **ESP32**, **ESP32-C2**, **ESP32-C3**, **ESP32-S2**, **ESP32-S3**, and **ESP8266**.
 
 ## Installation
 
-```shell
+If you are installing `cargo-espflash` from source (ie. using `cargo install`) then you must have `rustc>=1.60.0` installed on your system. Additionally [libuv] must be installed; this is available via most popular package managers.
+
+```bash
+$ # macOS
+$ brew install libuv
+$ # Debian/Ubuntu/etc.
+$ apt-get install libuv-dev
+$ # Fedora
+$ dnf install systemd-devel
+```
+
+To install:
+
+```bash
 $ cargo install cargo-espflash
 ```
 
-Alternatively, you can use [cargo-binstall] to install pre-compiled binaries on any supported system. Please check the [releases] to see which architectures and operating systems have pre-compiled binaries.
+Alternatively, you can use [cargo-binstall] to download pre-compiled artifacts from the [releases] and use them instead:
 
-```shell
-$ cargo install cargo-binstall
+```bash
 $ cargo binstall cargo-espflash
 ```
 
-[cargo-binstall]: https://github.com/ryankurte/cargo-binstall
+If you would like to flash from a Raspberry Pi using the built-in UART peripheral, you can enable the `raspberry` feature (note that this is not available if using [cargo-binstall]):
+
+```bash
+$ cargo install cargo-espflash --features=raspberry
+```
+
+[libuv]: (https://libuv.org/)
+[cargo-binstall]: (https://github.com/cargo-bins/cargo-binstall)
 [releases]: https://github.com/esp-rs/espflash/releases
 
 ## Usage
 
 ```text
-cargo-espflash 2.0.0-dev
-Cargo subcommand for flashing Espressif devices over serial
+A cargo extension for flashing Espressif devices
 
-USAGE:
-    cargo espflash <SUBCOMMAND>
+Usage: cargo espflash <COMMAND>
 
-OPTIONS:
-    -h, --help       Print help information
-    -V, --version    Print version information
+Commands:
+  board-info       Display information about the connected board and exit without flashing
+  flash            Flash an application to a target device
+  monitor          Open the serial monitor without flashing
+  partition-table  Operations for partitions tables
+  save-image       Save the image to disk instead of flashing to device
+  help             Print this message or the help of the given subcommand(s)
 
-SUBCOMMANDS:
-    board-info         Display information about the connected board and exit without flashing
-    flash              Flash an application to a target device
-    help               Print this message or the help of the given subcommand(s)
-    monitor            Open the serial monitor without flashing
-    partition-table    Operations for partitions tables
-    save-image         Save the image to disk instead of flashing to device
+Options:
+  -h, --help     Print help information
+  -V, --version  Print version information
+```
+
+## Package Metadata
+
+You're able to specify paths to bootloader and partition table files ands image format in your package's Cargo metadata for per-project configuration:
+
+```toml
+[package.metadata.espflash]
+bootloader      = "bootloader.bin" # Must be a binary file
+partition_table = "partitions.csv" # Supports CSV and binary formats
+format          = "direct-boot"    # Can be 'esp-bootloader' or 'direct-boot'
 ```
 
 ## Configuration
 
-You can also specify the serial port and/or expected VID/PID values by setting them in the configuration file. This file is in different locations depending on your operating system:
+It's possible to specify a serial port and/or USB VID/PID values by setting them in a configuration file. The location of this file differs based on your operating system:
 
-| Operating System | Configuration Path                                                       |
-| :--------------- | :----------------------------------------------------------------------- |
-| **Linux:**       | `/home/alice/.config/espflash/espflash.toml`                             |
-| **Windows:**     | `C:\Users\Alice\AppData\Roaming\esp\espflash\espflash.toml`              |
-| **macOS:**       | `/Users/Alice/Library/Application Support/rs.esp.espflash/espflash.toml` |
-
-An example configuration file may look as follows (note that TOML does _not_ support hexadecimal literals):
-
-```toml
-[connection]
-serial = "/dev/ttyUSB0"
-
-[[usb_device]]
-vid = "303A"
-pid = "8000"
-```
+| Operating System | Configuration Path                                                |
+| :--------------- | :---------------------------------------------------------------- |
+| Linux            | `$HOME/.config/espflash/espflash.toml`                            |
+| macOS            | `$HOME/Library/Application Support/rs.esp.espflash/espflash.toml` |
+| Windows          | `%APPDATA%\esp\espflash\espflash.toml`                            |
 
 ## WSL2
 
-It is not possible to flash `usb-serial-jtag` chips with `WSL2` because the reset also resets `serial-jtag-peripheral` which disconnects the chip from WSL2.
-
-## Package Metadata
-
-You can specify the bootloader, partition table, or image format for a project in the package metadata in `Cargo.toml`:
-
-```toml
-[package.metadata.espflash]
-partition_table = "partitions.csv"
-bootloader = "bootloader.bin"
-format = "direct-boot"
-```
+It is not possible to flash chips using the built-in `USB_SERIAL_JTAG` when using WSL2, because the reset also resets `USB_SERIAL_JTAG` peripheral which then disconnects the chip from WSL2.
 
 ## License
 

--- a/cargo-espflash/README.md
+++ b/cargo-espflash/README.md
@@ -10,33 +10,35 @@ Supports the **ESP32**, **ESP32-C2**, **ESP32-C3**, **ESP32-S2**, **ESP32-S3**, 
 
 ## Installation
 
-If you are installing `cargo-espflash` from source (ie. using `cargo install`) then you must have `rustc>=1.60.0` installed on your system. Additionally [libuv] must be installed; this is available via most popular package managers.
+If you are installing `cargo-espflash` from source (ie. using `cargo install`) then you must have `rustc>=1.60.0` installed on your system.
+
+If you are running **macOS** or **Linux** then [libuv] must also be installed; this is available via most popular package managers. If you are running **Windows** you can ignore this step.
 
 ```bash
-$ # macOS
-$ brew install libuv
-$ # Debian/Ubuntu/etc.
-$ apt-get install libuv-dev
-$ # Fedora
-$ dnf install systemd-devel
+# macOS
+brew install libuv
+# Debian/Ubuntu/etc.
+apt-get install libuv-dev
+# Fedora
+dnf install systemd-devel
 ```
 
 To install:
 
 ```bash
-$ cargo install cargo-espflash
+cargo install cargo-espflash
 ```
 
 Alternatively, you can use [cargo-binstall] to download pre-compiled artifacts from the [releases] and use them instead:
 
 ```bash
-$ cargo binstall cargo-espflash
+cargo binstall cargo-espflash
 ```
 
 If you would like to flash from a Raspberry Pi using the built-in UART peripheral, you can enable the `raspberry` feature (note that this is not available if using [cargo-binstall]):
 
 ```bash
-$ cargo install cargo-espflash --features=raspberry
+cargo install cargo-espflash --features=raspberry
 ```
 
 [libuv]: (https://libuv.org/)

--- a/espflash/README.md
+++ b/espflash/README.md
@@ -11,33 +11,35 @@ Supports the **ESP32**, **ESP32-C2**, **ESP32-C3**, **ESP32-S2**, **ESP32-S3**, 
 
 ## Installation
 
-If you are installing `espflash` from source (ie. using `cargo install`) then you must have `rustc>=1.60.0` installed on your system. Additionally [libuv] must be installed; this is available via most popular package managers.
+If you are installing `espflash` from source (ie. using `cargo install`) then you must have `rustc>=1.60.0` installed on your system.
+
+If you are running **macOS** or **Linux** then [libuv] must also be installed; this is available via most popular package managers. If you are running **Windows** you can ignore this step.
 
 ```bash
-$ # macOS
-$ brew install libuv
-$ # Debian/Ubuntu/etc.
-$ apt-get install libuv-dev
-$ # Fedora
-$ dnf install systemd-devel
+# macOS
+brew install libuv
+# Debian/Ubuntu/etc.
+apt-get install libuv-dev
+# Fedora
+dnf install systemd-devel
 ```
 
 To install:
 
 ```bash
-$ cargo install espflash
+cargo install espflash
 ```
 
 Alternatively, you can use [cargo-binstall] to download pre-compiled artifacts from the [releases] and use them instead:
 
 ```bash
-$ cargo binstall espflash
+cargo binstall espflash
 ```
 
 If you would like to flash from a Raspberry Pi using the built-in UART peripheral, you can enable the `raspberry` feature (note that this is not available if using [cargo-binstall]):
 
 ```bash
-$ cargo install espflash --features=raspberry
+cargo install espflash --features=raspberry
 ```
 
 [libuv]: (https://libuv.org/)
@@ -71,7 +73,7 @@ You can also use `espflash` as a Cargo runner by adding the following to your pr
 
 ```toml
 [target.'cfg(any(target_arch = "riscv32", target_arch = "xtensa"))']
-runner = "espflash --baud=921600 --ram --monitor /dev/ttyUSB0"
+runner = "espflash --baud=921600 --monitor /dev/ttyUSB0"
 ```
 
 With this configuration you can flash and monitor you application using `cargo run`.


### PR DESCRIPTION
Pretty self-explanatory.

I wanted to pull as much out of the repo-level `README` as possible, as you only ever see it looking at the repository on GitHub. The other two files are rendered on [crates.io](https://crates.io) so they contain all relevant information, with plenty of duplication between the two files as necessary.

Rendered views:
- [`cargo-espflash/README.md`](https://github.com/esp-rs/espflash/tree/d0402d964bf029ac1aa81a31b938eedd03de96df/cargo-espflash)
- [`espflash/README.md`](https://github.com/esp-rs/espflash/tree/d0402d964bf029ac1aa81a31b938eedd03de96df/espflash)
- [`README.md` ](https://github.com/esp-rs/espflash/blob/d0402d964bf029ac1aa81a31b938eedd03de96df/README.md)

Please let me know if you feel anything is missing, or if any formatting/wording/etc. can be improved.