### PR TITLE
Re-export esp-idf-part

### DIFF
--- a/espflash/src/lib.rs
+++ b/espflash/src/lib.rs
@@ -59,6 +59,8 @@ pub mod targets;
 
 mod command;
 
+pub use esp_idf_part;
+
 /// Logging utilties
 #[cfg(feature = "cli")]
 #[cfg_attr(docsrs, doc(cfg(feature = "cli")))]


### PR DESCRIPTION
Library users may need to parse partition tables and it is surprising that the partition table is in a separate crate.

This PR re-exports the esp-idf-part crate for better developer experience. This way the users don't need to add the dependency and keep it in sync in the future.