### PR TITLE
Update `toml` dependency and fix errors, feature gate `ctrlc` dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -230,7 +230,7 @@ checksum = "fdde5c9cd29ebd706ce1b35600920a33550e402fc998a2e53ad3b42c3c47a192"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.8",
+ "syn 2.0.10",
 ]
 
 [[package]]
@@ -436,7 +436,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.8",
+ "syn 2.0.10",
 ]
 
 [[package]]
@@ -537,9 +537,9 @@ dependencies = [
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28d997bd5e24a5928dd43e46dc529867e207907fe0b239c3477d924f7f2ca320"
+checksum = "280a9f2d8b3a38871a3c8a46fb80db65e5e5ed97da80c4d08bf27fb63e35e181"
 dependencies = [
  "libc",
 ]
@@ -1222,9 +1222,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "1.9.2"
+version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1885e79c1fc4b10f0e172c475f458b7f7b93061064d98c3293e98c5ba0c8b399"
+checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
 dependencies = [
  "autocfg",
  "hashbrown",
@@ -1342,9 +1342,9 @@ checksum = "99227334921fae1a979cf0bfdfcc6b3e5ce376ef57e16fb6fb3ea2ed6095f80c"
 
 [[package]]
 name = "libgit2-sys"
-version = "0.14.2+1.5.1"
+version = "0.14.1+1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f3d95f6b51075fe9810a7ae22c7095f12b98005ab364d8544797a825ce946a4"
+checksum = "4a07fb2692bc3593bda59de45a502bb3071659f2c515e28c71e728306b038e17"
 dependencies = [
  "cc",
  "libc",
@@ -1748,9 +1748,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.53"
+version = "1.0.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba466839c78239c09faf015484e5cc04860f88242cff4d03eb038f04b4699b73"
+checksum = "e472a104799c74b514a57226160104aa483546de37e839ec50e3c2e41dd87534"
 dependencies = [
  "unicode-ident",
 ]
@@ -1807,9 +1807,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.7.2"
+version = "1.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cce168fea28d3e05f158bda4576cf0c844d5045bc2cc3620fa0292ed5bb5814c"
+checksum = "8b1f693b24f6ac912f4893ef08244d70b6067480d2f1a46e950c9691e6749d1d"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1994,7 +1994,7 @@ checksum = "e801c1712f48475582b7696ac71e0ca34ebb30e09338425384269d9717c62cad"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.8",
+ "syn 2.0.10",
 ]
 
 [[package]]
@@ -2008,9 +2008,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.94"
+version = "1.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c533a59c9d8a93a09c6ab31f0fd5e5f4dd1b8fc9434804029839884765d04ea"
+checksum = "d721eca97ac802aa7777b701877c8004d950fc142651367300d21c1cc0194744"
 dependencies = [
  "itoa",
  "ryu",
@@ -2022,6 +2022,15 @@ name = "serde_plain"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6018081315db179d0ce57b1fe4b62a12a0028c9cf9bbef868c9cf477b3c34ae"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "serde_spanned"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0efd8caf556a6cebd3b285caf480045fcc1ac04f6bd786b09a6f11af30c4fcf4"
 dependencies = [
  "serde",
 ]
@@ -2248,9 +2257,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.8"
+version = "2.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcc02725fd69ab9f26eab07fad303e2497fad6fb9eba4f96c4d1687bdf704ad9"
+checksum = "5aad1363ed6d37b84299588d62d3a7d95b5a5c2d9aad5c85609fda12afaa1f40"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2339,7 +2348,7 @@ checksum = "f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.8",
+ "syn 2.0.10",
 ]
 
 [[package]]
@@ -2369,11 +2378,14 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "toml"
-version = "0.5.11"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4f7f0dd8d50a853a531c426359045b1998f04219d88799810762cd4ad314234"
+checksum = "b403acf6f2bb0859c93c7f0d967cb4a75a7ac552100f9322faf64dc047669b21"
 dependencies = [
  "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit 0.19.8",
 ]
 
 [[package]]
@@ -2381,6 +2393,9 @@ name = "toml_datetime"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ab8ed2edee10b50132aed5f331333428b011c99402b5a534154ed15746f9622"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "toml_edit"
@@ -2402,6 +2417,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "239410c8609e8125456927e6707163a3b1fdb40561e4b803bc041f466ccfdc13"
 dependencies = [
  "indexmap",
+ "serde",
+ "serde_spanned",
  "toml_datetime",
  "winnow",
 ]
@@ -2788,6 +2805,6 @@ checksum = "2fe21bcc34ca7fe6dd56cc2cb1261ea59d6b93620215aefb5ea6032265527784"
 
 [[package]]
 name = "zeroize"
-version = "1.5.7"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c394b5bd0c6f669e7275d9c20aa90ae064cb22e75a1cad54e1b34088034b149f"
+checksum = "2a0956f1ba7c7909bfb66c2e9e4124ab6f6482560f6628b5aaeba39207c9aad9"

--- a/cargo-espflash/Cargo.toml
+++ b/cargo-espflash/Cargo.toml
@@ -31,4 +31,4 @@ log = "0.4.17"
 miette = { version = "5.5.0", features = ["fancy"] }
 serde = { version = "1.0.152", features = ["derive"] }
 thiserror = "1.0.38"
-toml = "0.5.10"
+toml = "0.7.3"

--- a/cargo-espflash/src/error.rs
+++ b/cargo-espflash/src/error.rs
@@ -4,7 +4,7 @@ use std::{
 };
 
 use espflash::targets::Chip;
-use miette::{Diagnostic, LabeledSpan, SourceCode, SourceOffset};
+use miette::{Diagnostic, LabeledSpan, SourceCode};
 use thiserror::Error;
 
 #[derive(Debug, Diagnostic, Error)]
@@ -92,13 +92,9 @@ impl Diagnostic for TomlError {
     }
 
     fn labels(&self) -> Option<Box<dyn Iterator<Item = LabeledSpan> + '_>> {
-        let (line, col) = self.err.line_col()?;
-        let offset = SourceOffset::from_location(&self.source, line + 1, col + 1);
-
-        Some(Box::new(once(LabeledSpan::new(
+        Some(Box::new(once(LabeledSpan::new_with_span(
             Some(self.err.to_string()),
-            offset.offset(),
-            0,
+            self.err.span()?,
         ))))
     }
 }

--- a/espflash/Cargo.toml
+++ b/espflash/Cargo.toml
@@ -31,7 +31,7 @@ bytemuck = { version = "1.12.3", features = ["derive"] }
 clap = { version = "4.0.32", features = ["derive", "env"], optional = true }
 comfy-table = { version = "6.1.4", optional = true }
 crossterm = { version = "0.26.1", optional = true }
-ctrlc = "3.2.5"
+ctrlc = { version = "3.2.5", optional = true }
 dialoguer = { version = "0.10.2", optional = true }
 directories-next = { version = "2.0.0", optional = true }
 env_logger = { version = "0.10.0", optional = true }
@@ -62,6 +62,7 @@ cli = [
     "dep:clap",
     "dep:comfy-table",
     "dep:crossterm",
+    "dep:ctrlc",
     "dep:dialoguer",
     "dep:directories-next",
     "dep:env_logger",

--- a/espflash/Cargo.toml
+++ b/espflash/Cargo.toml
@@ -51,7 +51,7 @@ sha2 = "0.10.6"
 slip-codec = "0.3.3"
 strum = { version = "0.24.1", features = ["derive"] }
 thiserror = "1.0.38"
-toml = "0.5.10"
+toml = "0.7.3"
 update-informer = { version = "0.6.0", optional = true }
 xmas-elf = "0.9.0"
 

--- a/espflash/src/cli/config.rs
+++ b/espflash/src/cli/config.rs
@@ -8,7 +8,7 @@
 //! [espflash]: https://crates.io/crates/espflash
 
 use std::{
-    fs::{create_dir_all, read, write},
+    fs::{create_dir_all, read_to_string, write},
     path::PathBuf,
 };
 
@@ -69,8 +69,8 @@ impl Config {
         let dirs = ProjectDirs::from("rs", "esp", "espflash").unwrap();
         let file = dirs.config_dir().join("espflash.toml");
 
-        let mut config = if let Ok(data) = read(&file) {
-            toml::from_slice(&data).into_diagnostic()?
+        let mut config = if let Ok(data) = read_to_string(&file) {
+            toml::from_str(&data).into_diagnostic()?
         } else {
             Self::default()
         };


### PR DESCRIPTION
- New version of `toml` with some breaking API changes, which were addressed
- I forgot to gate `ctrlc` behind the `cli` feature when I added it
    - #372