### PR TITLE
Make command module public

### DIFF
--- a/espflash/src/lib.rs
+++ b/espflash/src/lib.rs
@@ -49,6 +49,7 @@
 #[cfg(feature = "cli")]
 #[cfg_attr(docsrs, doc(cfg(feature = "cli")))]
 pub mod cli;
+pub mod command;
 pub mod connection;
 pub mod elf;
 pub mod error;
@@ -56,8 +57,6 @@ pub mod flasher;
 pub mod image_format;
 pub mod interface;
 pub mod targets;
-
-mod command;
 
 /// Logging utilties
 #[cfg(feature = "cli")]


### PR DESCRIPTION
Functions like [`Connection::write_command`](https://docs.rs/espflash/1.7.0/espflash/connection/struct.Connection.html#method.write_command) are public, but the `Command` type, which is one of their argument, is not accessible outside of the crate. This PR makes the command module public so users have the opportunity to implement functionality other than flashing a binary.