### PR TITLE
Make the flasher return a struct of device information instead of printing directly

### DIFF
--- a/cargo-espflash/src/main.rs
+++ b/cargo-espflash/src/main.rs
@@ -139,7 +139,7 @@ fn main() -> Result<()> {
     // Execute the correct action based on the provided subcommand and its
     // associated arguments.
     match args {
-        Commands::BoardInfo(args) => board_info(args, &config),
+        Commands::BoardInfo(args) => board_info(&args, &config),
         Commands::Flash(args) => flash(args, &config),
         Commands::Monitor(args) => serial_monitor(args, &config),
         Commands::PartitionTable(args) => partition_table(args),
@@ -165,7 +165,7 @@ fn flash(args: FlashArgs, config: &Config) -> Result<()> {
     // Print the board information once the project has successfully built. We do
     // here rather than upon connection to show the Cargo output prior to the board
     // information, rather than breaking up cargo-espflash's output.
-    flasher.board_info()?;
+    board_info(&args.connect_args, config)?;
 
     // Read the ELF data from the build path and load it to the target.
     let elf_data = fs::read(build_ctx.artifact_path).into_diagnostic()?;

--- a/espflash/src/bin/espflash.rs
+++ b/espflash/src/bin/espflash.rs
@@ -106,7 +106,7 @@ fn main() -> Result<()> {
     // Execute the correct action based on the provided subcommand and its
     // associated arguments.
     match args {
-        Commands::BoardInfo(args) => board_info(args, &config),
+        Commands::BoardInfo(args) => board_info(&args, &config),
         Commands::Flash(args) => flash(args, &config),
         Commands::Monitor(args) => serial_monitor(args, &config),
         Commands::PartitionTable(args) => partition_table(args),
@@ -117,7 +117,7 @@ fn main() -> Result<()> {
 
 fn flash(args: FlashArgs, config: &Config) -> Result<()> {
     let mut flasher = connect(&args.connect_args, config)?;
-    flasher.board_info()?;
+    board_info(&args.connect_args, config)?;
 
     // Read the ELF data from the build path and load it to the target.
     let elf_data = fs::read(&args.image).into_diagnostic()?;
@@ -213,7 +213,7 @@ fn save_image(args: SaveImageArgs) -> Result<()> {
 
 fn write_bin(args: WriteBinArgs, config: &Config) -> Result<()> {
     let mut flasher = connect(&args.connect_args, config)?;
-    flasher.board_info()?;
+    board_info(&args.connect_args, config)?;
 
     let mut f = File::open(&args.bin_file).into_diagnostic()?;
     let size = f.metadata().into_diagnostic()?.len();

--- a/espflash/src/cli/mod.rs
+++ b/espflash/src/cli/mod.rs
@@ -276,9 +276,20 @@ pub fn connect(args: &ConnectArgs, config: &Config) -> Result<Flasher> {
 }
 
 /// Connect to a target device and print information about its chip
-pub fn board_info(args: ConnectArgs, config: &Config) -> Result<()> {
+pub fn board_info(args: &ConnectArgs, config: &Config) -> Result<()> {
     let mut flasher = connect(&args, config)?;
-    flasher.board_info()?;
+    let info = flasher.device_info()?;
+
+    print!("Chip type:         {}", info.chip);
+    if let Some((major, minor)) = info.revision {
+        println!(" (revision v{major}.{minor})");
+    } else {
+        println!("");
+    }
+    println!("Crystal frequency: {}MHz", info.crystal_frequency);
+    println!("Flash size:        {}", info.flash_size);
+    println!("Features:          {}", info.features.join(", "));
+    println!("MAC address:       {}", info.mac_address);
 
     Ok(())
 }


### PR DESCRIPTION
This makes the functionality a bit more useful when using `espflash` as a library, and will also allow us to avoid multiple successive reads from the device during other operations.