### PR TITLE
Add unix tight reset

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -907,6 +907,7 @@ dependencies = [
  "hex 0.4.3",
  "indicatif",
  "lazy_static",
+ "libc",
  "log",
  "miette",
  "parse_int",

--- a/espflash/Cargo.toml
+++ b/espflash/Cargo.toml
@@ -54,6 +54,7 @@ thiserror = "1.0.38"
 toml = "0.7.3"
 update-informer = { version = "0.6.0", optional = true }
 xmas-elf = "0.9.0"
+libc = "0.2"
 
 [features]
 default = ["cli"]

--- a/espflash/src/connection.rs
+++ b/espflash/src/connection.rs
@@ -125,6 +125,7 @@ impl Connection {
         Ok(reset_after_flash(&mut self.serial, pid)?)
     }
 
+    #[cfg(unix)]
     fn classic_reset(&mut self, extra_delay: bool) -> Result<(), Error> {
         info!(
             "Attempting Classic reset with {} delay...",

--- a/espflash/src/connection.rs
+++ b/espflash/src/connection.rs
@@ -125,7 +125,6 @@ impl Connection {
         Ok(reset_after_flash(&mut self.serial, pid)?)
     }
 
-    #[cfg(unix)]
     fn classic_reset(&mut self, extra_delay: bool) -> Result<(), Error> {
         info!(
             "Attempting Classic reset with {} delay...",
@@ -153,6 +152,7 @@ impl Connection {
         self.wait_for_connection()
     }
 
+    #[cfg(unix)]
     fn unix_tight_reset(&mut self, extra_delay: bool) -> Result<(), Error> {
         info!(
             "Attempting UnixTight reset with {} delay...",
@@ -177,24 +177,29 @@ impl Connection {
 
     fn usb_jtag_reset(&mut self) -> Result<(), Error> {
         info!("Attempting USB-JTAG reset...");
-        self.serial.write_data_terminal_ready(false)?;
-        self.serial.write_request_to_send(false)?;
+        self.serial.write_dtr_rts(false, false)?;
+        // self.serial.write_data_terminal_ready(false)?;
+        // self.serial.write_request_to_send(false)?;
 
         sleep(Duration::from_millis(100));
 
-        self.serial.write_data_terminal_ready(true)?;
-        self.serial.write_request_to_send(false)?;
+        self.serial.write_dtr_rts(true, false)?;
+        // self.serial.write_data_terminal_ready(true)?;
+        // self.serial.write_request_to_send(false)?;
 
         sleep(Duration::from_millis(100));
 
-        self.serial.write_request_to_send(true)?;
-        self.serial.write_data_terminal_ready(false)?;
-        self.serial.write_request_to_send(true)?;
+        self.serial.write_dtr_rts(false, true)?;
+        // self.serial.write_request_to_send(true)?;
+        // self.serial.write_data_terminal_ready(false)?;
+        // self.serial.write_request_to_send(true)?;
+        self.serial.write_dtr_rts(false, true)?;
 
         sleep(Duration::from_millis(100));
 
-        self.serial.write_data_terminal_ready(false)?;
-        self.serial.write_request_to_send(false)?;
+        // self.serial.write_data_terminal_ready(false)?;
+        // self.serial.write_request_to_send(false)?;
+        self.serial.write_dtr_rts(false, false)?;
         self.wait_for_connection()
     }
 

--- a/espflash/src/connection.rs
+++ b/espflash/src/connection.rs
@@ -69,7 +69,7 @@ impl Connection {
         } else {
             #[cfg(unix)]
             if self.unix_tight_reset(extra_delay).is_ok() {
-                return Ok(())
+                return Ok(());
             }
 
             self.classic_reset(extra_delay)

--- a/espflash/src/connection.rs
+++ b/espflash/src/connection.rs
@@ -161,7 +161,7 @@ impl Connection {
 
         self.serial.write_dtr_rts(false, false)?;
         self.serial.write_dtr_rts(true, true)?;
-        self.serial.write_dtr_rts(false, true)?; // IO = HIGH, EN = LOW, chip in reset
+        self.serial.write_dtr_rts(false, true)?; // IO0 = HIGH, EN = LOW, chip in reset
 
         sleep(Duration::from_millis(100));
 

--- a/espflash/src/connection.rs
+++ b/espflash/src/connection.rs
@@ -177,29 +177,24 @@ impl Connection {
 
     fn usb_jtag_reset(&mut self) -> Result<(), Error> {
         info!("Attempting USB-JTAG reset...");
-        self.serial.write_dtr_rts(false, false)?;
-        // self.serial.write_data_terminal_ready(false)?;
-        // self.serial.write_request_to_send(false)?;
+        self.serial.write_data_terminal_ready(false)?;
+        self.serial.write_request_to_send(false)?;
 
         sleep(Duration::from_millis(100));
 
-        self.serial.write_dtr_rts(true, false)?;
-        // self.serial.write_data_terminal_ready(true)?;
-        // self.serial.write_request_to_send(false)?;
+        self.serial.write_data_terminal_ready(true)?;
+        self.serial.write_request_to_send(false)?;
 
         sleep(Duration::from_millis(100));
 
-        self.serial.write_dtr_rts(false, true)?;
-        // self.serial.write_request_to_send(true)?;
-        // self.serial.write_data_terminal_ready(false)?;
-        // self.serial.write_request_to_send(true)?;
-        self.serial.write_dtr_rts(false, true)?;
+        self.serial.write_request_to_send(true)?;
+        self.serial.write_data_terminal_ready(false)?;
+        self.serial.write_request_to_send(true)?;
 
         sleep(Duration::from_millis(100));
 
-        // self.serial.write_data_terminal_ready(false)?;
-        // self.serial.write_request_to_send(false)?;
-        self.serial.write_dtr_rts(false, false)?;
+        self.serial.write_data_terminal_ready(false)?;
+        self.serial.write_request_to_send(false)?;
         self.wait_for_connection()
     }
 

--- a/espflash/src/interface.rs
+++ b/espflash/src/interface.rs
@@ -7,7 +7,7 @@
 use std::io::Read;
 
 #[cfg(unix)]
-use { std::os::unix::io::AsRawFd, std::io, libc };
+use {libc, std::io, std::os::unix::io::AsRawFd};
 
 use miette::{Context, Result};
 #[cfg(feature = "raspberry")]
@@ -127,7 +127,7 @@ impl Interface {
             let mut status: i32 = 0;
             let res = libc::ioctl(fd, libc::TIOCMGET, &status);
             if res != 0 {
-                return Err(io::Error::last_os_error().into())
+                return Err(io::Error::last_os_error().into());
             }
 
             if dtr {
@@ -144,7 +144,7 @@ impl Interface {
 
             let res = libc::ioctl(fd, libc::TIOCMSET, &status);
             if res != 0 {
-                return Err(io::Error::last_os_error().into())
+                return Err(io::Error::last_os_error().into());
             }
         }
         Ok(())


### PR DESCRIPTION
This adds the 'UnixTight' reset to flash method that Espressif added to EspTool to fix https://github.com/espressif/esptool/issues/712. It takes some things from https://github.com/esp-rs/espflash/pull/344 but I tried to minimize the code impact a bit more. If more ways of resetting show up in the future the approach of actually creating an explicit ResetStrategy trait might still turn out to be better.

The flow is slightly different from what EspTool does, as this first tries UnixTight and Classic resets with the normal delay and then retries both with the longer delay. I think that should be fine as the same things are tried, just in a different order. 

I've tested this on Linux and Windows, but not on macOS. It would be nice if someone could test that.