### PR TITLE
Replace --erase-otadata with --erase-parts and --erase-data-parts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -577,9 +577,9 @@ dependencies = [
 
 [[package]]
 name = "esp-idf-part"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcfd669cf23fd4d1ecacfc717fdbd995fe536103bab915c8c9eeb95b619f819e"
+checksum = "f1e342bf53cd885a16dfe1850b06013b7c95046ce45114a4d09b4a17d8313439"
 dependencies = [
  "csv",
  "deku",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -223,6 +223,7 @@ dependencies = [
  "cargo_toml",
  "clap",
  "env_logger",
+ "esp-idf-part",
  "espflash",
  "log",
  "miette",

--- a/cargo-espflash/Cargo.toml
+++ b/cargo-espflash/Cargo.toml
@@ -35,6 +35,7 @@ cargo_toml = "0.12.2"
 clap = { version = "4.0.14", features = ["derive"] }
 env_logger = "0.9.1"
 espflash = { version = "=2.0.0-dev", path = "../espflash" }
+esp-idf-part = "0.1.0"
 log = "0.4.17"
 miette = { version = "5.3.0", features = ["fancy"] }
 serde = { version = "1.0.145", features = ["derive"] }

--- a/cargo-espflash/Cargo.toml
+++ b/cargo-espflash/Cargo.toml
@@ -35,7 +35,7 @@ cargo_toml = "0.12.2"
 clap = { version = "4.0.14", features = ["derive"] }
 env_logger = "0.9.1"
 espflash = { version = "=2.0.0-dev", path = "../espflash" }
-esp-idf-part = "0.1.0"
+esp-idf-part = "0.1.1"
 log = "0.4.17"
 miette = { version = "5.3.0", features = ["fancy"] }
 serde = { version = "1.0.145", features = ["derive"] }

--- a/espflash/Cargo.toml
+++ b/espflash/Cargo.toml
@@ -45,7 +45,7 @@ comfy-table = "6.1.0"
 crossterm = { version = "0.25.0", optional = true }
 dialoguer = { version = "0.10.2", optional = true }
 directories-next = "2.0.0"
-esp-idf-part = "0.1.0"
+esp-idf-part = "0.1.1"
 env_logger = { version = "0.9.1", optional = true }
 flate2 = "1.0.24"
 indicatif = "0.17.1"

--- a/espflash/src/error.rs
+++ b/espflash/src/error.rs
@@ -395,13 +395,18 @@ impl<T> ResultExt for Result<T, Error> {
 }
 
 #[derive(Debug, Error, Diagnostic)]
-#[error("No otadata partition was found")]
+#[error("Missing partition")]
 #[diagnostic(
-    code(espflash::partition_table::no_otadata),
-    help("Partition table must contain an otadata partition when trying to erase it")
+    code(espflash::partition_table::missing_partition),
+    help("Partition table must contain the partition of type `{0}` that is going to be erased")
 )]
+pub struct MissingPartition(String);
 
-pub struct NoOtadataError;
+impl From<String> for MissingPartition {
+    fn from(part: String) -> Self {
+        MissingPartition(part)
+    }
+}
 
 #[derive(Debug, Error, Diagnostic)]
 #[error("Missing partition table")]


### PR DESCRIPTION
Instead of having a `--erase-otadata` flag to erase only the otadata partition, we can now erase any partitions by their labels with `--erase-parts part1,part2`  or any data partition by their sub-types using `--erase-data-parts ota,nvs` and so on.

This PR is awaiting on https://github.com/esp-rs/esp-idf-part/pull/5