### PR TITLE
Support ESPFLASH_BAUD env var

### DIFF
--- a/espflash/Cargo.toml
+++ b/espflash/Cargo.toml
@@ -39,7 +39,7 @@ addr2line = { version = "0.19.0", optional = true }
 base64 = "0.13.1"
 binread = "2.2.0"
 bytemuck = { version = "1.12.3", features = ["derive"] }
-clap = { version = "4.0.29", features = ["derive"], optional = true }
+clap = { version = "4.0.29", features = ["derive", "env"], optional = true }
 comfy-table = { version = "6.1.3", optional = true }
 crossterm = { version = "0.25.0", optional = true }
 dialoguer = { version = "0.10.2", optional = true }

--- a/espflash/src/cli/mod.rs
+++ b/espflash/src/cli/mod.rs
@@ -63,7 +63,7 @@ pub use clap_enum_variants;
 #[derive(Debug, Args)]
 pub struct ConnectArgs {
     /// Baud rate at which to communicate with target device
-    #[arg(short = 'b', long)]
+    #[arg(short = 'b', long, env = "ESPFLASH_BAUD")]
     pub baud: Option<u32>,
     /// Serial port connected to target device
     #[arg(short = 'p', long)]


### PR DESCRIPTION
This makes it possible to use `ESPFLASH_BAUD` env-variable to specify the flashing baud-rate.

This might be useful since the max possible baud-rate might be different depending on the host
