### PR TITLE
If exactly one port matches, use it

### DIFF
--- a/espflash/src/cli/serial.rs
+++ b/espflash/src/cli/serial.rs
@@ -214,7 +214,7 @@ fn select_serial_port(
         let port_names = ports
             .iter()
             .map(|port_info| {
-                let formatted = if matches(&port_info) {
+                let formatted = if matches(port_info) {
                     port_info.port_name.as_str().bold()
                 } else {
                     port_info.port_name.as_str().reset()


### PR DESCRIPTION
Fixes #367.

Since I added the `matches` closure, it felt like some clean-up was appropriate. But if you'd prefer a more minimal PR I can do that too.

This also slightly changes the behavior of non-usb serial ports, for consistency. Previously, you could make them match by manually editing the config file and adding "vid=0, pid=0", but they wouldn't be sorted and highlighted as though they matched. After this change, non-usb serial ports won't auto-match at all.