### PR TITLE
Clean up unused code, optimize comparison in `find_serial_port`

### DIFF
--- a/espflash/src/cli/serial.rs
+++ b/espflash/src/cli/serial.rs
@@ -1,3 +1,4 @@
+#[cfg(not(target_os = "windows"))]
 use std::fs;
 
 use crossterm::style::Stylize;

--- a/espflash/src/connection.rs
+++ b/espflash/src/connection.rs
@@ -7,7 +7,6 @@
 use std::{io::BufWriter, thread::sleep, time::Duration};
 
 use binread::{io::Cursor, BinRead, BinReaderExt};
-use bytemuck::{Pod, Zeroable};
 use log::info;
 use serialport::UsbPortInfo;
 use slip_codec::SlipDecoder;
@@ -38,15 +37,6 @@ pub struct Connection {
     serial: Interface,
     port_info: UsbPortInfo,
     decoder: SlipDecoder,
-}
-
-#[derive(Zeroable, Pod, Copy, Clone, Debug)]
-#[repr(C)]
-struct WriteRegParams {
-    addr: u32,
-    value: u32,
-    mask: u32,
-    delay_us: u32,
 }
 
 impl Connection {


### PR DESCRIPTION
This is just a small housekeeping PR to keep my fork free of warnings, as well as some cleanup/optimization I've noticed.