### PR TITLE
Remove serde-hex crate due to save / load conflict

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -34,7 +34,7 @@ dependencies = [
  "gimli",
  "object",
  "rustc-demangle",
- "smallvec 1.10.0",
+ "smallvec",
 ]
 
 [[package]]
@@ -68,15 +68,6 @@ name = "anyhow"
 version = "1.0.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7de8ce5e0f9f8d88245311066a578d72b7af3e7088f32783804676302df237e4"
-
-[[package]]
-name = "array-init"
-version = "0.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23589ecb866b460d3a0f1278834750268c607e8e28a1b982c907219f3178cd72"
-dependencies = [
- "nodrop",
-]
 
 [[package]]
 name = "arrayvec"
@@ -921,7 +912,6 @@ dependencies = [
  "regex",
  "rppal",
  "serde",
- "serde-hex",
  "serialport",
  "sha2",
  "slip-codec",
@@ -1454,12 +1444,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "maybe-uninit"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60302e4db3a61da70c0cb7991976248362f30319e88850c487b9b95bbf059e00"
-
-[[package]]
 name = "md5"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1554,12 +1538,6 @@ dependencies = [
  "libc",
  "static_assertions",
 ]
-
-[[package]]
-name = "nodrop"
-version = "0.1.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72ef4a56884ca558e5ddb05a1d1e7e1bfd9a68d9ed024c21704cc98872dae1bb"
 
 [[package]]
 name = "num-traits"
@@ -1699,7 +1677,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "redox_syscall",
- "smallvec 1.10.0",
+ "smallvec",
  "windows-sys 0.45.0",
 ]
 
@@ -1976,17 +1954,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde-hex"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca37e3e4d1b39afd7ff11ee4e947efae85adfddf4841787bfa47c470e96dc26d"
-dependencies = [
- "array-init",
- "serde",
- "smallvec 0.6.14",
-]
-
-[[package]]
 name = "serde_derive"
 version = "1.0.158"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2120,15 +2087,6 @@ name = "slip-codec"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "399892aa22101014dcebb84944dc950f6d02695e91ea5f7e11baf02998fc59e2"
-
-[[package]]
-name = "smallvec"
-version = "0.6.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b97fcaeba89edba30f044a10c6a3cc39df9c3f17d7cd829dd1446cab35f890e0"
-dependencies = [
- "maybe-uninit",
-]
 
 [[package]]
 name = "smallvec"

--- a/espflash/Cargo.toml
+++ b/espflash/Cargo.toml
@@ -45,7 +45,6 @@ parse_int = { version = "0.6.0", optional = true }
 regex = { version = "1.7.1", optional = true }
 rppal = { version = "0.14.1", optional = true }
 serde = { version = "1.0.152", features = ["derive"] }
-serde-hex = { version = "0.1.0", optional = true }
 serialport = "4.2.0"
 sha2 = "0.10.6"
 slip-codec = "0.3.3"
@@ -70,7 +69,6 @@ cli = [
     "dep:lazy_static",
     "dep:parse_int",
     "dep:regex",
-    "dep:serde-hex",
     "dep:update-informer",
 ]
 raspberry = ["dep:rppal"]

--- a/espflash/src/cli/config.rs
+++ b/espflash/src/cli/config.rs
@@ -15,7 +15,6 @@ use std::{
 use directories_next::ProjectDirs;
 use miette::{IntoDiagnostic, Result, WrapErr};
 use serde::{Deserialize, Serialize};
-use serde_hex::{Compact, SerHex};
 use serialport::UsbPortInfo;
 
 /// A configured, known serial connection
@@ -35,10 +34,8 @@ pub struct Connection {
 #[derive(Debug, Deserialize, Serialize, Default, Clone)]
 pub struct UsbDevice {
     /// USB Vendor ID
-    #[serde(with = "SerHex::<Compact>")]
     pub vid: u16,
     /// USB Product ID
-    #[serde(with = "SerHex::<Compact>")]
     pub pid: u16,
 }
 


### PR DESCRIPTION
When using serde-hex, the vid and pid are saved as:

```
[connection]

[[usb_device]]
vid = "303a"
pid = "1001"
```

in the `~/.config/espflash/espflash.toml` file.

However, upon loading, we see an error message:

```
Error:
  × TOML parse error at line 4, column 7
  │   |
  │ 4 | vid = "303a"
  │   |       ^^^^^^
  │ invalid type: string "303a", expected a borrowed byte array
  │
```

The serde-hex source code hasn't been updated in 4 years, and is not apparently compatible with the toml crate.

Storing the vid and pid as decimal integers is not ideal, but it at least works correctly.