### PR TITLE
Fix rev check for c3 direct boot

### DIFF
--- a/espflash/src/targets/esp32c3.rs
+++ b/espflash/src/targets/esp32c3.rs
@@ -93,7 +93,7 @@ impl Target for Esp32c3 {
                 flash_size,
                 flash_freq,
             )?)),
-            (ImageFormatKind::DirectBoot, None | Some((3.., _))) => {
+            (ImageFormatKind::DirectBoot, None | Some((0.., 3..))) => {
                 Ok(Box::new(DirectBootFormat::new(image, 0)?))
             }
             _ => Err(


### PR DESCRIPTION
Before this PR:

```rust
Chip type:         esp32c3 (revision v0.3)
Crystal frequency: 40MHz
Flash size:        4M
Features:          WiFi, BLE
MAC address:       60:55:f9:c0:25:c0
Error: espflash::unsupported_image_format

  × Image format direct-boot is not supported by the esp32c3 revision v0.3
  help: The esp32c3: only supports direct-boot starting with revision 3
```