### PR TITLE
Fix monitor after flash for ESP32-C2

### DIFF
--- a/espflash/src/bin/espflash.rs
+++ b/espflash/src/bin/espflash.rs
@@ -10,8 +10,8 @@ use espflash::{
     cli::{
         self, board_info, build_progress_bar_callback, clap_enum_variants, config::Config, connect,
         erase_partitions, flash_elf_image, monitor::monitor, parse_partition_table,
-        partition_table, progress_bar, save_elf_as_image, serial_monitor, ConnectArgs,
-        FlashConfigArgs, MonitorArgs, PartitionTableArgs,
+        partition_table, print_board_info, progress_bar, save_elf_as_image, serial_monitor,
+        ConnectArgs, FlashConfigArgs, MonitorArgs, PartitionTableArgs,
     },
     image_format::ImageFormatKind,
     logging::initialize_logger,
@@ -117,7 +117,7 @@ fn main() -> Result<()> {
 
 fn flash(args: FlashArgs, config: &Config) -> Result<()> {
     let mut flasher = connect(&args.connect_args, config)?;
-    board_info(&args.connect_args, config)?;
+    print_board_info(&mut flasher)?;
 
     // Read the ELF data from the build path and load it to the target.
     let elf_data = fs::read(&args.image).into_diagnostic()?;

--- a/espflash/src/cli/mod.rs
+++ b/espflash/src/cli/mod.rs
@@ -278,6 +278,13 @@ pub fn connect(args: &ConnectArgs, config: &Config) -> Result<Flasher> {
 /// Connect to a target device and print information about its chip
 pub fn board_info(args: &ConnectArgs, config: &Config) -> Result<()> {
     let mut flasher = connect(&args, config)?;
+    print_board_info(&mut flasher)?;
+
+    Ok(())
+}
+
+/// Print information about a chip
+pub fn print_board_info(flasher: &mut Flasher) -> Result<()> {
     let info = flasher.device_info()?;
 
     print!("Chip type:         {}", info.chip);


### PR DESCRIPTION
- fixes a bug introduced in 1a0a8481ff770ae3133d7d31634dcb95d9746fa9
- fixes the problem that flashing with `--monitor` didn't work for ESP32-C2 anymore
