### PR TITLE
Additional docstrings for `enums`, `structs`, and `traits`

### DIFF
--- a/espflash/src/cli/config.rs
+++ b/espflash/src/cli/config.rs
@@ -21,18 +21,23 @@ use serialport::UsbPortInfo;
 /// A configured, known serial connection
 #[derive(Debug, Deserialize, Serialize, Default, Clone)]
 pub struct Connection {
+    /// Name of the serial port used for communication
     pub serial: Option<String>,
-    #[cfg(feature = "raspberry")]
-    pub rts: Option<u8>,
+    /// Data Transmit Ready pin
     #[cfg(feature = "raspberry")]
     pub dtr: Option<u8>,
+    /// Ready To Send pin
+    #[cfg(feature = "raspberry")]
+    pub rts: Option<u8>,
 }
 
 /// A configured, known USB device
 #[derive(Debug, Deserialize, Serialize, Default, Clone)]
 pub struct UsbDevice {
+    /// USB Vendor ID
     #[serde(with = "SerHex::<Compact>")]
     pub vid: u16,
+    /// USB Product ID
     #[serde(with = "SerHex::<Compact>")]
     pub pid: u16,
 }
@@ -46,8 +51,10 @@ impl UsbDevice {
 /// Deserialized contents of a configuration file
 #[derive(Debug, Deserialize, Serialize, Default, Clone)]
 pub struct Config {
+    /// Preferred serial port connection information
     #[serde(default)]
     pub connection: Connection,
+    /// Preferred USB devices
     #[serde(default)]
     pub usb_device: Vec<UsbDevice>,
     #[serde(skip)]

--- a/espflash/src/elf.rs
+++ b/espflash/src/elf.rs
@@ -19,11 +19,18 @@ use crate::{
     targets::Chip,
 };
 
+/// Operations for working with firmware images
 pub trait FirmwareImage<'a> {
+    /// Firmware image entry point
     fn entry(&self) -> u32;
+
+    /// Firmware image segments
     fn segments(&'a self) -> Box<dyn Iterator<Item = CodeSegment<'a>> + 'a>;
+
+    /// Firmware image segments, with their associated load addresses
     fn segments_with_load_addresses(&'a self) -> Box<dyn Iterator<Item = CodeSegment<'a>> + 'a>;
 
+    /// Firmware image ROM segments
     fn rom_segments(&'a self, chip: Chip) -> Box<dyn Iterator<Item = CodeSegment<'a>> + 'a> {
         Box::new(
             self.segments()
@@ -31,6 +38,7 @@ pub trait FirmwareImage<'a> {
         )
     }
 
+    /// Firmware image RAM segments
     fn ram_segments(&'a self, chip: Chip) -> Box<dyn Iterator<Item = CodeSegment<'a>> + 'a> {
         Box::new(
             self.segments()

--- a/espflash/src/elf.rs
+++ b/espflash/src/elf.rs
@@ -47,6 +47,7 @@ pub trait FirmwareImage<'a> {
     }
 }
 
+/// A firmware image built from an ELF file
 pub struct ElfFirmwareImage<'a> {
     elf: ElfFile<'a>,
 }
@@ -116,8 +117,9 @@ impl<'a> FirmwareImage<'a> for ElfFirmwareImage<'a> {
 }
 
 #[derive(Eq, Clone, Default)]
-/// A segment of code from the source elf
+/// A segment of code from the source ELF
 pub struct CodeSegment<'a> {
+    /// Base address of the code segment
     pub addr: u32,
     data: Cow<'a, [u8]>,
 }
@@ -228,7 +230,9 @@ impl Ord for CodeSegment<'_> {
 #[derive(Clone)]
 /// A segment of data to write to the flash
 pub struct RomSegment<'a> {
+    /// ROM address at which the segment begins
     pub addr: u32,
+    /// Segment data
     pub data: Cow<'a, [u8]>,
 }
 

