### PR TITLE
Add `ESPFLASH_PORT` environment variable

### DIFF
--- a/espflash/src/cli/mod.rs
+++ b/espflash/src/cli/mod.rs
@@ -44,7 +44,7 @@ pub struct ConnectArgs {
     #[arg(short = 'b', long, env = "ESPFLASH_BAUD")]
     pub baud: Option<u32>,
     /// Serial port connected to target device
-    #[arg(short = 'p', long)]
+    #[arg(short = 'p', long, env = "ESPFLASH_PORT")]
     pub port: Option<String>,
     /// DTR pin to use for the internal UART hardware. Uses BCM numbering.
     #[cfg(feature = "raspberry")]


### PR DESCRIPTION
Simple PR that extends #322.

The addition of this env variable is particularly useful when you have multiple ESPs connected, as you can have different run configurations for the different ESPs with this env variable set accordingly.