### PR TITLE
connection: error handling

### DIFF
--- a/espflash/src/connection.rs
+++ b/espflash/src/connection.rs
@@ -226,7 +226,7 @@ impl Connection {
         for _ in 0..100 {
             match self.read_response().for_command(ty)? {
                 Some(response) if response.return_op == ty as u8 => {
-                    return if response.status == 1 {
+                    return if response.error != 0 {
                         let _error = self.flush();
                         Err(Error::RomError(RomError::new(
                             command.command_type(),

--- a/espflash/src/error.rs
+++ b/espflash/src/error.rs
@@ -287,6 +287,38 @@ pub enum RomErrorKind {
     #[error("Malformed compressed data received")]
     #[diagnostic(code(espflash::rom::deflate))]
     DeflateError = 0x0b,
+
+    #[error("Bad data length")]
+    #[diagnostic(code(espflash::rom::data_len))]
+    BadDataLen = 0xc0,
+    #[error("Bad data checksum")]
+    #[diagnostic(code(espflash::rom::data_crc))]
+    BadDataChecksum = 0xc1,
+    #[error("Bad block isze")]
+    #[diagnostic(code(espflash::rom::block_size))]
+    BadBlocksize = 0xc2,
+    #[error("Invalid command")]
+    #[diagnostic(code(espflash::rom::cmd))]
+    InvalidCommand = 0xc3,
+    #[error("SPI operation failed")]
+    #[diagnostic(code(espflash::rom::spi))]
+    FailedSpiOp = 0xc4,
+    #[error("SPI unlock failed")]
+    #[diagnostic(code(espflash::rom::spi_unlock))]
+    FailedSpiUnlock = 0xc5,
+    #[error("Not in flash mode")]
+    #[diagnostic(code(espflash::rom::flash_mode))]
+    NotInFlashMode = 0xc6,
+    #[error("Error when uncompressing the data")]
+    #[diagnostic(code(espflash::rom::inflate))]
+    InflateError = 0xc7,
+    #[error("Didn't receive enough data")]
+    #[diagnostic(code(espflash::rom::not_enough))]
+    NotEnoughData = 0xc8,
+    #[error("Received too much data")]
+    #[diagnostic(code(espflash::rom::too_much_data))]
+    TooMuchData = 0xc9,
+
     #[error("Other")]
     #[diagnostic(code(espflash::rom::other))]
     Other = 0xff,
@@ -302,6 +334,18 @@ impl From<u8> for RomErrorKind {
             0x09 => RomErrorKind::FlashReadError,
             0x0a => RomErrorKind::FlashReadLengthError,
             0x0b => RomErrorKind::DeflateError,
+
+            0xc0 => RomErrorKind::BadDataLen,
+            0xc1 => RomErrorKind::BadDataChecksum,
+            0xc2 => RomErrorKind::BadBlocksize,
+            0xc3 => RomErrorKind::InvalidCommand,
+            0xc4 => RomErrorKind::FailedSpiOp,
+            0xc5 => RomErrorKind::FailedSpiUnlock,
+            0xc6 => RomErrorKind::NotInFlashMode,
+            0xc7 => RomErrorKind::InflateError,
+            0xc8 => RomErrorKind::NotEnoughData,
+            0xc9 => RomErrorKind::TooMuchData,
+            
             _ => RomErrorKind::Other,
         }
     }

--- a/espflash/src/error.rs
+++ b/espflash/src/error.rs
@@ -345,7 +345,7 @@ impl From<u8> for RomErrorKind {
             0xc7 => RomErrorKind::InflateError,
             0xc8 => RomErrorKind::NotEnoughData,
             0xc9 => RomErrorKind::TooMuchData,
-            
+
             _ => RomErrorKind::Other,
         }
     }

--- a/espflash/src/error.rs
+++ b/espflash/src/error.rs
@@ -294,7 +294,7 @@ pub enum RomErrorKind {
     #[error("Bad data checksum")]
     #[diagnostic(code(espflash::rom::data_crc))]
     BadDataChecksum = 0xc1,
-    #[error("Bad block isze")]
+    #[error("Bad block size")]
     #[diagnostic(code(espflash::rom::block_size))]
     BadBlocksize = 0xc2,
     #[error("Invalid command")]

--- a/espflash/src/targets/flash_target/esp32.rs
+++ b/espflash/src/targets/flash_target/esp32.rs
@@ -114,7 +114,7 @@ impl FlashTarget for Esp32Target {
             CommandType::FlashDeflateBegin.timeout_for_size(erase_size),
             |connection| {
                 connection.command(Command::FlashDeflateBegin {
-                    size: erase_size,
+                    size: segment.data.len() as u32,
                     blocks: block_count as u32,
                     block_size: flash_write_size as u32,
                     offset: addr,


### PR DESCRIPTION
Since we just swapped the two fields, we need to check `error` instead of `status` now.

I've been mainly working with the stub since I'm erasing the OTA partition when flashing.
After taking a better look at the error handling there I'm not really sure where the values from `RomErrorKind` are coming from, since they are neither in the C stub code nor the `bootloader` and `bootloader_support` components.

I added the generic errors from the stub. There is other values used in other places in there but they are not under an enum and it would take quite a bit of time to reference all of them for now.

If anyone has any clue where those are coming from, otherwise I'd say that we can remove them at some point.