--- a/espflash/src/flasher/mod.rs
+++ b/espflash/src/flasher/mod.rs
@@ -41,26 +41,37 @@ const FLASH_SECTORS_PER_BLOCK: usize = FLASH_SECTOR_SIZE / FLASH_BLOCK_SIZE;
 #[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, Display, EnumVariantNames)]
 #[repr(u8)]
 pub enum FlashFrequency {
+    /// 12 MHz
     #[strum(serialize = "12M")]
     Flash12M,
+    /// 15 MHz
     #[strum(serialize = "15M")]
     Flash15M,
+    /// 16 MHz
     #[strum(serialize = "16M")]
     Flash16M,
+    /// 20 MHz
     #[strum(serialize = "20M")]
     Flash20M,
+    /// 24 MHz
     #[strum(serialize = "24M")]
     Flash24M,
+    /// 26 MHz
     #[strum(serialize = "26M")]
     Flash26M,
+    /// 30 MHz
     #[strum(serialize = "30M")]
     Flash30M,
+    /// 40 MHz
     #[strum(serialize = "40M")]
     Flash40M,
+    /// 48 MHz
     #[strum(serialize = "48M")]
     Flash48M,
+    /// 60 MHz
     #[strum(serialize = "60M")]
     Flash60M,
+    /// 80 MHz
     #[strum(serialize = "80M")]
     Flash80M,
 }
@@ -92,9 +103,13 @@ impl FromStr for FlashFrequency {
 #[derive(Copy, Clone, Debug, EnumVariantNames)]
 #[strum(serialize_all = "lowercase")]
 pub enum FlashMode {
+    /// Quad I/O (4 pins used for address & data)
     Qio,
+    /// Quad Output (4 pins used for data)
     Qout,
+    /// Dual I/O (2 pins used for address & data)
     Dio,
+    /// Dual Output (2 pins used for data)
     Dout,
 }
 
@@ -120,24 +135,34 @@ impl FromStr for FlashMode {
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Display, EnumVariantNames)]
 #[repr(u8)]
 pub enum FlashSize {
+    /// 256 KB
     #[strum(serialize = "256K")]
     Flash256Kb = 0x12,
+    /// 512 KB
     #[strum(serialize = "512K")]
     Flash512Kb = 0x13,
+    /// 1 MB
     #[strum(serialize = "1M")]
     Flash1Mb = 0x14,
+    /// 2 MB
     #[strum(serialize = "2M")]
     Flash2Mb = 0x15,
+    /// 4 MB
     #[strum(serialize = "4M")]
     Flash4Mb = 0x16,
+    /// 8 MB
     #[strum(serialize = "8M")]
     Flash8Mb = 0x17,
+    /// 16 MB
     #[strum(serialize = "16M")]
     Flash16Mb = 0x18,
+    /// 32 MB
     #[strum(serialize = "32M")]
     Flash32Mb = 0x19,
+    /// 64 MB
     #[strum(serialize = "64M")]
     Flash64Mb = 0x1a,
+    /// 128 MB
     #[strum(serialize = "128M")]
     Flash128Mb = 0x21,
 }

--- a/espflash/src/image_format/mod.rs
+++ b/espflash/src/image_format/mod.rs
@@ -56,13 +56,16 @@ pub trait ImageFormat<'a>: Send {
         'a: 'b;
 }
 
+/// All supported firmware image formats
 #[derive(
     Debug, Copy, Clone, Eq, PartialEq, Display, IntoStaticStr, EnumVariantNames, Deserialize,
 )]
 #[strum(serialize_all = "kebab-case")]
 #[serde(rename_all = "kebab-case")]
 pub enum ImageFormatKind {
+    /// Use the second-stage bootloader from ESP-IDF
     EspBootloader,
+    /// Use direct boot and do not use a second-stage bootloader at all
     DirectBoot,
 }
 

--- a/espflash/src/image_format/mod.rs
+++ b/espflash/src/image_format/mod.rs
@@ -41,6 +41,7 @@ struct SegmentHeader {
     length: u32,
 }
 
+/// Operations for working with firmware image formats
 pub trait ImageFormat<'a>: Send {
     /// Get the rom segments needed when flashing to device
     fn flash_segments<'b>(&'b self) -> Box<dyn Iterator<Item = RomSegment<'b>> + 'b>

