### PR TITLE
Pass progress by value when possible, replace optional with null object

### DIFF
--- a/cargo-espflash/src/main.rs
+++ b/cargo-espflash/src/main.rs
@@ -171,7 +171,7 @@ fn flash(args: FlashArgs, config: &Config) -> Result<()> {
     print_board_info(&mut flasher)?;
 
     if args.flash_args.ram {
-        flasher.load_elf_to_ram(&elf_data, Some(&mut EspflashProgress::default()))?;
+        flasher.load_elf_to_ram(&elf_data, EspflashProgress::default())?;
     } else {
         let bootloader = args
             .flash_args

--- a/espflash/src/bin/espflash.rs
+++ b/espflash/src/bin/espflash.rs
@@ -126,7 +126,7 @@ fn flash(args: FlashArgs, config: &Config) -> Result<()> {
     let elf_data = fs::read(&args.image).into_diagnostic()?;
 
     if args.flash_args.ram {
-        flasher.load_elf_to_ram(&elf_data, Some(&mut EspflashProgress::default()))?;
+        flasher.load_elf_to_ram(&elf_data, &mut EspflashProgress::default())?;
     } else {
         let bootloader = args.flash_args.bootloader.as_deref();
         let partition_table = args.flash_args.partition_table.as_deref();
@@ -233,7 +233,7 @@ fn write_bin(args: WriteBinArgs, config: &Config) -> Result<()> {
     let mut buffer = Vec::with_capacity(size.try_into().into_diagnostic()?);
     f.read_to_end(&mut buffer).into_diagnostic()?;
 
-    flasher.write_bin_to_flash(args.addr, &buffer, Some(&mut EspflashProgress::default()))?;
+    flasher.write_bin_to_flash(args.addr, &buffer, &mut EspflashProgress::default())?;
 
     Ok(())
 }

--- a/espflash/src/bin/espflash.rs
+++ b/espflash/src/bin/espflash.rs
@@ -126,7 +126,7 @@ fn flash(args: FlashArgs, config: &Config) -> Result<()> {
     let elf_data = fs::read(&args.image).into_diagnostic()?;
 
     if args.flash_args.ram {
-        flasher.load_elf_to_ram(&elf_data, &mut EspflashProgress::default())?;
+        flasher.load_elf_to_ram(&elf_data, EspflashProgress::default())?;
     } else {
         let bootloader = args.flash_args.bootloader.as_deref();
         let partition_table = args.flash_args.partition_table.as_deref();
@@ -233,7 +233,7 @@ fn write_bin(args: WriteBinArgs, config: &Config) -> Result<()> {
     let mut buffer = Vec::with_capacity(size.try_into().into_diagnostic()?);
     f.read_to_end(&mut buffer).into_diagnostic()?;
 
-    flasher.write_bin_to_flash(args.addr, &buffer, &mut EspflashProgress::default())?;
+    flasher.write_bin_to_flash(args.addr, &buffer, EspflashProgress::default())?;
 
     Ok(())
 }

--- a/espflash/src/cli/mod.rs
+++ b/espflash/src/cli/mod.rs
@@ -468,7 +468,7 @@ pub fn flash_elf_image(
         flash_mode,
         flash_size,
         flash_freq,
-        &mut EspflashProgress::default(),
+        EspflashProgress::default(),
     )?;
     info!("Flashing has completed!");
 

--- a/espflash/src/cli/mod.rs
+++ b/espflash/src/cli/mod.rs
@@ -468,7 +468,7 @@ pub fn flash_elf_image(
         flash_mode,
         flash_size,
         flash_freq,
-        Some(&mut EspflashProgress::default()),
+        &mut EspflashProgress::default(),
     )?;
     info!("Flashing has completed!");
 

--- a/espflash/src/flasher/mod.rs
+++ b/espflash/src/flasher/mod.rs
@@ -629,7 +629,7 @@ impl Flasher {
     pub fn load_elf_to_ram(
         &mut self,
         elf_data: &[u8],
-        progress: &mut dyn ProgressCallbacks,
+        mut progress: impl ProgressCallbacks,
     ) -> Result<(), Error> {
         let image = ElfFirmwareImage::try_from(elf_data)?;
         if image.rom_segments(self.chip).next().is_some() {
@@ -646,7 +646,7 @@ impl Flasher {
 
         for segment in image.ram_segments(self.chip) {
             target
-                .write_segment(&mut self.connection, segment.into(), progress)
+                .write_segment(&mut self.connection, segment.into(), &mut progress)
                 .flashing()?;
         }
 
@@ -663,7 +663,7 @@ impl Flasher {
         flash_mode: Option<FlashMode>,
         flash_size: Option<FlashSize>,
         flash_freq: Option<FlashFrequency>,
-        progress: &mut dyn ProgressCallbacks,
+        mut progress: impl ProgressCallbacks,
     ) -> Result<(), Error> {
         let image = ElfFirmwareImage::try_from(elf_data)?;
 
@@ -691,7 +691,7 @@ impl Flasher {
 
         for segment in image.flash_segments() {
             target
-                .write_segment(&mut self.connection, segment, progress)
+                .write_segment(&mut self.connection, segment, &mut progress)
                 .flashing()?;
         }
 
@@ -705,7 +705,7 @@ impl Flasher {
         &mut self,
         addr: u32,
         data: &[u8],
-        progress: &mut dyn ProgressCallbacks,
+        mut progress: impl ProgressCallbacks,
     ) -> Result<(), Error> {
         let segment = RomSegment {
             addr,
@@ -714,7 +714,7 @@ impl Flasher {
 
         let mut target = self.chip.flash_target(self.spi_params, self.use_stub);
         target.begin(&mut self.connection).flashing()?;
-        target.write_segment(&mut self.connection, segment, progress)?;
+        target.write_segment(&mut self.connection, segment, &mut progress)?;
         target.finish(&mut self.connection, true).flashing()?;
 
         Ok(())
@@ -729,7 +729,7 @@ impl Flasher {
         flash_mode: Option<FlashMode>,
         flash_size: Option<FlashSize>,
         flash_freq: Option<FlashFrequency>,
-        progress: &mut dyn ProgressCallbacks,
+        progress: impl ProgressCallbacks,
     ) -> Result<(), Error> {
         self.load_elf_to_flash_with_format(
             elf_data,

--- a/espflash/src/targets/flash_target/esp32.rs
+++ b/espflash/src/targets/flash_target/esp32.rs
@@ -98,7 +98,7 @@ impl FlashTarget for Esp32Target {
         &mut self,
         connection: &mut Connection,
         segment: RomSegment,
-        progress: &mut Option<&mut dyn ProgressCallbacks>,
+        progress: &mut dyn ProgressCallbacks,
     ) -> Result<(), Error> {
         let addr = segment.addr;
 
@@ -131,7 +131,7 @@ impl FlashTarget for Esp32Target {
         let chunks = compressed.chunks(flash_write_size);
         let num_chunks = chunks.len();
 
-        progress.as_mut().map(|cb| cb.init(addr, num_chunks));
+        progress.init(addr, num_chunks);
 
         // decode the chunks to see how much data the device will have to save
         let mut decoder = ZlibDecoder::new(Vec::new());
@@ -156,10 +156,10 @@ impl FlashTarget for Esp32Target {
                 },
             )?;
 
-            progress.as_mut().map(|cb| cb.update(i + 1));
+            progress.update(i + 1);
         }
 
-        progress.as_mut().map(|cb| cb.finish());
+        progress.finish();
 
         Ok(())
     }

--- a/espflash/src/targets/flash_target/esp8266.rs
+++ b/espflash/src/targets/flash_target/esp8266.rs
@@ -34,7 +34,7 @@ impl FlashTarget for Esp8266Target {
         &mut self,
         connection: &mut Connection,
         segment: RomSegment,
-        progress: &mut Option<&mut dyn ProgressCallbacks>,
+        progress: &mut dyn ProgressCallbacks,
     ) -> Result<(), Error> {
         let addr = segment.addr;
         let block_count = (segment.data.len() + FLASH_WRITE_SIZE - 1) / FLASH_WRITE_SIZE;
@@ -57,7 +57,7 @@ impl FlashTarget for Esp8266Target {
         let chunks = segment.data.chunks(FLASH_WRITE_SIZE);
         let num_chunks = chunks.len();
 
-        progress.as_mut().map(|cb| cb.init(addr, num_chunks));
+        progress.init(addr, num_chunks);
 
         for (i, block) in chunks.enumerate() {
             connection.command(Command::FlashData {
@@ -67,10 +67,10 @@ impl FlashTarget for Esp8266Target {
                 data: block,
             })?;
 
-            progress.as_mut().map(|cb| cb.update(i + 1));
+            progress.update(i + 1);
         }
 
-        progress.as_mut().map(|cb| cb.finish());
+        progress.finish();
 
         Ok(())
     }

--- a/espflash/src/targets/flash_target/mod.rs
+++ b/espflash/src/targets/flash_target/mod.rs
@@ -18,7 +18,7 @@ pub trait FlashTarget {
         &mut self,
         connection: &mut Connection,
         segment: RomSegment,
-        progress: &mut Option<&mut dyn ProgressCallbacks>,
+        progress: &mut dyn ProgressCallbacks,
     ) -> Result<(), Error>;
 
     /// Complete the flashing operation

--- a/espflash/src/targets/flash_target/ram.rs
+++ b/espflash/src/targets/flash_target/ram.rs
@@ -45,7 +45,7 @@ impl FlashTarget for RamTarget {
         &mut self,
         connection: &mut Connection,
         segment: RomSegment,
-        progress: &mut Option<&mut dyn ProgressCallbacks>,
+        progress: &mut dyn ProgressCallbacks,
     ) -> Result<(), Error> {
         let addr = segment.addr;
 
@@ -63,7 +63,7 @@ impl FlashTarget for RamTarget {
         let chunks = segment.data.chunks(self.block_size);
         let num_chunks = chunks.len();
 
-        progress.as_mut().map(|cb| cb.init(addr, num_chunks));
+        progress.init(addr, num_chunks);
 
         for (i, block) in chunks.enumerate() {
             connection.command(Command::MemData {
@@ -73,10 +73,10 @@ impl FlashTarget for RamTarget {
                 data: block,
             })?;
 
-            progress.as_mut().map(|cb| cb.update(i + 1));
+            progress.update(i + 1);
         }
 
-        progress.as_mut().map(|cb| cb.finish());
+        progress.finish();
 
         Ok(())
     }


### PR DESCRIPTION
Follow-up for #333 that implements my suggestions. The null object allows cleaning up some of the usage sites, and taking by value is something that I hope improves usability.

Replacing _all_ `dyn ProgressCallbacks` instances is indeed not possible, but it is not a big deal.

@jessebraham please don't feel in any way pressured to accept this. This PR may or may not actually be a good idea and I only intend this as an illustration of what I had in mind. I did not think of it too deeply and I might have missed use cases where the PR might hurt more than help.