### PR TITLE
Fix `espflash::write_bin`

### DIFF
--- a/espflash/src/bin/espflash.rs
+++ b/espflash/src/bin/espflash.rs
@@ -226,7 +226,7 @@ fn save_image(args: SaveImageArgs) -> Result<()> {
 
 fn write_bin(args: WriteBinArgs, config: &Config) -> Result<()> {
     let mut flasher = connect(&args.connect_args, config)?;
-    board_info(&args.connect_args, config)?;
+    print_board_info(&mut flasher)?;
 
     let mut f = File::open(&args.bin_file).into_diagnostic()?;
     let size = f.metadata().into_diagnostic()?.len();


### PR DESCRIPTION
I was encountering this error while using the `espflash` CLI utility, more specifically the `write-bin` subcommand:
```
> cargo run -p espflash -- write-bin 0x0 file.bin
[2023-02-14T08:08:28Z INFO ] Serial port: 'COM20'
[2023-02-14T08:08:28Z INFO ] Connecting...
[2023-02-14T08:08:28Z INFO ] Serial port: 'COM20'
[2023-02-14T08:08:28Z INFO ] Connecting...
Error: espflash::connection_failed

  x Failed to open serial port COM20
  |-> Failed to open serial port COM20
  |-> Error while connecting to device
  `-> Serial port not found
  help: Ensure that the device is connected and your host recognizes the serial adapter
```

And I found it strange that the serial port was being opened twice in a row, and by looking at the code I found the problem: `board_info` tries to open a new connection when a `connect` was already previously called.

Switching to `print_board_info` which reuses the same connection solved the problem