### PR TITLE
Only display progress bars when `cli` feature is enabled, allow passing progress callback

### DIFF
--- a/espflash/Cargo.toml
+++ b/espflash/Cargo.toml
@@ -47,7 +47,7 @@ directories-next = { version = "2.0.0", optional = true }
 esp-idf-part = "0.1.1"
 env_logger = { version = "0.9.1", optional = true }
 flate2 = "1.0.24"
-indicatif = "0.17.1"
+indicatif = { version = "0.17.1", optional = true }
 lazy_static = { version = "1.4.0", optional = true }
 log = "0.4.17"
 miette = { version = "5.3.0", features = ["fancy"] }
@@ -69,7 +69,7 @@ xmas-elf = "0.8.0"
 default = ["cli"]
 cli = [
     "dep:addr2line", "dep:clap", "dep:comfy-table", "dep:crossterm", "dep:dialoguer",
-    "dep:directories-next", "dep:env_logger", "dep:lazy_static", "dep:parse_int",
-    "dep:regex", "dep:serde-hex", "dep:update-informer"
+    "dep:directories-next", "dep:env_logger", "dep:indicatif", "dep:lazy_static",
+    "dep:parse_int", "dep:regex", "dep:serde-hex", "dep:update-informer"
 ]
 raspberry = ["dep:rppal"]

--- a/espflash/src/bin/espflash.rs
+++ b/espflash/src/bin/espflash.rs
@@ -8,9 +8,10 @@ use std::{
 use clap::{Args, Parser, Subcommand};
 use espflash::{
     cli::{
-        self, board_info, clap_enum_variants, config::Config, connect, erase_partitions,
-        flash_elf_image, monitor::monitor, parse_partition_table, partition_table,
-        save_elf_as_image, serial_monitor, ConnectArgs, FlashConfigArgs, PartitionTableArgs,
+        self, board_info, build_progress_bar_callback, clap_enum_variants, config::Config, connect,
+        erase_partitions, flash_elf_image, monitor::monitor, parse_partition_table,
+        partition_table, progress_bar, save_elf_as_image, serial_monitor, ConnectArgs,
+        FlashConfigArgs, PartitionTableArgs,
     },
     image_format::ImageFormatKind,
     logging::initialize_logger,
@@ -206,7 +207,10 @@ fn write_bin(args: WriteBinArgs, config: &Config) -> Result<()> {
     let mut buffer = Vec::with_capacity(size.try_into().into_diagnostic()?);
     f.read_to_end(&mut buffer).into_diagnostic()?;
 
-    flasher.write_bin_to_flash(args.addr, &buffer)?;
+    let progress = progress_bar(format!("segment 0x{:X}", args.addr), None);
+    let progress_cb = Some(build_progress_bar_callback(progress));
+
+    flasher.write_bin_to_flash(args.addr, &buffer, progress_cb)?;
 
     Ok(())
 }

--- a/espflash/src/targets/flash_target/esp32.rs
+++ b/espflash/src/targets/flash_target/esp32.rs
@@ -98,6 +98,7 @@ impl FlashTarget for Esp32Target {
         &mut self,
         connection: &mut Connection,
         segment: RomSegment,
+        progress_cb: Option<Box<dyn Fn(usize, usize)>>,
     ) -> Result<(), Error> {
         let addr = segment.addr;
 
@@ -128,6 +129,7 @@ impl FlashTarget for Esp32Target {
         )?;
 
         let chunks = compressed.chunks(flash_write_size);
+        let num_chunks = chunks.len();
 
         // decode the chunks to see how much data the device will have to save
         let mut decoder = ZlibDecoder::new(Vec::new());
@@ -151,6 +153,10 @@ impl FlashTarget for Esp32Target {
                     Ok(())
                 },
             )?;
+
+            if let Some(ref cb) = progress_cb {
+                cb(i + 1, num_chunks);
+            }
         }
 
         Ok(())

--- a/espflash/src/targets/flash_target/mod.rs
+++ b/espflash/src/targets/flash_target/mod.rs
@@ -18,6 +18,7 @@ pub trait FlashTarget {
         &mut self,
         connection: &mut Connection,
         segment: RomSegment,
+        progress_cb: Option<Box<dyn Fn(usize, usize)>>,
     ) -> Result<(), Error>;
 
     /// Complete the flashing operation


### PR DESCRIPTION
Mostly just decoupling the progress bars from the flash targets in this. I think now all of the CLI-only dependencies are optional. Not 100% happy with it, but frankly it's good enough.

Closes #274 