### PR TITLE
Add dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+version: 2
+updates:
+  - package-ecosystem: "cargo"
+    # Look for `Cargo.toml` and `Cargo.lock` in the root directory
+    directory: "/"
+    # Check for updates every Monday
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 20
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    # Check for updates every Monday
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 20


### PR DESCRIPTION
Adding dependabot can help us to update the dependencies, at least for CI actions. Should you have any other opinion, let me know, and I am more than happy to modify or close the PR.