--- a/espflash/src/interface.rs
+++ b/espflash/src/interface.rs
@@ -24,9 +24,12 @@ pub enum SerialConfigError {
 /// Wrapper around SerialPort where platform-specific modifications can be
 /// implemented.
 pub struct Interface {
+    /// Hardware serial port used for communication
     pub serial_port: Box<dyn SerialPort>,
+    /// Data Transmit Ready pin
     #[cfg(feature = "raspberry")]
     pub dtr: Option<OutputPin>,
+    /// Ready To Send pin
     #[cfg(feature = "raspberry")]
     pub rts: Option<OutputPin>,
 }

--- a/espflash/src/targets/esp32.rs
+++ b/espflash/src/targets/esp32.rs
@@ -31,6 +31,7 @@ const UART_CLKDIV_MASK: u32 = 0xfffff;
 
 const XTAL_CLK_DIVIDER: u32 = 1;
 
+/// ESP32 Target
 pub struct Esp32;
 
 impl Esp32 {

--- a/espflash/src/targets/esp32c2.rs
+++ b/espflash/src/targets/esp32c2.rs
@@ -29,6 +29,7 @@ const PARAMS: Esp32Params = Esp32Params::new(
     include_bytes!("../../resources/bootloaders/esp32c2-bootloader.bin"),
 );
 
+/// ESP32-C2 Target
 pub struct Esp32c2;
 
 impl Esp32c2 {

--- a/espflash/src/targets/esp32c3.rs
+++ b/espflash/src/targets/esp32c3.rs
@@ -29,6 +29,7 @@ const PARAMS: Esp32Params = Esp32Params::new(
     include_bytes!("../../resources/bootloaders/esp32c3-bootloader.bin"),
 );
 
+/// ESP32-C3 Target
 pub struct Esp32c3;
 
 impl Esp32c3 {

--- a/espflash/src/targets/esp32s2.rs
+++ b/espflash/src/targets/esp32s2.rs
@@ -28,6 +28,7 @@ const PARAMS: Esp32Params = Esp32Params::new(
     include_bytes!("../../resources/bootloaders/esp32s2-bootloader.bin"),
 );
 
+/// ESP32-S2 Target
 pub struct Esp32s2;
 
 impl Esp32s2 {

--- a/espflash/src/targets/esp32s3.rs
+++ b/espflash/src/targets/esp32s3.rs
@@ -26,6 +26,7 @@ const PARAMS: Esp32Params = Esp32Params::new(
     include_bytes!("../../resources/bootloaders/esp32s3-bootloader.bin"),
 );
 
+/// ESP32-S2 Target
 pub struct Esp32s3;
 
 impl Esp32s3 {

--- a/espflash/src/targets/esp8266.rs
+++ b/espflash/src/targets/esp8266.rs
@@ -22,6 +22,7 @@ const UART_CLKDIV_MASK: u32 = 0xfffff;
 
 const XTAL_CLK_DIVIDER: u32 = 1;
 
+/// ESP8266 Target
 pub struct Esp8266;
 
 impl Esp8266 {

--- a/espflash/src/targets/flash_target/esp32.rs
+++ b/espflash/src/targets/flash_target/esp32.rs
@@ -16,6 +16,7 @@ use crate::{
     targets::Chip,
 };
 
+/// Applications running from an ESP32's (or variant's) flash
 pub struct Esp32Target {
     chip: Chip,
     spi_attach_params: SpiAttachParams,

--- a/espflash/src/targets/flash_target/esp8266.rs
+++ b/espflash/src/targets/flash_target/esp8266.rs
@@ -9,6 +9,7 @@ use crate::{
     flasher::{get_erase_size, FLASH_WRITE_SIZE},
 };
 
+/// Applications running from an ESP8266's flash
 pub struct Esp8266Target;
 
 impl Esp8266Target {

--- a/espflash/src/targets/flash_target/mod.rs
+++ b/espflash/src/targets/flash_target/mod.rs
@@ -8,13 +8,19 @@ mod esp32;
 mod esp8266;
 mod ram;
 
+/// Operations for interacting with a flash target
 pub trait FlashTarget {
+    /// Begin the flashing operation
     fn begin(&mut self, connection: &mut Connection) -> Result<(), Error>;
+
+    /// Write a segment to the target device
     fn write_segment(
         &mut self,
         connection: &mut Connection,
         segment: RomSegment,
     ) -> Result<(), Error>;
+
+    /// Complete the flashing operation
     fn finish(&mut self, connection: &mut Connection, reboot: bool) -> Result<(), Error>;
 }
 

--- a/espflash/src/targets/flash_target/ram.rs
+++ b/espflash/src/targets/flash_target/ram.rs
@@ -17,6 +17,7 @@ struct EntryParams {
     entry: u32,
 }
 
+/// Applications running in the target device's RAM
 pub struct RamTarget {
     entry: Option<u32>,
     block_size: usize,

--- a/espflash/src/targets/mod.rs
+++ b/espflash/src/targets/mod.rs
@@ -123,6 +123,7 @@ impl Chip {
     }
 }
 
+/// Device-specific parameters
 #[derive(Debug, Clone, Copy)]
 pub struct Esp32Params {
     pub boot_addr: u32,
@@ -192,6 +193,7 @@ impl Esp32Params {
     }
 }
 
+/// SPI register addresses
 pub struct SpiRegisters {
     base: u32,
     usr_offset: u32,

--- a/espflash/src/targets/mod.rs
+++ b/espflash/src/targets/mod.rs
@@ -37,14 +37,21 @@ mod esp32s3;
 mod esp8266;
 mod flash_target;
 
+/// Enumeration of all supported devices
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Display, EnumIter, EnumVariantNames)]
 #[strum(serialize_all = "lowercase")]
 pub enum Chip {
+    /// ESP32
     Esp32,
+    /// ESP32-C2, ESP8684
     Esp32c2,
+    /// ESP32-C3, ESP8685
     Esp32c3,
+    /// ESP32-S2
     Esp32s2,
+    /// ESP32-S3
     Esp32s3,
+    /// ESP8266
     Esp8266,
 }
 

--- a/espflash/src/targets/mod.rs
+++ b/espflash/src/targets/mod.rs
@@ -244,17 +244,23 @@ pub trait ReadEFuse {
     }
 }
 
+/// Operations for interacting with supported target devices
 pub trait Target: ReadEFuse {
+    /// Is the provided address `addr` in flash?
     fn addr_is_flash(&self, addr: u32) -> bool;
 
+    /// Enumerate the chip's features, read from eFuse
     fn chip_features(&self, connection: &mut Connection) -> Result<Vec<&str>, Error>;
 
+    /// Deterimine the chip's revision number, if it has one
     fn chip_revision(&self, _connection: &mut Connection) -> Result<Option<u32>, Error> {
         Ok(None)
     }
 
+    /// What is the crystal frequency?
     fn crystal_freq(&self, connection: &mut Connection) -> Result<u32, Error>;
 
+    /// Numeric encodings for the flash frequencies supported by a chip
     fn flash_frequency_encodings(&self) -> HashMap<FlashFrequency, u8> {
         use FlashFrequency::*;
 
@@ -268,10 +274,12 @@ pub trait Target: ReadEFuse {
         HashMap::from(encodings)
     }
 
+    /// Write size for flashing operations
     fn flash_write_size(&self, _connection: &mut Connection) -> Result<usize, Error> {
         Ok(FLASH_WRITE_SIZE)
     }
 
+    /// Build an image from the provided data for flashing
     fn get_flash_image<'a>(
         &self,
         image: &'a dyn FirmwareImage<'a>,
@@ -284,6 +292,7 @@ pub trait Target: ReadEFuse {
         flash_freq: Option<FlashFrequency>,
     ) -> Result<Box<dyn ImageFormat<'a> + 'a>, Error>;
 
+    /// What is the MAC address?
     fn mac_address(&self, connection: &mut Connection) -> Result<String, Error> {
         let word5 = self.read_efuse(connection, 5)?;
         let word6 = self.read_efuse(connection, 6)?;
@@ -295,18 +304,23 @@ pub trait Target: ReadEFuse {
         Ok(bytes_to_mac_addr(bytes))
     }
 
+    /// Maximum RAM block size for writing
     fn max_ram_block_size(&self, _connection: &mut Connection) -> Result<usize, Error> {
         Ok(MAX_RAM_BLOCK_SIZE)
     }
 
+    /// SPI register addresses for a chip
     fn spi_registers(&self) -> SpiRegisters;
 
+    /// Image formats supported by a chip
     fn supported_image_formats(&self) -> &[ImageFormatKind] {
         &[ImageFormatKind::EspBootloader]
     }
 
+    /// Build targets supported by a chip
     fn supported_build_targets(&self) -> &[&str];
 
+    /// Is the build target `target` supported by the chip?
     fn supports_build_target(&self, target: &str) -> bool {
         self.supported_build_targets().contains(&target)
     }


### PR DESCRIPTION
Still need to document all the public functions in all of the structs, though I'm not sure if I'll go that far before the release...