### PR TITLE
No longer build releases for the Windows GNU target

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,13 +47,6 @@ jobs:
 
   # Windows
 
-  x86_64-pc-windows-gnu:
-    uses: ./.github/workflows/package.yml
-    with:
-      runs_on: windows-latest
-      target: x86_64-pc-windows-gnu
-      extension: .exe
-
   x86_64-pc-windows-msvc:
     uses: ./.github/workflows/package.yml
     with:


### PR DESCRIPTION
This use to work, and now fails. It's not a super common target, and users can still install from source, so I'm not going to bother troubleshooting this right now.

Closes #312.