### PR TITLE
Update dependencies to their latest versions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -149,9 +149,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitvec"
-version = "0.22.3"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5237f00a8c86130a0cc317830e558b966dd7850d48a953d998c813f01a41b527"
+checksum = "1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c"
 dependencies = [
  "funty",
  "radium",
@@ -286,9 +286,9 @@ checksum = "fff857943da45f546682664a79488be82e69e43c1a7a2307679ab9afb3a66d2e"
 
 [[package]]
 name = "clap"
-version = "4.0.22"
+version = "4.0.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91b9970d7505127a162fdaa9b96428d28a479ba78c9ec7550a63a5d9863db682"
+checksum = "389ca505fd2c00136e0d0cd34bcd8b6bd0b59d5779aab396054b716334230c1c"
 dependencies = [
  "atty",
  "bitflags",
@@ -468,9 +468,9 @@ dependencies = [
 
 [[package]]
 name = "deku"
-version = "0.14.1"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a3da532261a0db01cb5652ce0c86691ff06231dbbaa61dd1ec63eb2015def30"
+checksum = "28a6ebcd26e59dcd590e8869c751eccccfd89047bf20048966d1de823e442a7b"
 dependencies = [
  "bitvec",
  "deku_derive",
@@ -478,9 +478,9 @@ dependencies = [
 
 [[package]]
 name = "deku_derive"
-version = "0.14.1"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa430e6ee3f037853a23584f9e85ec3d495ea9e59f443777dcdfd9d47f190765"
+checksum = "d77061e73fa9f78497426c53d62e28a6d64949a53f53bbd4d946ade2c9ede86f"
 dependencies = [
  "darling",
  "proc-macro-crate",
@@ -578,9 +578,9 @@ dependencies = [
 
 [[package]]
 name = "esp-idf-part"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1e342bf53cd885a16dfe1850b06013b7c95046ce45114a4d09b4a17d8313439"
+checksum = "7fa758fff38bcfb58c48193bc5329165a8268c864540b7904f2e854da09342f6"
 dependencies = [
  "csv",
  "deku",
@@ -670,9 +670,9 @@ dependencies = [
 
 [[package]]
 name = "funty"
-version = "1.2.0"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1847abb9cb65d566acd5942e94aea9c8f547ad02c98e1649326fc0e8910b8b1e"
+checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "generic-array"
@@ -753,12 +753,13 @@ dependencies = [
 
 [[package]]
 name = "indicatif"
-version = "0.17.1"
+version = "0.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfddc9561e8baf264e0e45e197fd7696320026eb10a8180340debc27b18f535b"
+checksum = "4295cbb7573c16d310e99e713cf9e75101eb190ab31fccd35f2d2691b4352b19"
 dependencies = [
  "console",
  "number_prefix",
+ "portable-atomic",
  "unicode-width",
 ]
 
@@ -1042,6 +1043,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ac9a59f73473f1b8d852421e59e64809f025994837ef743615c6d0c5b305160"
 
 [[package]]
+name = "portable-atomic"
+version = "0.3.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15eb2c6e362923af47e13c23ca5afb859e83d54452c55b0b9ac763b8f7c1ac16"
+
+[[package]]
 name = "proc-macro-crate"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1096,9 +1103,9 @@ dependencies = [
 
 [[package]]
 name = "radium"
-version = "0.6.2"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "643f8f41a8ebc4c5dc4515c82bb8abd397b527fc20fd681b7c011c2aee5d44fb"
+checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "redox_syscall"
@@ -1169,11 +1176,10 @@ dependencies = [
 
 [[package]]
 name = "rppal"
-version = "0.13.1"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c88c9c6248de4d337747b619d8f671055ef48a87dc21b97998833f189a0bbd4f"
+checksum = "b6f5900fcc67cad69c619ec872c685ca80181eae325ea425c4bd7adb4406dab4"
 dependencies = [
- "lazy_static",
  "libc",
 ]
 
@@ -1818,9 +1824,9 @@ checksum = "f40009d85759725a34da6d89a94e63d7bdc50a862acf0dbc7c8e488f1edcb6f5"
 
 [[package]]
 name = "wyz"
-version = "0.4.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "129e027ad65ce1453680623c3fb5163cbf7107bfe1aa32257e7d0e63f9ced188"
+checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
 dependencies = [
  "tap",
 ]

--- a/espflash/Cargo.toml
+++ b/espflash/Cargo.toml
@@ -39,21 +39,21 @@ addr2line = { version = "0.18.0", optional = true }
 base64 = "0.13.1"
 binread = "2.2.0"
 bytemuck = { version = "1.12.3", features = ["derive"] }
-clap = { version = "4.0.22", features = ["derive"], optional = true }
+clap = { version = "4.0.25", features = ["derive"], optional = true }
 comfy-table = { version = "6.1.2", optional = true }
 crossterm = { version = "0.25.0", optional = true }
 dialoguer = { version = "0.10.2", optional = true }
 directories-next = { version = "2.0.0", optional = true }
-esp-idf-part = "0.1.1"
+esp-idf-part = "0.1.2"
 env_logger = { version = "0.9.3", optional = true }
 flate2 = "1.0.24"
-indicatif = { version = "0.17.1", optional = true }
+indicatif = { version = "0.17.2", optional = true }
 lazy_static = { version = "1.4.0", optional = true }
 log = "0.4.17"
 miette = { version = "5.4.1", features = ["fancy"] }
 parse_int = { version = "0.6.0", optional = true }
 regex = { version = "1.7.0", optional = true }
-rppal = { version = "0.13.1", optional = true }
+rppal = { version = "0.14.0", optional = true }
 serde = { version = "1.0.147", features = ["derive"] }
 serde-hex = { version = "0.1.0", optional = true }
 serialport = "4.2.0"


### PR DESCRIPTION
This resolves an issue in which `deku` (used by `esp-idf-part`) had a dependency yanked, and as such we were unable to install without the `--locked` flag. Also presumably pulls in some additional improvements/fixes.