### PR TITLE
connection: Swap error and status in CommandResponse

### DIFF
--- a/espflash/src/connection.rs
+++ b/espflash/src/connection.rs
@@ -22,8 +22,8 @@ pub struct CommandResponse {
     pub return_op: u8,
     pub return_length: u16,
     pub value: u32,
-    pub status: u8,
     pub error: u8,
+    pub status: u8,
 }
 
 pub struct Connection {


### PR DESCRIPTION
In [stub_flasher.c:319](https://github.com/espressif/esptool/blob/52278a9c695d9d4298bed00085947b8cb28b1539/flasher_stub/stub_flasher.c#L319) we can see that error is sent before status:
```c
SLIP_send_frame_data(error);
SLIP_send_frame_data(status);
SLIP_send_frame_delimiter();
```

This PR swap those two fields in the `CommandResponse` struct.