### PR TITLE
Fix config file parsing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -34,7 +34,7 @@ dependencies = [
  "gimli",
  "object",
  "rustc-demangle",
- "smallvec 1.10.0",
+ "smallvec",
 ]
 
 [[package]]
@@ -68,15 +68,6 @@ name = "anyhow"
 version = "1.0.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7de8ce5e0f9f8d88245311066a578d72b7af3e7088f32783804676302df237e4"
-
-[[package]]
-name = "array-init"
-version = "0.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23589ecb866b460d3a0f1278834750268c607e8e28a1b982c907219f3178cd72"
-dependencies = [
- "nodrop",
-]
 
 [[package]]
 name = "arrayvec"
@@ -921,7 +912,6 @@ dependencies = [
  "regex",
  "rppal",
  "serde",
- "serde-hex",
  "serialport",
  "sha2",
  "slip-codec",
@@ -1454,12 +1444,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "maybe-uninit"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60302e4db3a61da70c0cb7991976248362f30319e88850c487b9b95bbf059e00"
-
-[[package]]
 name = "md5"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1554,12 +1538,6 @@ dependencies = [
  "libc",
  "static_assertions",
 ]
-
-[[package]]
-name = "nodrop"
-version = "0.1.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72ef4a56884ca558e5ddb05a1d1e7e1bfd9a68d9ed024c21704cc98872dae1bb"
 
 [[package]]
 name = "num-traits"
@@ -1699,7 +1677,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "redox_syscall",
- "smallvec 1.10.0",
+ "smallvec",
  "windows-sys 0.45.0",
 ]
 
@@ -1976,17 +1954,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde-hex"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca37e3e4d1b39afd7ff11ee4e947efae85adfddf4841787bfa47c470e96dc26d"
-dependencies = [
- "array-init",
- "serde",
- "smallvec 0.6.14",
-]
-
-[[package]]
 name = "serde_derive"
 version = "1.0.158"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2120,15 +2087,6 @@ name = "slip-codec"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "399892aa22101014dcebb84944dc950f6d02695e91ea5f7e11baf02998fc59e2"
