### PR TITLE
Print additional information when invoking the `save-image` subcommand

### DIFF
--- a/cargo-espflash/src/main.rs
+++ b/cargo-espflash/src/main.rs
@@ -410,6 +410,15 @@ fn save_image(
         .or(build_ctx.partition_table_path.as_deref())
         .map(|p| p.to_path_buf());
 
+    // Since we have no `Flasher` instance and as such cannot print the board
+    // information, we will print whatever information we _do_ have.
+    println!("Chip type:         {}", args.save_image_args.chip);
+    if let Some(format) = args.format {
+        println!("Image format:      {:?}", format);
+    }
+    println!("Merge:             {}", args.save_image_args.merge);
+    println!("Skip padding:      {}", args.save_image_args.skip_padding);
+
     save_elf_as_image(
         args.save_image_args.chip,
         &elf_data,

--- a/espflash/src/bin/espflash.rs
+++ b/espflash/src/bin/espflash.rs
@@ -166,6 +166,15 @@ fn save_image(args: SaveImageArgs) -> Result<()> {
         .into_diagnostic()
         .wrap_err_with(|| format!("Failed to open image {}", args.image.display()))?;
 
+    // Since we have no `Flasher` instance and as such cannot print the board
+    // information, we will print whatever information we _do_ have.
+    println!("Chip type:         {}", args.save_image_args.chip);
+    if let Some(format) = args.format {
+        println!("Image format:      {:?}", format);
+    }
+    println!("Merge:             {}", args.save_image_args.merge);
+    println!("Skip padding:      {}", args.save_image_args.skip_padding);
+
     save_elf_as_image(
         args.save_image_args.chip,
         &elf_data,


### PR DESCRIPTION
Previously this subcommand only printed the application/partition sizes, which was sort of strange. It now prints some additional information in a similar way to the `board_info` function in `Flasher`.

Closes #264