### PR TITLE
CLI improvements and dependency updates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -25,23 +25,14 @@ dependencies = [
 
 [[package]]
 name = "addr2line"
-version = "0.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9ecd88a8c8378ca913a680cd98f0f13ac67383d35993f86c90a70e3f137816b"
-dependencies = [
- "gimli 0.26.2",
-]
-
-[[package]]
-name = "addr2line"
 version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a76fd60b23679b7d19bd066031410fb7e458ccc5e958eb5c325888ce4baedc97"
 dependencies = [
  "cpp_demangle",
  "fallible-iterator",
- "gimli 0.27.0",
- "object 0.30.0",
+ "gimli",
+ "object",
  "rustc-demangle",
  "smallvec 1.10.0",
 ]
@@ -74,9 +65,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.66"
+version = "1.0.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "216261ddc8289130e551ddcd5ce8a064710c0d064a4d2895c67151c92b5443f6"
+checksum = "2cb2f989d18dd141ab8ae82f64d1a8cdd37e0840f73a406896cf5e99502fab61"
 
 [[package]]
 name = "array-init"
@@ -112,16 +103,16 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "backtrace"
-version = "0.3.66"
+version = "0.3.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cab84319d616cfb654d03394f38ab7e6f0919e181b1b57e1fd15e7fb4077d9a7"
+checksum = "233d376d6d185f2a3093e58f283f60f880315b6c60075b01f36b3b85154564ca"
 dependencies = [
- "addr2line 0.17.0",
+ "addr2line",
  "cc",
  "cfg-if",
  "libc",
- "miniz_oxide 0.5.4",
- "object 0.29.0",
+ "miniz_oxide",
+ "object",
  "rustc-demangle",
 ]
 
@@ -130,6 +121,12 @@ name = "base64"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
+
+[[package]]
+name = "base64"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4a4ddaa51a5bc52a6948f74c06d20aaaddb71924eab79b8c97a8c556e942d6a"
 
 [[package]]
 name = "binread"
@@ -202,6 +199,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "bstr"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b45ea9b00a7b3f2988e9a65ad3917e62123c38dba709b666506207be96d1790b"
+dependencies = [
+ "memchr",
+ "serde",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -241,9 +248,9 @@ checksum = "6c58ec36aac5066d5ca17df51b3e70279f5670a72102f5752cb7e7c856adfc70"
 
 [[package]]
 name = "camino"
-version = "1.1.1"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88ad0e1e3e88dd237a156ab9f571021b8a158caa0ae44b1968a241efb5144c1e"
+checksum = "c77df041dc383319cc661b428b6961a005db4d6808d5e12536931b1ca9556055"
 dependencies = [
  "serde",
 ]
@@ -314,7 +321,7 @@ version = "2.0.0-rc.2"
 dependencies = [
  "cargo",
  "cargo_metadata",
- "clap 4.0.29",
+ "clap 4.0.32",
  "env_logger 0.10.0",
  "esp-idf-part",
  "espflash",
@@ -373,9 +380,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.77"
+version = "1.0.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9f73505338f7d905b19d18738976aae232eb46b8efc15554ffc56deb5d9ebe4"
+checksum = "a20104e2335ce8a659d6dd92a51a767a0c062599c73b343fd152cb401e828c3d"
 dependencies = [
  "jobserver",
 ]
@@ -385,12 +392,6 @@ name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
-
-[[package]]
-name = "chunked_transfer"
-version = "1.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fff857943da45f546682664a79488be82e69e43c1a7a2307679ab9afb3a66d2e"
 
 [[package]]
 name = "clap"
@@ -409,9 +410,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.0.29"
+version = "4.0.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d63b9e9c07271b9957ad22c173bae2a4d9a81127680962039296abcd2f8251d"
+checksum = "a7db700bc935f9e43e88d00b0850dae18a63773cfbec6d8e070fccf7fef89a39"
 dependencies = [
  "bitflags",
  "clap_derive",
@@ -465,9 +466,9 @@ dependencies = [
 
 [[package]]
 name = "comfy-table"
-version = "6.1.3"
+version = "6.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e621e7e86c46fd8a14c32c6ae3cb95656621b4743a27d0cffedb831d46e7ad21"
+checksum = "6e7b787b0dc42e8111badfdbe4c3059158ccb2db8780352fa1b01e8ccf45cc4d"
 dependencies = [
  "crossterm",
  "strum",
@@ -495,16 +496,15 @@ dependencies = [
 
 [[package]]
 name = "console"
-version = "0.15.2"
+version = "0.15.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c050367d967ced717c04b65d8c619d863ef9292ce0c5760028655a2fb298718c"
+checksum = "c9b6515d269224923b26b5febea2ed42b2d5f2ce37284a4dd670fedd6cb8347a"
 dependencies = [
  "encode_unicode",
  "lazy_static",
  "libc",
- "terminal_size",
  "unicode-width",
- "winapi",
+ "windows-sys",
 ]
 
 [[package]]
@@ -565,15 +565,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "crossbeam-utils"
-version = "0.8.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fb766fa798726286dbbb842f174001dab8abc7b627a1dd86e0b7222a95d929f"
-dependencies = [
- "cfg-if",
-]
-
-[[package]]
 name = "crossterm"
 version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -626,7 +617,7 @@ version = "1.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22813a6dc45b335f9bade10bf7271dc477e81113e89eb251a0bc2a8a81c536e1"
 dependencies = [
- "bstr",
+ "bstr 0.2.17",
  "csv-core",
  "itoa 0.4.8",
  "ryu",
@@ -710,9 +701,9 @@ dependencies = [
 
 [[package]]
 name = "deku"
-version = "0.15.0"
+version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28a6ebcd26e59dcd590e8869c751eccccfd89047bf20048966d1de823e442a7b"
+checksum = "c3d631ba36587888e2f176cda075d73971c504283efd7d0112997a3fd02372c0"
 dependencies = [
  "bitvec",
  "deku_derive",
@@ -720,9 +711,9 @@ dependencies = [
 
 [[package]]
 name = "deku_derive"
-version = "0.15.0"
+version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d77061e73fa9f78497426c53d62e28a6d64949a53f53bbd4d946ade2c9ede86f"
+checksum = "9009099da9734d3dc49ce9c8c7f9b12905612c84c6dd4b4c075455743e47840d"
 dependencies = [
  "darling",
  "proc-macro-crate",
@@ -873,11 +864,11 @@ dependencies = [
 name = "espflash"
 version = "2.0.0-rc.2"
 dependencies = [
- "addr2line 0.19.0",
- "base64",
+ "addr2line",
+ "base64 0.21.0",
  "binread",
  "bytemuck",
- "clap 4.0.29",
+ "clap 4.0.32",
  "comfy-table",
  "crossterm",
  "dialoguer",
@@ -921,14 +912,14 @@ dependencies = [
 
 [[package]]
 name = "filetime"
-version = "0.2.18"
+version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b9663d381d07ae25dc88dbdf27df458faa83a9b25336bcac83d5e452b5fc9d3"
+checksum = "4e884668cd0c7480504233e951174ddc3b382f7c2666e3b7310b5c4e7b0c37f9"
 dependencies = [
  "cfg-if",
  "libc",
  "redox_syscall",
- "windows-sys 0.42.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -939,7 +930,7 @@ checksum = "a8a2db397cb1c8772f31494cb8917e48cd1e64f0fa7efac59fbd741a0a8ce841"
 dependencies = [
  "crc32fast",
  "libz-sys",
- "miniz_oxide 0.6.2",
+ "miniz_oxide",
 ]
 
 [[package]]
@@ -1011,12 +1002,6 @@ dependencies = [
 
 [[package]]
 name = "gimli"
-version = "0.26.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22030e2c5a68ec659fde1e949a745124b48e6fa8b045b7ed5bd1fe4ccc5c4e5d"
-
-[[package]]
-name = "gimli"
 version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dec7af912d60cdbd3677c1af9352ebae6fb8394d165568a2234df0fa00f87793"
@@ -1054,18 +1039,18 @@ dependencies = [
 
 [[package]]
 name = "glob"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
+checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 
 [[package]]
 name = "globset"
-version = "0.4.9"
+version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a1e17342619edbc21a964c2afbeb6c820c6a2560032872f397bb97ea127bd0a"
+checksum = "029d74589adefde59de1a0c4f4732695c32805624aec7b68d91503d4dba79afc"
 dependencies = [
  "aho-corasick",
- "bstr",
+ "bstr 1.1.0",
  "fnv",
  "log",
  "regex",
@@ -1149,11 +1134,10 @@ dependencies = [
 
 [[package]]
 name = "ignore"
-version = "0.4.18"
+version = "0.4.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "713f1b139373f96a2e0ce3ac931cd01ee973c3c5dd7c40c0c2efe96ad2b6751d"
+checksum = "a05705bc64e0b66a806c3740bd6578ea66051b157ec42dc219c785cbf185aef3"
 dependencies = [
- "crossbeam-utils",
  "globset",
  "lazy_static",
  "log",
@@ -1217,19 +1201,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46112a93252b123d31a119a8d1a1ac19deac4fac6e0e8b0df58f0d4e5870e63c"
 dependencies = [
  "libc",
- "windows-sys 0.42.0",
+ "windows-sys",
 ]
 
 [[package]]
 name = "is-terminal"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "927609f78c2913a6f6ac3c27a4fe87f43e2a35367c0c4b0f8265e8f49a104330"
+checksum = "28dfb6c8100ccc63462345b67d1bbc3679177c75ee4bf59bf29c8b1d110b8189"
 dependencies = [
  "hermit-abi 0.2.6",
  "io-lifetimes",
  "rustix",
- "windows-sys 0.42.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -1255,9 +1239,9 @@ checksum = "b71991ff56294aa922b450139ee08b3bfc70982c6b2c7562771375cf73542dd4"
 
 [[package]]
 name = "itoa"
-version = "1.0.4"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4217ad341ebadf8d8e724e264f13e593e0648f5b3e94b3896a5df283be015ecc"
+checksum = "fad582f4b9e86b6caa621cabeb0963332d92eea04729ab12892c2533951e6440"
 
 [[package]]
 name = "jobserver"
@@ -1300,15 +1284,15 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.137"
+version = "0.2.139"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc7fcc620a3bff7cdd7a365be3376c97191aeaccc2a603e600951e452615bf89"
+checksum = "201de327520df007757c1f0adce6e827fe8562fbc28bfd9c15571c66ca1f5f79"
 
 [[package]]
 name = "libgit2-sys"
-version = "0.14.0+1.5.0"
+version = "0.14.1+1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47a00859c70c8a4f7218e6d1cc32875c4b55f6799445b842b0d8ed5e4c3d959b"
+checksum = "4a07fb2692bc3593bda59de45a502bb3071659f2c515e28c71e728306b038e17"
 dependencies = [
  "cc",
  "libc",
@@ -1376,9 +1360,9 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f9f08d8963a6c613f4b1a78f4f4a4dbfadf8e6545b2d72861731e4858b8b47f"
+checksum = "f051f77a7c8e6957c0696eac88f26b0117e54f52d3fc682ab19397a8812846a4"
 
 [[package]]
 name = "lock_api"
@@ -1468,15 +1452,6 @@ dependencies = [
 
 [[package]]
 name = "miniz_oxide"
-version = "0.5.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96590ba8f175222643a85693f33d26e9c8a015f599c216509b1a6894af675d34"
-dependencies = [
- "adler",
-]
-
-[[package]]
-name = "miniz_oxide"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b275950c28b37e794e8c55d88aeb5e139d0ce23fdbbeda68f8d7174abdf9e8fa"
@@ -1493,7 +1468,7 @@ dependencies = [
  "libc",
  "log",
  "wasi",
- "windows-sys 0.42.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -1507,9 +1482,9 @@ dependencies = [
 
 [[package]]
 name = "nix"
-version = "0.24.2"
+version = "0.24.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "195cdbc1741b8134346d515b3a56a1c94b0912758009cfd53f99ea0f57b065fc"
+checksum = "fa52e972a9a719cecb6864fb88568781eb706bac2cd1d4f04a648542dbf78069"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -1539,18 +1514,9 @@ checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
 
 [[package]]
 name = "object"
-version = "0.29.0"
+version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21158b2c33aa6d4561f1c0a6ea283ca92bc54802a93b263e910746d679a7eb53"
-dependencies = [
- "memchr",
-]
-
-[[package]]
-name = "object"
-version = "0.30.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "239da7f290cfa979f43f85a8efeee9a8a76d0827c356d37f9d3d7254d6b537fb"
+checksum = "8d864c91689fdc196779b98dba0aceac6118594c2df6ee5d943eb6a8df4d107a"
 dependencies = [
  "flate2",
  "memchr",
@@ -1558,9 +1524,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.16.0"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86f0b0d4bf799edbc74508c1e8bf170ff5f41238e5f8225603ca7caaae2b7860"
+checksum = "6f61fba1741ea2b3d6a1e3178721804bb716a68a6aeba1149b5d52e3d464ea66"
 
 [[package]]
 name = "opener"
@@ -1568,15 +1534,15 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ea3ebcd72a54701f56345f16785a6d3ac2df7e986d273eb4395c0b01db17952"
 dependencies = [
- "bstr",
+ "bstr 0.2.17",
  "winapi",
 ]
 
 [[package]]
 name = "openssl"
-version = "0.10.43"
+version = "0.10.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "020433887e44c27ff16365eaa2d380547a94544ad509aff6eb5b6e3e0b27b376"
+checksum = "b102428fd03bc5edf97f62620f7298614c45cedf287c271e7ed450bbaf83f2e1"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -1615,9 +1581,9 @@ dependencies = [
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.78"
+version = "0.9.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07d5c8cb6e57b3a3612064d7b18b117912b4ce70955c2504d4b741c9e244b132"
+checksum = "23bbbf7854cd45b83958ebe919f0e8e516793727652e27fda10a8384cfc790b7"
 dependencies = [
  "autocfg",
  "cc",
@@ -1670,7 +1636,7 @@ dependencies = [
  "libc",
  "redox_syscall",
  "smallvec 1.10.0",
- "windows-sys 0.42.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -1702,9 +1668,9 @@ checksum = "6ac9a59f73473f1b8d852421e59e64809f025994837ef743615c6d0c5b305160"
 
 [[package]]
 name = "portable-atomic"
-version = "0.3.15"
+version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15eb2c6e362923af47e13c23ca5afb859e83d54452c55b0b9ac763b8f7c1ac16"
+checksum = "26f6a7b87c2e435a3241addceeeff740ff8b7e76b74c13bf9acb17fa454ea00b"
 
 [[package]]
 name = "proc-macro-crate"
@@ -1743,18 +1709,18 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.47"
+version = "1.0.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ea3d908b0e36316caf9e9e2c4625cdde190a7e6f440d794667ed17a1855e725"
+checksum = "57a8eca9f9c4ffde41714334dee777596264c7825420f521abc92b5b5deb63a5"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.21"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbe448f377a7d6961e30f5955f9b8d106c3f5e449d493ee1b125c1d43c2b5179"
+checksum = "8856d8364d252a14d474036ea1358d63c9e6965c8e5c1885c18f73d70bff9c7b"
 dependencies = [
  "proc-macro2",
 ]
@@ -1802,9 +1768,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.7.0"
+version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e076559ef8e241f2ae3479e36f97bd5741c0330689e217ad51ce2c76808b868a"
+checksum = "48aaa5748ba571fb95cd2c85c09f629215d3a6ece942baa100950af03a34f733"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1882,16 +1848,16 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.36.4"
+version = "0.36.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb93e85278e08bb5788653183213d3a60fc242b10cb9be96586f5a73dcb67c23"
+checksum = "4feacf7db682c6c329c4ede12649cd36ecab0f3be5b7d74e6a20304725db4549"
 dependencies = [
  "bitflags",
  "errno",
  "io-lifetimes",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.42.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -1908,15 +1874,15 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.9"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97477e48b4cf8603ad5f7aaf897467cf42ab4218a38ef76fb14c2d6773a6d6a8"
+checksum = "5583e89e108996506031660fe09baa5011b9dd0341b89029313006d1fb508d70"
 
 [[package]]
 name = "ryu"
-version = "1.0.11"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4501abdff3ae82a1c1b477a17252eb69cee9e66eb915c1abaa4f44d873df9f09"
+checksum = "7b4b9743ed687d4b4bcedf9ff5eaa7398495ae14e61cba0a295704edbc7decde"
 
 [[package]]
 name = "same-file"
@@ -1929,12 +1895,11 @@ dependencies = [
 
 [[package]]
 name = "schannel"
-version = "0.1.20"
+version = "0.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88d6731146462ea25d9244b2ed5fd1d716d25c52e4d54aa4fb0f3c4e9854dbe2"
+checksum = "713cfb06c7059f3588fb8044c0fad1d09e3c01d225e25b9220dbfdcf16dbb1b3"
 dependencies = [
- "lazy_static",
- "windows-sys 0.36.1",
+ "windows-sys",
 ]
 
 [[package]]
@@ -1955,18 +1920,18 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.14"
+version = "1.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e25dfac463d778e353db5be2449d1cce89bd6fd23c9f1ea21310ce6e5a1b29c4"
+checksum = "58bc9567378fc7690d6b2addae4e60ac2eeea07becb2c64b9f218b53865cba2a"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "serde"
-version = "1.0.148"
+version = "1.0.152"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e53f64bb4ba0191d6d0676e1b141ca55047d83b74f5607e6d8eb88126c52c2dc"
+checksum = "bb7d1f0d3021d347a83e556fc4683dea2ea09d87bccdf88ff5c12545d89d5efb"
 dependencies = [
  "serde_derive",
 ]
@@ -1984,9 +1949,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.148"
+version = "1.0.152"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a55492425aa53521babf6137309e7d34c20bbfbbfcfe2c7f3a047fd1f6b92c0c"
+checksum = "af487d118eecd09402d70a5d72551860e788df87b464af30e5ea6a38c75c541e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1995,20 +1960,20 @@ dependencies = [
 
 [[package]]
 name = "serde_ignored"
-version = "0.1.5"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82b3da7eedd967647a866f67829d1c79d184d7c4521126e9cc2c46a9585c6d21"
+checksum = "94eb4a4087ba8bdf14a9208ac44fddbf55c01a6195f7edfc511ddaff6cae45a6"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.89"
+version = "1.0.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "020ff22c755c2ed3f8cf162dbb41a7268d934702f3ed3631656ea597e08fc3db"
+checksum = "877c235533714907a8c2464236f5c4b2a17262ef1bd71f38f35ea592c8da6883"
 dependencies = [
- "itoa 1.0.4",
+ "itoa 1.0.5",
  "ryu",
  "serde",
 ]
@@ -2218,9 +2183,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.105"
+version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60b9b43d45702de4c839cb9b51d9f529c5dd26a4aff255b42b1ebc03e88ee908"
+checksum = "1f4064b5b16e03ae50984a5a8ed5d4f8803e6bc1fd170a3cda91a1be4b18e3f5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2295,18 +2260,18 @@ checksum = "222a222a5bfe1bba4a77b45ec488a741b3cb8872e5e499451fd7d0129c9c7c3d"
 
 [[package]]
 name = "thiserror"
-version = "1.0.37"
+version = "1.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10deb33631e3c9018b9baf9dcbbc4f737320d2b576bac10f6aefa048fa407e3e"
+checksum = "6a9cd18aa97d5c45c6603caea1da6628790b37f7a34b6ca89522331c5180fed0"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.37"
+version = "1.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "982d17546b47146b28f7c22e3d08465f6b8903d0ea13c1660d9d84a6e7adcdbb"
+checksum = "1fb327af4685e4d03fa8cbcf1716380da910eeb2bb8be417e7f9fd3fb164f36f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2339,9 +2304,9 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "toml"
-version = "0.5.9"
+version = "0.5.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d82e1a7758622a465f8cee077614c73484dac5b836c02ff6a40d5d1010324d7"
+checksum = "1333c76748e868a4d9d1017b5ab53171dfd095f70c712fdb4653a406547f598f"
 dependencies = [
  "serde",
 ]
@@ -2361,9 +2326,9 @@ dependencies = [
 
 [[package]]
 name = "typenum"
-version = "1.15.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcf81ac59edc17cc8697ff311e8f5ef2d99fcbd9817b34cec66f90b6c3dfd987"
+checksum = "497961ef93d974e23eb6f433eb5fe1b7930b659f06d12dec6fc44a8f554c0bba"
 
 [[package]]
 name = "unicode-bidi"
@@ -2373,9 +2338,9 @@ checksum = "099b7128301d285f79ddd55b9a83d5e6b9e97c92e0ea0daebee7263e932de992"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.5"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ceab39d59e4c9499d4e5a8ee0e2735b891bb7308ac83dfb4e80cad195c9f6f3"
+checksum = "84a22b9f218b40614adcb3f4ff08b703773ad44fa9423e4e0d346d5db86e4ebc"
 
 [[package]]
 name = "unicode-linebreak"
@@ -2416,9 +2381,9 @@ checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
 
 [[package]]
 name = "update-informer"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f154aee470c0882ea0f3b1cc2a46c5f4d24f282655f7b0cec065614fe24c447f"
+checksum = "152ff185ca29f7f487c51ca785b0f1d85970c4581f4cdd12ed499227890200f5"
 dependencies = [
  "directories",
  "semver",
@@ -2429,12 +2394,11 @@ dependencies = [
 
 [[package]]
 name = "ureq"
-version = "2.5.0"
+version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b97acb4c28a254fd7a4aeec976c46a7fa404eac4d7c134b30c75144846d7cb8f"
+checksum = "733b5ad78377302af52c0dbcb2623d78fe50e4b3bf215948ff29e9ee031d8566"
 dependencies = [
- "base64",
- "chunked_transfer",
+ "base64 0.13.1",
  "flate2",
  "log",
  "once_cell",
@@ -2589,9 +2553,9 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
-version = "0.22.5"
+version = "0.22.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "368bfe657969fb01238bb756d351dcade285e0f6fcbd36dcb23359a5169975be"
+checksum = "b6c71e40d7d2c34a5106301fb632274ca37242cd0c9d3e64dbece371a40a2d87"
 dependencies = [
  "webpki",
 ]
@@ -2629,30 +2593,17 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-sys"
-version = "0.36.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea04155a16a59f9eab786fe12a4a450e75cdb175f9e0d80da1e17db09f55b8d2"
-dependencies = [
- "windows_aarch64_msvc 0.36.1",
- "windows_i686_gnu 0.36.1",
- "windows_i686_msvc 0.36.1",
- "windows_x86_64_gnu 0.36.1",
- "windows_x86_64_msvc 0.36.1",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a3e1820f08b8513f676f7ab6c1f99ff312fb97b553d30ff4dd86f9f15728aa7"
 dependencies = [
  "windows_aarch64_gnullvm",
- "windows_aarch64_msvc 0.42.0",
- "windows_i686_gnu 0.42.0",
- "windows_i686_msvc 0.42.0",
- "windows_x86_64_gnu 0.42.0",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
  "windows_x86_64_gnullvm",
- "windows_x86_64_msvc 0.42.0",
+ "windows_x86_64_msvc",
 ]
 
 [[package]]
@@ -2663,21 +2614,9 @@ checksum = "41d2aa71f6f0cbe00ae5167d90ef3cfe66527d6f613ca78ac8024c3ccab9a19e"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.36.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9bb8c3fd39ade2d67e9874ac4f3db21f0d710bee00fe7cab16949ec184eeaa47"
-
-[[package]]
-name = "windows_aarch64_msvc"
 version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd0f252f5a35cac83d6311b2e795981f5ee6e67eb1f9a7f64eb4500fbc4dcdb4"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.36.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "180e6ccf01daf4c426b846dfc66db1fc518f074baa793aa7d9b9aaeffad6a3b6"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -2687,21 +2626,9 @@ checksum = "fbeae19f6716841636c28d695375df17562ca208b2b7d0dc47635a50ae6c5de7"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.36.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2e7917148b2812d1eeafaeb22a97e4813dfa60a3f8f78ebe204bcc88f12f024"
-
-[[package]]
-name = "windows_i686_msvc"
 version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "84c12f65daa39dd2babe6e442988fc329d6243fdce47d7d2d155b8d874862246"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.36.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4dcd171b8776c41b97521e5da127a2d86ad280114807d0b2ab1e462bc764d9e1"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -2714,12 +2641,6 @@ name = "windows_x86_64_gnullvm"
 version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09d525d2ba30eeb3297665bd434a54297e4170c7f1a44cad4ef58095b4cd2028"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.36.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c811ca4a8c853ef420abd8592ba53ddbbac90410fab6903b3e79972a631f7680"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -2738,9 +2659,9 @@ dependencies = [
 
 [[package]]
 name = "xmas-elf"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d29b4d8e7beaceb4e77447ba941a7600d23d0319ab52da0461abea214832d5a"
+checksum = "f820cc767d65b32eef9d7ce7201448f28501c59edc55d47b71375fea579fc2df"
 dependencies = [
  "zero",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -328,7 +328,6 @@ dependencies = [
  "log",
  "miette",
  "serde",
- "strum",
  "thiserror",
  "toml",
 ]

--- a/cargo-espflash/Cargo.toml
+++ b/cargo-espflash/Cargo.toml
@@ -31,13 +31,13 @@ pkg-fmt = "zip"
 [dependencies]
 cargo = { version = "0.66.0", features = ["vendored-openssl"] }
 cargo_metadata = "0.15.2"
-clap = { version = "4.0.29", features = ["derive"] }
+clap = { version = "4.0.32", features = ["derive"] }
 env_logger = "0.10.0"
 esp-idf-part = "0.1.2"
 espflash = { version = "=2.0.0-rc.2", path = "../espflash" }
 log = "0.4.17"
 miette = { version = "5.5.0", features = ["fancy"] }
-serde = { version = "1.0.148", features = ["derive"] }
+serde = { version = "1.0.152", features = ["derive"] }
 strum = "0.24.1"
-thiserror = "1.0.37"
-toml = "0.5.9"
+thiserror = "1.0.38"
+toml = "0.5.10"

--- a/cargo-espflash/Cargo.toml
+++ b/cargo-espflash/Cargo.toml
@@ -38,6 +38,5 @@ espflash = { version = "=2.0.0-rc.2", path = "../espflash" }
 log = "0.4.17"
 miette = { version = "5.5.0", features = ["fancy"] }
 serde = { version = "1.0.152", features = ["derive"] }
-strum = "0.24.1"
 thiserror = "1.0.38"
 toml = "0.5.10"

--- a/cargo-espflash/src/main.rs
+++ b/cargo-espflash/src/main.rs
@@ -162,7 +162,7 @@ fn flash(args: FlashArgs, config: &Config) -> Result<()> {
 
     let chip = flasher.chip();
     let target = chip.into_target();
-    let target_xtal_freq = target.crystal_freq(&mut flasher.connection())?;
+    let target_xtal_freq = target.crystal_freq(flasher.connection())?;
 
     let build_ctx =
         build(&args.build_args, &cargo_config, chip).wrap_err("Failed to build project")?;
@@ -320,7 +320,7 @@ fn build(
     let output = Command::new("cargo")
         .arg("build")
         .args(args)
-        .args(&["--message-format", "json-diagnostic-rendered-ansi"])
+        .args(["--message-format", "json-diagnostic-rendered-ansi"])
         .stdout(Stdio::piped())
         .stderr(Stdio::inherit())
         .spawn()

--- a/cargo-espflash/src/main.rs
+++ b/cargo-espflash/src/main.rs
@@ -8,10 +8,10 @@ use cargo_metadata::Message;
 use clap::{Args, Parser, Subcommand};
 use espflash::{
     cli::{
-        self, board_info, clap_enum_variants, config::Config, connect, erase_partitions,
-        flash_elf_image, monitor::monitor, parse_partition_table, partition_table,
-        print_board_info, save_elf_as_image, serial_monitor, ConnectArgs, FlashConfigArgs,
-        MonitorArgs, PartitionTableArgs,
+        self, board_info, config::Config, connect, erase_partitions, flash_elf_image,
+        monitor::monitor, parse_partition_table, partition_table, print_board_info,
+        save_elf_as_image, serial_monitor, ConnectArgs, FlashConfigArgs, MonitorArgs,
+        PartitionTableArgs,
     },
     image_format::ImageFormatKind,
     logging::initialize_logger,
@@ -20,7 +20,6 @@ use espflash::{
 };
 use log::{debug, LevelFilter};
 use miette::{IntoDiagnostic, Result, WrapErr};
-use strum::VariantNames;
 
 use crate::{
     cargo_config::CargoConfig,
@@ -110,7 +109,7 @@ struct FlashArgs {
 #[derive(Debug, Args)]
 struct SaveImageArgs {
     /// Image format to flash
-    #[arg(long, value_parser = clap_enum_variants!(ImageFormatKind))]
+    #[arg(long, value_enum)]
     pub format: Option<ImageFormatKind>,
 
     #[clap(flatten)]

--- a/espflash/Cargo.toml
+++ b/espflash/Cargo.toml
@@ -36,11 +36,11 @@ required-features = ["cli"]
 
 [dependencies]
 addr2line = { version = "0.19.0", optional = true }
-base64 = "0.13.1"
+base64 = "0.21.0"
 binread = "2.2.0"
 bytemuck = { version = "1.12.3", features = ["derive"] }
-clap = { version = "4.0.29", features = ["derive", "env"], optional = true }
-comfy-table = { version = "6.1.3", optional = true }
+clap = { version = "4.0.32", features = ["derive", "env"], optional = true }
+comfy-table = { version = "6.1.4", optional = true }
 crossterm = { version = "0.25.0", optional = true }
 dialoguer = { version = "0.10.2", optional = true }
 directories-next = { version = "2.0.0", optional = true }
@@ -52,18 +52,18 @@ lazy_static = { version = "1.4.0", optional = true }
 log = "0.4.17"
 miette = { version = "5.5.0", features = ["fancy"] }
 parse_int = { version = "0.6.0", optional = true }
-regex = { version = "1.7.0", optional = true }
+regex = { version = "1.7.1", optional = true }
 rppal = { version = "0.14.1", optional = true }
-serde = { version = "1.0.148", features = ["derive"] }
+serde = { version = "1.0.152", features = ["derive"] }
 serde-hex = { version = "0.1.0", optional = true }
 serialport = "4.2.0"
 sha2 = "0.10.6"
 slip-codec = "0.3.3"
 strum = { version = "0.24.1", features = ["derive"] }
-thiserror = "1.0.37"
-toml = "0.5.9"
-update-informer = { version = "0.5.0", optional = true }
-xmas-elf = "0.8.0"
+thiserror = "1.0.38"
+toml = "0.5.10"
+update-informer = { version = "0.6.0", optional = true }
+xmas-elf = "0.9.0"
 
 [features]
 default = ["cli"]

--- a/espflash/src/bin/espflash.rs
+++ b/espflash/src/bin/espflash.rs
@@ -120,7 +120,7 @@ fn flash(args: FlashArgs, config: &Config) -> Result<()> {
 
     let chip = flasher.chip();
     let target = chip.into_target();
-    let target_xtal_freq = target.crystal_freq(&mut flasher.connection())?;
+    let target_xtal_freq = target.crystal_freq(flasher.connection())?;
 
     // Read the ELF data from the build path and load it to the target.
     let elf_data = fs::read(&args.image).into_diagnostic()?;

--- a/espflash/src/bin/espflash.rs
+++ b/espflash/src/bin/espflash.rs
@@ -8,10 +8,10 @@ use std::{
 use clap::{Args, Parser, Subcommand};
 use espflash::{
     cli::{
-        self, board_info, build_progress_bar_callback, clap_enum_variants, config::Config, connect,
-        erase_partitions, flash_elf_image, monitor::monitor, parse_partition_table,
-        partition_table, print_board_info, progress_bar, save_elf_as_image, serial_monitor,
-        ConnectArgs, FlashConfigArgs, MonitorArgs, PartitionTableArgs,
+        self, board_info, build_progress_bar_callback, config::Config, connect, erase_partitions,
+        flash_elf_image, monitor::monitor, parse_partition_table, partition_table,
+        print_board_info, progress_bar, save_elf_as_image, serial_monitor, ConnectArgs,
+        FlashConfigArgs, MonitorArgs, PartitionTableArgs,
     },
     image_format::ImageFormatKind,
     logging::initialize_logger,
@@ -20,7 +20,6 @@ use espflash::{
 };
 use log::{debug, LevelFilter};
 use miette::{IntoDiagnostic, Result, WrapErr};
-use strum::VariantNames;
 
 #[derive(Debug, Parser)]
 #[clap(about, version, propagate_version = true)]
@@ -57,7 +56,7 @@ struct FlashArgs {
 #[derive(Debug, Args)]
 struct SaveImageArgs {
     /// Image format to flash
-    #[arg(long, value_parser = clap_enum_variants!(ImageFormatKind))]
+    #[arg(long, value_enum)]
     format: Option<ImageFormatKind>,
 
     #[clap(flatten)]

--- a/espflash/src/cli/mod.rs
+++ b/espflash/src/cli/mod.rs
@@ -22,7 +22,6 @@ use indicatif::{style::ProgressStyle, HumanCount, ProgressBar, ProgressDrawTarge
 use log::{debug, info};
 use miette::{IntoDiagnostic, Result, WrapErr};
 use serialport::{SerialPortType, UsbPortInfo};
-use strum::VariantNames;
 
 use self::{config::Config, monitor::monitor, serial::get_serial_port_info};
 use crate::{
@@ -38,26 +37,6 @@ pub mod config;
 pub mod monitor;
 
 mod serial;
-
-// Since as of `clap@4.0.x` the `possible_values` attribute is no longer
-// present, we must use the more convoluted `value_parser` attribute instead.
-// Since this is a bit tedious, we'll use a helper macro to abstract away all
-// the cruft. It's important to note that this macro assumes the
-// `strum::EnumVariantNames` trait has been implemented for the provided type,
-// and that the provided type is in scope when calling this macro.
-//
-// See this comment for details:
-// https://github.com/clap-rs/clap/discussions/4264#discussioncomment-3737696
-#[doc(hidden)]
-#[macro_export]
-macro_rules! clap_enum_variants {
-    ($e: ty) => {{
-        use clap::builder::TypedValueParser;
-        clap::builder::PossibleValuesParser::new(<$e>::VARIANTS).map(|s| s.parse::<$e>().unwrap())
-    }};
-}
-
-pub use clap_enum_variants;
 
 /// Establish a connection with a target device
 #[derive(Debug, Args)]
@@ -85,13 +64,13 @@ pub struct ConnectArgs {
 #[derive(Debug, Args)]
 pub struct FlashConfigArgs {
     /// Flash frequency
-    #[arg(short = 'f', long, value_name = "FREQ", value_parser = clap_enum_variants!(FlashFrequency))]
+    #[arg(short = 'f', long, value_name = "FREQ", value_enum)]
     pub flash_freq: Option<FlashFrequency>,
     /// Flash mode to use
-    #[arg(short = 'm', long, value_name = "MODE", value_parser = clap_enum_variants!(FlashMode))]
+    #[arg(short = 'm', long, value_name = "MODE", value_enum)]
     pub flash_mode: Option<FlashMode>,
     /// Flash size of the target
-    #[arg(short = 's', long, value_name = "SIZE", value_parser = clap_enum_variants!(FlashSize))]
+    #[arg(short = 's', long, value_name = "SIZE", value_enum)]
     pub flash_size: Option<FlashSize>,
 }
 
@@ -111,10 +90,16 @@ pub struct FlashArgs {
     )]
     pub erase_parts: Option<Vec<String>>,
     /// Erase specified data partitions
-    #[arg(long, requires = "partition_table", value_name = "PARTS", value_parser = clap_enum_variants!(DataType), value_delimiter = ',')]
+    #[arg(
+        long,
+        requires = "partition_table",
+        value_name = "PARTS",
+        value_enum,
+        value_delimiter = ','
+    )]
     pub erase_data_parts: Option<Vec<DataType>>,
     /// Image format to flash
-    #[arg(long, value_parser = clap_enum_variants!(ImageFormatKind))]
+    #[arg(long, value_enum)]
     pub format: Option<ImageFormatKind>,
     /// Open a serial monitor after flashing
     #[arg(short = 'M', long)]
@@ -155,7 +140,7 @@ pub struct SaveImageArgs {
     #[arg(long, value_name = "FILE")]
     pub bootloader: Option<PathBuf>,
     /// Chip to create an image for
-    #[arg(long, value_parser = clap_enum_variants!(Chip))]
+    #[arg(long, value_enum)]
     pub chip: Chip,
     /// File name to save the generated image to
     pub file: PathBuf,

--- a/espflash/src/cli/serial.rs
+++ b/espflash/src/cli/serial.rs
@@ -33,9 +33,9 @@ pub fn get_serial_port_info(
     let ports = detect_usb_serial_ports().unwrap_or_default();
 
     if let Some(serial) = &matches.port {
-        find_serial_port(&ports, &serial)
+        find_serial_port(&ports, serial)
     } else if let Some(serial) = &config.connection.serial {
-        find_serial_port(&ports, &serial)
+        find_serial_port(&ports, serial)
     } else {
         let (port, matches) = select_serial_port(ports, config)?;
 

--- a/espflash/src/command.rs
+++ b/espflash/src/command.rs
@@ -205,7 +205,7 @@ impl<'a> Command<'a> {
                 data_command(writer, data, pad_to, pad_byte, sequence)?;
             }
             Command::FlashEnd { reboot } => {
-                write_basic(writer, &[if reboot { 0 } else { 1 }], 0)?;
+                write_basic(writer, &[u8::from(!reboot)], 0)?;
             }
             Command::MemBegin {
                 size,
@@ -242,7 +242,7 @@ impl<'a> Command<'a> {
                     entry: u32,
                 }
                 let params = EntryParams {
-                    no_entry: if reboot { 1 } else { 0 },
+                    no_entry: u32::from(reboot),
                     entry,
                 };
                 write_basic(writer, bytes_of(&params), 0)?;
@@ -325,7 +325,7 @@ impl<'a> Command<'a> {
                 data_command(writer, data, pad_to, pad_byte, sequence)?;
             }
             Command::FlashDeflateEnd { reboot } => {
-                write_basic(writer, &[if reboot { 0 } else { 1 }], 0)?;
+                write_basic(writer, &[u8::from(!reboot)], 0)?;
             }
             Command::FlashDetect => {
                 write_basic(writer, &[], 0)?;

--- a/espflash/src/flasher/mod.rs
+++ b/espflash/src/flasher/mod.rs
@@ -38,6 +38,7 @@ const FLASH_SECTORS_PER_BLOCK: usize = FLASH_SECTOR_SIZE / FLASH_BLOCK_SIZE;
 /// Supported flash frequencies
 ///
 /// Note that not all frequencies are supported by each target device.
+#[cfg_attr(feature = "cli", derive(clap::ValueEnum))]
 #[derive(Debug, Default, Clone, Copy, Hash, PartialEq, Eq, Display, EnumVariantNames)]
 #[repr(u8)]
 pub enum FlashFrequency {
@@ -101,6 +102,7 @@ impl FromStr for FlashFrequency {
 }
 
 /// Supported flash modes
+#[cfg_attr(feature = "cli", derive(clap::ValueEnum))]
 #[derive(Copy, Clone, Debug, Default, EnumVariantNames)]
 #[strum(serialize_all = "lowercase")]
 pub enum FlashMode {
@@ -134,6 +136,7 @@ impl FromStr for FlashMode {
 /// Supported flash sizes
 ///
 /// Note that not all sizes are supported by each target device.
+#[cfg_attr(feature = "cli", derive(clap::ValueEnum))]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq, Display, EnumVariantNames, EnumIter)]
 #[repr(u8)]
 pub enum FlashSize {

--- a/espflash/src/flasher/mod.rs
+++ b/espflash/src/flasher/mod.rs
@@ -43,62 +43,28 @@ const FLASH_SECTORS_PER_BLOCK: usize = FLASH_SECTOR_SIZE / FLASH_BLOCK_SIZE;
 #[repr(u8)]
 pub enum FlashFrequency {
     /// 12 MHz
-    #[strum(serialize = "12M")]
-    Flash12M,
+    _12Mhz,
     /// 15 MHz
-    #[strum(serialize = "15M")]
-    Flash15M,
+    _15Mhz,
     /// 16 MHz
-    #[strum(serialize = "16M")]
-    Flash16M,
+    _16Mhz,
     /// 20 MHz
-    #[strum(serialize = "20M")]
-    Flash20M,
+    _20Mhz,
     /// 24 MHz
-    #[strum(serialize = "24M")]
-    Flash24M,
+    _24Mhz,
     /// 26 MHz
-    #[strum(serialize = "26M")]
-    Flash26M,
+    _26Mhz,
     /// 30 MHz
-    #[strum(serialize = "30M")]
-    Flash30M,
+    _30Mhz,
     /// 40 MHz
     #[default]
-    #[strum(serialize = "40M")]
-    Flash40M,
+    _40Mhz,
     /// 48 MHz
-    #[strum(serialize = "48M")]
-    Flash48M,
+    _48Mhz,
     /// 60 MHz
-    #[strum(serialize = "60M")]
-    Flash60M,
+    _60Mhz,
     /// 80 MHz
-    #[strum(serialize = "80M")]
-    Flash80M,
-}
-
-impl FromStr for FlashFrequency {
-    type Err = Error;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        use FlashFrequency::*;
-
-        match s.to_uppercase().as_str() {
-            "12M" => Ok(Flash12M),
-            "15M" => Ok(Flash15M),
-            "16M" => Ok(Flash16M),
-            "20M" => Ok(Flash20M),
-            "24M" => Ok(Flash24M),
-            "26M" => Ok(Flash26M),
-            "30M" => Ok(Flash30M),
-            "40M" => Ok(Flash40M),
-            "48M" => Ok(Flash48M),
-            "60M" => Ok(Flash60M),
-            "80M" => Ok(Flash80M),
-            _ => Err(Error::InvalidFlashFrequency(s.to_string())),
-        }
-    }
+    _80Mhz,
 }
 
 /// Supported flash modes
@@ -117,75 +83,50 @@ pub enum FlashMode {
     Dout,
 }
 
-impl FromStr for FlashMode {
-    type Err = Error;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let mode = match s.to_lowercase().as_str() {
-            "qio" => FlashMode::Qio,
-            "qout" => FlashMode::Qout,
-            "dio" => FlashMode::Dio,
-            "dout" => FlashMode::Dout,
-            _ => return Err(Error::InvalidFlashMode(s.to_string())),
-        };
-
-        Ok(mode)
-    }
-}
-
 /// Supported flash sizes
 ///
 /// Note that not all sizes are supported by each target device.
 #[cfg_attr(feature = "cli", derive(clap::ValueEnum))]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq, Display, EnumVariantNames, EnumIter)]
 #[repr(u8)]
+#[strum(serialize_all = "SCREAMING_SNAKE_CASE")]
 pub enum FlashSize {
     /// 256 KB
-    #[strum(serialize = "256K")]
-    Flash256Kb = 0x12,
+    _256Kb = 0x12,
     /// 512 KB
-    #[strum(serialize = "512K")]
-    Flash512Kb = 0x13,
+    _512Kb = 0x13,
     /// 1 MB
-    #[strum(serialize = "1M")]
-    Flash1Mb = 0x14,
+    _1Mb = 0x14,
     /// 2 MB
-    #[strum(serialize = "2M")]
-    Flash2Mb = 0x15,
+    _2Mb = 0x15,
     /// 4 MB
     #[default]
-    #[strum(serialize = "4M")]
-    Flash4Mb = 0x16,
+    _4Mb = 0x16,
     /// 8 MB
-    #[strum(serialize = "8M")]
-    Flash8Mb = 0x17,
+    _8Mb = 0x17,
     /// 16 MB
-    #[strum(serialize = "16M")]
-    Flash16Mb = 0x18,
+    _16Mb = 0x18,
     /// 32 MB
-    #[strum(serialize = "32M")]
-    Flash32Mb = 0x19,
+    _32Mb = 0x19,
     /// 64 MB
-    #[strum(serialize = "64M")]
-    Flash64Mb = 0x1a,
+    _64Mb = 0x1a,
     /// 128 MB
-    #[strum(serialize = "128M")]
-    Flash128Mb = 0x21,
+    _128Mb = 0x21,
 }
 
 impl FlashSize {
     fn from(value: u8) -> Result<FlashSize, Error> {
         match value {
-            0x12 => Ok(FlashSize::Flash256Kb),
-            0x13 => Ok(FlashSize::Flash512Kb),
-            0x14 => Ok(FlashSize::Flash1Mb),
-            0x15 => Ok(FlashSize::Flash2Mb),
-            0x16 => Ok(FlashSize::Flash4Mb),
-            0x17 => Ok(FlashSize::Flash8Mb),
-            0x18 => Ok(FlashSize::Flash16Mb),
-            0x19 => Ok(FlashSize::Flash32Mb),
-            0x1a => Ok(FlashSize::Flash64Mb),
-            0x21 => Ok(FlashSize::Flash128Mb),
+            0x12 => Ok(FlashSize::_256Kb),
+            0x13 => Ok(FlashSize::_512Kb),
+            0x14 => Ok(FlashSize::_1Mb),
+            0x15 => Ok(FlashSize::_2Mb),
+            0x16 => Ok(FlashSize::_4Mb),
+            0x17 => Ok(FlashSize::_8Mb),
+            0x18 => Ok(FlashSize::_16Mb),
+            0x19 => Ok(FlashSize::_32Mb),
+            0x1a => Ok(FlashSize::_64Mb),
+            0x21 => Ok(FlashSize::_128Mb),
             _ => Err(Error::UnsupportedFlash(FlashDetectError::from(value))),
         }
     }
@@ -193,16 +134,16 @@ impl FlashSize {
     /// Returns the flash size in bytes
     pub fn size(self) -> u32 {
         match self {
-            FlashSize::Flash256Kb => 0x0040000,
-            FlashSize::Flash512Kb => 0x0080000,
-            FlashSize::Flash1Mb => 0x0100000,
-            FlashSize::Flash2Mb => 0x0200000,
-            FlashSize::Flash4Mb => 0x0400000,
-            FlashSize::Flash8Mb => 0x0800000,
-            FlashSize::Flash16Mb => 0x1000000,
-            FlashSize::Flash32Mb => 0x2000000,
-            FlashSize::Flash64Mb => 0x4000000,
-            FlashSize::Flash128Mb => 0x8000000,
+            FlashSize::_256Kb => 0x0040000,
+            FlashSize::_512Kb => 0x0080000,
+            FlashSize::_1Mb => 0x0100000,
+            FlashSize::_2Mb => 0x0200000,
+            FlashSize::_4Mb => 0x0400000,
+            FlashSize::_8Mb => 0x0800000,
+            FlashSize::_16Mb => 0x1000000,
+            FlashSize::_32Mb => 0x2000000,
+            FlashSize::_64Mb => 0x4000000,
+            FlashSize::_128Mb => 0x8000000,
         }
     }
 }
@@ -353,7 +294,7 @@ impl Flasher {
         let mut flasher = Flasher {
             connection,
             chip,
-            flash_size: FlashSize::Flash4Mb,
+            flash_size: FlashSize::_4Mb,
             spi_params: SpiAttachParams::default(),
             use_stub,
         };
@@ -495,7 +436,7 @@ impl Flasher {
                     flash_id,
                     size_id
                 );
-                FlashSize::Flash4Mb
+                FlashSize::_4Mb
             }
         };
 

--- a/espflash/src/flasher/stubs.rs
+++ b/espflash/src/flasher/stubs.rs
@@ -1,3 +1,4 @@
+use base64::{engine::general_purpose, Engine as _};
 use serde::{Deserialize, Serialize};
 
 use crate::targets::Chip;
@@ -52,13 +53,13 @@ impl FlashStub {
 
     /// Fetch text start address and bytes
     pub fn text(&self) -> (u32, Vec<u8>) {
-        let v = base64::decode(&self.text).unwrap();
+        let v = general_purpose::STANDARD.decode(&self.text).unwrap();
         (self.text_start, v)
     }
 
     /// Fetch data start address and bytes
     pub fn data(&self) -> (u32, Vec<u8>) {
-        let v = base64::decode(&self.data).unwrap();
+        let v = general_purpose::STANDARD.decode(&self.data).unwrap();
         (self.data_start, v)
     }
 }

--- a/espflash/src/image_format/esp8266.rs
+++ b/espflash/src/image_format/esp8266.rs
@@ -167,13 +167,13 @@ fn encode_flash_size(size: FlashSize) -> Result<u8, FlashDetectError> {
     use FlashSize::*;
 
     match size {
-        Flash256Kb => Ok(0x10),
-        Flash512Kb => Ok(0x00),
-        Flash1Mb => Ok(0x20),
-        Flash2Mb => Ok(0x30),
-        Flash4Mb => Ok(0x40),
-        Flash8Mb => Ok(0x80),
-        Flash16Mb => Ok(0x90),
+        _256Kb => Ok(0x10),
+        _512Kb => Ok(0x00),
+        _1Mb => Ok(0x20),
+        _2Mb => Ok(0x30),
+        _4Mb => Ok(0x40),
+        _8Mb => Ok(0x80),
+        _16Mb => Ok(0x90),
         _ => Err(FlashDetectError::from(size as u8)),
     }
 }

--- a/espflash/src/image_format/idf_bootloader.rs
+++ b/espflash/src/image_format/idf_bootloader.rs
@@ -243,14 +243,14 @@ fn encode_flash_size(size: FlashSize) -> Result<u8, FlashDetectError> {
     use FlashSize::*;
 
     match size {
-        Flash1Mb => Ok(0x00),
-        Flash2Mb => Ok(0x10),
-        Flash4Mb => Ok(0x20),
-        Flash8Mb => Ok(0x30),
-        Flash16Mb => Ok(0x40),
-        Flash32Mb => Ok(0x19),
-        Flash64Mb => Ok(0x1a),
-        Flash128Mb => Ok(0x21),
+        _1Mb => Ok(0x00),
+        _2Mb => Ok(0x10),
+        _4Mb => Ok(0x20),
+        _8Mb => Ok(0x30),
+        _16Mb => Ok(0x40),
+        _32Mb => Ok(0x19),
+        _64Mb => Ok(0x1a),
+        _128Mb => Ok(0x21),
         _ => Err(FlashDetectError::from(size as u8)),
     }
 }

--- a/espflash/src/image_format/idf_bootloader.rs
+++ b/espflash/src/image_format/idf_bootloader.rs
@@ -134,7 +134,7 @@ impl<'a> IdfBootloaderFormat<'a> {
 
                     let pad_header = SegmentHeader {
                         addr: 0,
-                        length: pad_len as u32,
+                        length: pad_len,
                     };
                     data.write_all(bytes_of(&pad_header))?;
 
@@ -158,7 +158,7 @@ impl<'a> IdfBootloaderFormat<'a> {
         }
 
         let padding = 15 - (data.len() % 16);
-        let padding = &[0u8; 16][0..padding as usize];
+        let padding = &[0u8; 16][0..padding];
         data.write_all(padding)?;
 
         data.write_all(&[checksum])?;

--- a/espflash/src/image_format/mod.rs
+++ b/espflash/src/image_format/mod.rs
@@ -65,6 +65,7 @@ pub trait ImageFormat<'a>: Send {
 }
 
 /// All supported firmware image formats
+#[cfg_attr(feature = "cli", derive(clap::ValueEnum))]
 #[derive(
     Debug, Copy, Clone, Eq, PartialEq, Display, IntoStaticStr, EnumVariantNames, Deserialize,
 )]

--- a/espflash/src/targets/esp32c2.rs
+++ b/espflash/src/targets/esp32c2.rs
@@ -77,12 +77,7 @@ impl Target for Esp32c2 {
     fn flash_frequency_encodings(&self) -> HashMap<FlashFrequency, u8> {
         use FlashFrequency::*;
 
-        let encodings = [
-            (Flash15M, 0x2),
-            (Flash20M, 0x1),
-            (Flash30M, 0x0),
-            (Flash60M, 0xF),
-        ];
+        let encodings = [(_15Mhz, 0x2), (_20Mhz, 0x1), (_30Mhz, 0x0), (_60Mhz, 0xF)];
 
         HashMap::from(encodings)
     }

--- a/espflash/src/targets/mod.rs
+++ b/espflash/src/targets/mod.rs
@@ -282,12 +282,7 @@ pub trait Target: ReadEFuse {
     fn flash_frequency_encodings(&self) -> HashMap<FlashFrequency, u8> {
         use FlashFrequency::*;
 
-        let encodings = [
-            (Flash20M, 0x2),
-            (Flash26M, 0x1),
-            (Flash40M, 0x0),
-            (Flash80M, 0xf),
-        ];
+        let encodings = [(_20Mhz, 0x2), (_26Mhz, 0x1), (_40Mhz, 0x0), (_80Mhz, 0xf)];
 
         HashMap::from(encodings)
     }

--- a/espflash/src/targets/mod.rs
+++ b/espflash/src/targets/mod.rs
@@ -40,6 +40,7 @@ mod esp8266;
 mod flash_target;
 
 /// Enumeration of all supported devices
+#[cfg_attr(feature = "cli", derive(clap::ValueEnum))]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Display, EnumIter, EnumVariantNames)]
 #[strum(serialize_all = "lowercase")]
 pub enum Chip {


### PR DESCRIPTION
- Update dependencies to their latest versions
- Derive `clap::ValueEnum` for all enums used as command line values, rather than the macro we were previously using
- Simplify the variant names of the flash configuration enums, making them more consistent in the process
- Fix a deprecation warning and a number of `clippy` warnings