-
-[[package]]
-name = "smallvec"
-version = "0.6.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b97fcaeba89edba30f044a10c6a3cc39df9c3f17d7cd829dd1446cab35f890e0"
-dependencies = [
- "maybe-uninit",
-]
 
 [[package]]
 name = "smallvec"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -904,6 +904,7 @@ dependencies = [
  "env_logger 0.10.0",
  "esp-idf-part",
  "flate2",
+ "hex 0.4.3",
  "indicatif",
  "lazy_static",
  "log",
@@ -1147,6 +1148,9 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "home"

--- a/espflash/Cargo.toml
+++ b/espflash/Cargo.toml
@@ -37,7 +37,7 @@ directories-next = { version = "2.0.0", optional = true }
 env_logger = { version = "0.10.0", optional = true }
 esp-idf-part = "0.2.0"
 flate2 = "1.0.25"
-hex = { version = "0.4.3", features = ["serde"] }
+hex = { version = "0.4.3", features = ["serde"], optional = true }
 indicatif = { version = "0.17.2", optional = true }
 lazy_static = { version = "1.4.0", optional = true }
 log = "0.4.17"

--- a/espflash/Cargo.toml
+++ b/espflash/Cargo.toml
@@ -37,6 +37,7 @@ directories-next = { version = "2.0.0", optional = true }
 env_logger = { version = "0.10.0", optional = true }
 esp-idf-part = "0.2.0"
 flate2 = "1.0.25"
+hex = { version = "0.4.3", features = ["serde"] }
 indicatif = { version = "0.17.2", optional = true }
 lazy_static = { version = "1.4.0", optional = true }
 log = "0.4.17"
@@ -45,7 +46,6 @@ parse_int = { version = "0.6.0", optional = true }
 regex = { version = "1.7.1", optional = true }
 rppal = { version = "0.14.1", optional = true }
 serde = { version = "1.0.152", features = ["derive"] }
-serde-hex = { version = "0.1.0", optional = true }
 serialport = "4.2.0"
 sha2 = "0.10.6"
 slip-codec = "0.3.3"
@@ -66,11 +66,11 @@ cli = [
     "dep:dialoguer",
     "dep:directories-next",
     "dep:env_logger",
+    "dep:hex",
     "dep:indicatif",
     "dep:lazy_static",
     "dep:parse_int",
     "dep:regex",
-    "dep:serde-hex",
     "dep:update-informer",
 ]
 raspberry = ["dep:rppal"]

--- a/espflash/src/cli/config.rs
+++ b/espflash/src/cli/config.rs
@@ -46,7 +46,6 @@ where
     D: serde::Deserializer<'de>,
 {
     let s = String::deserialize(deserializer)?;
-    // Check if the string is less than 4 digits, if so, pad it with 0s
     let bytes = hex::decode(if s.len() % 2 == 1 {
         format!("0{}", s)
     } else {

--- a/espflash/src/cli/config.rs
+++ b/espflash/src/cli/config.rs
@@ -164,28 +164,23 @@ mod tests {
     #[test]
     fn test_parse_u16_hex() {
         // Valid hexadecimal input with 1 digit
-        let input = "1";
-        let result: Result<TestData, _> = toml::from_str(&format!("value = \"{}\"", input));
+        let result: Result<TestData, _> = toml::from_str(r#"value = "1""#);
         assert_eq!(result.unwrap().value, 0x1);
 
         // Valid hexadecimal input with 2 digits
-        let input = "ff";
-        let result: Result<TestData, _> = toml::from_str(&format!("value = \"{}\"", input));
+        let result: Result<TestData, _> = toml::from_str(r#"value = "ff""#);
         assert_eq!(result.unwrap().value, 0xff);
 
         // Valid hexadecimal input with 3 digits
-        let input = "b1a";
-        let result: Result<TestData, _> = toml::from_str(&format!("value = \"{}\"", input));
+        let result: Result<TestData, _> = toml::from_str(r#"value = "b1a""#);
         assert_eq!(result.unwrap().value, 0xb1a);
 
         // Valid hexadecimal input with 4 digits
-        let input = "abc1";
-        let result: Result<TestData, _> = toml::from_str(&format!("value = \"{}\"", input));
+        let result: Result<TestData, _> = toml::from_str(r#"value = "abc1""#);
         assert_eq!(result.unwrap().value, 0xabc1);
 
         // Invalid input (non-hexadecimal character)
-        let input = "xyz";
-        let result: Result<TestData, _> = toml::from_str(&format!("value = \"{}\"", input));
+        let result: Result<TestData, _> = toml::from_str(r#"value = "xyz""#);
         assert!(result.is_err());
     }
 }

--- a/espflash/src/cli/config.rs
+++ b/espflash/src/cli/config.rs
@@ -126,9 +126,9 @@ mod tests {
     use super::*;
     use serde::Deserialize;
 
-    #[derive(Debug, Deserialize)]
+    #[derive(Debug, Deserialize, Serialize)]
     struct TestData {
-        #[serde(deserialize_with = "parse_hex_u16")]
+        #[serde(serialize_with = "parse_u16_hex", deserialize_with = "parse_hex_u16")]
         value: u16,
     }
 
@@ -166,6 +166,34 @@ mod tests {
         assert!(result.is_err());
 
         let input = "10gg";
+        let result: Result<TestData, _> = toml::from_str(&format!("value = \"{}\"", input));
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_parse_u16_hex() {
+        // Valid hexadecimal input with 1 digit
+        let input = "1";
+        let result: Result<TestData, _> = toml::from_str(&format!("value = \"{}\"", input));
+        assert_eq!(result.unwrap().value, 0x1);
+
+        // Valid hexadecimal input with 2 digits
+        let input = "ff";
+        let result: Result<TestData, _> = toml::from_str(&format!("value = \"{}\"", input));
+        assert_eq!(result.unwrap().value, 0xff);
+
+        // Valid hexadecimal input with 3 digits
+        let input = "b1a";
+        let result: Result<TestData, _> = toml::from_str(&format!("value = \"{}\"", input));
+        assert_eq!(result.unwrap().value, 0xb1a);
+
+        // Valid hexadecimal input with 4 digits
+        let input = "abc1";
+        let result: Result<TestData, _> = toml::from_str(&format!("value = \"{}\"", input));
+        assert_eq!(result.unwrap().value, 0xabc1);
+
+        // Invalid input (non-hexadecimal character)
+        let input = "xyz";
         let result: Result<TestData, _> = toml::from_str(&format!("value = \"{}\"", input));
         assert!(result.is_err());
     }

--- a/espflash/src/cli/config.rs
+++ b/espflash/src/cli/config.rs
@@ -133,38 +133,31 @@ mod tests {
     #[test]
     fn test_parse_hex_u16() {
         // Test no padding
-        let input = "aaaa";
-        let result: Result<TestData, _> = toml::from_str(&format!("value = \"{}\"", input));
+        let result: Result<TestData, _> = toml::from_str(r#"value = "aaaa""#);
         assert_eq!(result.unwrap().value, 0xaaaa);
-        let input = "1234";
-        let result: Result<TestData, _> = toml::from_str(&format!("value = \"{}\"", input));
+
+        let result: Result<TestData, _> = toml::from_str(r#"value = "1234""#);
         assert_eq!(result.unwrap().value, 0x1234);
 
         // Test padding
-        let input = "a";
-        let result: Result<TestData, _> = toml::from_str(&format!("value = \"{}\"", input));
+        let result: Result<TestData, _> = toml::from_str(r#"value = "a""#);
         assert_eq!(result.unwrap().value, 0x0a);
 
-        let input = "10";
-        let result: Result<TestData, _> = toml::from_str(&format!("value = \"{}\"", input));
+        let result: Result<TestData, _> = toml::from_str(r#"value = "10""#);
         assert_eq!(result.unwrap().value, 0x10);
 
-        let input = "100";
-        let result: Result<TestData, _> = toml::from_str(&format!("value = \"{}\"", input));
+        let result: Result<TestData, _> = toml::from_str(r#"value = "100""#);
         assert_eq!(result.unwrap().value, 0x0100);
 
         // Test uppercase
-        let input = "A1B2";
-        let result: Result<TestData, _> = toml::from_str(&format!("value = \"{}\"", input));
+        let result: Result<TestData, _> = toml::from_str(r#"value = "A1B2""#);
         assert_eq!(result.unwrap().value, 0xA1B2);
 
         // Test invalid
-        let input = "gg";
-        let result: Result<TestData, _> = toml::from_str(&format!("value = \"{}\"", input));
+        let result: Result<TestData, _> = toml::from_str(r#"value = "gg""#);
         assert!(result.is_err());
 
-        let input = "10gg";
-        let result: Result<TestData, _> = toml::from_str(&format!("value = \"{}\"", input));
+        let result: Result<TestData, _> = toml::from_str(r#"value = "10gg""#);
         assert!(result.is_err());
     }
 

--- a/espflash/src/cli/config.rs
+++ b/espflash/src/cli/config.rs
@@ -34,10 +34,10 @@ pub struct Connection {
 #[derive(Debug, Deserialize, Serialize, Default, Clone)]
 pub struct UsbDevice {
     /// USB Vendor ID
-    #[serde(deserialize_with = "parse_hex_u16")]
+    #[serde(serialize_with = "parse_u16_hex", deserialize_with = "parse_hex_u16")]
     pub vid: u16,
     /// USB Product ID
-    #[serde(deserialize_with = "parse_hex_u16")]
+    #[serde(serialize_with = "parse_u16_hex", deserialize_with = "parse_hex_u16")]
     pub pid: u16,
 }
 
@@ -58,6 +58,14 @@ where
     let vec = [&padding[..], &bytes[..]].concat();
     let decimal = u16::from_be_bytes(vec.try_into().unwrap());
     Ok(decimal)
+}
+
+fn parse_u16_hex<S>(decimal: &u16, serializer: S) -> Result<S::Ok, S::Error>
+where
+    S: serde::Serializer,
+{
+    let hex_string = format!("{:04x}", decimal);
+    serializer.serialize_str(&hex_string)
 }
 
 impl UsbDevice {

--- a/espflash/src/cli/config.rs
+++ b/espflash/src/cli/config.rs
@@ -53,7 +53,6 @@ where
     })
     .map_err(serde::de::Error::custom)?;
     let padding = vec![0; 2_usize.saturating_sub(bytes.len())];
-    // Apend the padding before the bytes
     let vec = [&padding[..], &bytes[..]].concat();
     let decimal = u16::from_be_bytes(vec.try_into().unwrap());
     Ok(decimal)

--- a/espflash/src/cli/config.rs
+++ b/espflash/src/cli/config.rs
@@ -53,7 +53,7 @@ where
         s
     })
     .map_err(serde::de::Error::custom)?;
-    let padding = vec![0; 2 - bytes.len()];
+    let padding = vec![0; 2_usize.saturating_sub(bytes.len())];
     // Apend the padding before the bytes
     let vec = [&padding[..], &bytes[..]].concat();
     let decimal = u16::from_be_bytes(vec.try_into().unwrap());

--- a/espflash/src/cli/config.rs
+++ b/espflash/src/cli/config.rs
@@ -50,7 +50,7 @@ where
     let bytes = hex::decode(if s.len() % 2 == 1 {
         format!("0{}", s)
     } else {
-        s.to_owned()
+        s
     })
     .map_err(serde::de::Error::custom)?;
     let padding = vec![0; 2 - bytes.len()];


### PR DESCRIPTION
- Remove `serde-hex` since it's no longer compatible with the new `toml` version
- Include the `hex` crate
- Add functions for serializing and deserializing
- Add test for serialization and deserialization methods

Not sure if this is the best way, but the file needed to be backward compatible.