### PR TITLE
fix: esp32c3 direct boot

### DIFF
--- a/espflash/src/error.rs
+++ b/espflash/src/error.rs
@@ -401,6 +401,7 @@ pub struct UnsupportedImageFormatError {
     format: ImageFormatKind,
     chip: Chip,
     revision: Option<(u32, u32)>,
+    context: Option<String>,
 }
 
 impl UnsupportedImageFormatError {
@@ -409,6 +410,7 @@ impl UnsupportedImageFormatError {
             format,
             chip,
             revision,
+            context: None,
         }
     }
 
@@ -420,6 +422,12 @@ impl UnsupportedImageFormatError {
             .map(|format| format.into())
             .collect::<Vec<&'static str>>()
             .join(", ")
+    }
+
+    pub fn with_context(mut self, ctx: String) -> Self {
+        self.context.replace(ctx);
+
+        self
     }
 }
 
@@ -447,19 +455,15 @@ impl Diagnostic for UnsupportedImageFormatError {
     }
 
     fn help<'a>(&'a self) -> Option<Box<dyn Display + 'a>> {
-        let str = if self.chip == Chip::Esp32c3 && self.format == ImageFormatKind::DirectBoot {
-            format!(
-                "The {} only supports direct-boot starting with revision 3",
-                self.chip,
-            )
+        if let Some(ref ctx) = self.context {
+            Some(Box::new(ctx))
         } else {
-            format!(
+            Some(Box::new(format!(
                 "The following image formats are supported by the {}: {}",
                 self.chip,
                 self.supported_formats()
-            )
-        };
-        Some(Box::new(str))
+            )))
+        }
     }
 }
 

--- a/espflash/src/targets/esp32c3.rs
+++ b/espflash/src/targets/esp32c3.rs
@@ -97,7 +97,12 @@ impl Target for Esp32c3 {
                 Ok(Box::new(DirectBootFormat::new(image, 0)?))
             }
             _ => Err(
-                UnsupportedImageFormatError::new(image_format, Chip::Esp32c3, chip_revision).into(),
+                UnsupportedImageFormatError::new(image_format, Chip::Esp32c3, chip_revision)
+                    .with_context(format!(
+                        "The {} only supports direct-boot starting with revision 3 (v0.3)",
+                        Chip::Esp32c3,
+                    ))
+                    .into(),
             ),
         }
     }

--- a/espflash/src/targets/esp32c3.rs
+++ b/espflash/src/targets/esp32c3.rs
@@ -93,7 +93,7 @@ impl Target for Esp32c3 {
                 flash_size,
                 flash_freq,
             )?)),
-            (ImageFormatKind::DirectBoot, None | Some((3.., _))) => {
+            (ImageFormatKind::DirectBoot, None | Some((_, 3..))) => {
                 Ok(Box::new(DirectBootFormat::new(image, 0)?))
             }
             _ => Err(

--- a/espflash/src/targets/flash_target/esp32.rs
+++ b/espflash/src/targets/flash_target/esp32.rs
@@ -8,7 +8,7 @@ use flate2::{
 use super::FlashTarget;
 use crate::{
     command::{Command, CommandType},
-    connection::{Connection, USB_SERIAL_JTAG_PID},
+    connection::Connection,
     elf::RomSegment,
     error::Error,
     flasher::{ProgressCallbacks, SpiAttachParams, FLASH_SECTOR_SIZE},


### PR DESCRIPTION
Prior to this change, attempting to `espflash flash` with the `--format
direct-boot` argument targeting an esp32c3 would fail, reporting:

```
Error: espflash::unsupported_image_format

  × Image format direct-boot is not supported by the esp32c3 revision v0.3
  help: The esp32c3 only supports direct-boot starting with revision 3
```

However, direct-boot on this board was working prior to the changes in
https://github.com/esp-rs/espflash/commit/b25af06912e3c257261ac5ab9788217c0405d033, and looking at the [docs][esp32c3 revisions] it seems that the
mapping that was chosen for the `c3` specifically was `v0.REVISION`:

> ECO  | Revision (Major.Minor)
> ---------|-------------------
> ECO1 | v0.1
> ECO2 | v0.2
> ECO3 | v0.3
> ECO4 | v0.4

[esp32c3 revisions]: https://docs.espressif.com/projects/esp-idf/en/latest/esp32c3/api-reference/system/chip_revision.html#revisions

Additionally, this PR contains a small cleanup change (https://github.com/esp-rs/espflash/commit/f0ab4dde79d18439bb499709d3ad9b6cf6ae26f9) and a proposal for moving/updating the error message emitted above.