### PR TITLE
Fix crystal frequency detection for ESP32-C2 and ESP8266

### DIFF
--- a/espflash/src/targets/esp8266.rs
+++ b/espflash/src/targets/esp8266.rs
@@ -20,7 +20,7 @@ const FLASH_RANGES: &[Range<u32>] = &[
 const UART_CLKDIV_REG: u32 = 0x6000_0014;
 const UART_CLKDIV_MASK: u32 = 0xfffff;
 
-const XTAL_CLK_DIVIDER: u32 = 1;
+const XTAL_CLK_DIVIDER: u32 = 2;
 
 /// ESP8266 Target
 pub struct Esp8266;


### PR DESCRIPTION
Apparently there are variants of the ESP32-C2 with a 26MHz crystal instead of 40MHz. Due to a ROM bug, this needs special handling.

Additionally fixes the crystal frequency divider values for the ESP8266.

Closes #313