### PR TITLE
Generate Shell completions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -327,7 +327,6 @@ dependencies = [
  "cargo",
  "cargo_metadata",
  "clap 4.1.13",
- "clap_complete",
  "env_logger 0.10.0",
  "esp-idf-part",
  "espflash",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -327,6 +327,7 @@ dependencies = [
  "cargo",
  "cargo_metadata",
  "clap 4.1.13",
+ "clap_complete",
  "env_logger 0.10.0",
  "esp-idf-part",
  "espflash",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -428,6 +428,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap_complete"
+version = "4.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01c22dcfb410883764b29953103d9ef7bb8fe21b3fa1158bc99986c2067294bd"
+dependencies = [
+ "clap 4.1.13",
+]
+
+[[package]]
 name = "clap_derive"
 version = "4.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -905,6 +914,7 @@ dependencies = [
  "binread",
  "bytemuck",
  "clap 4.1.13",
+ "clap_complete",
  "comfy-table",
  "crossterm 0.26.1",
  "ctrlc",

--- a/cargo-espflash/Cargo.toml
+++ b/cargo-espflash/Cargo.toml
@@ -22,6 +22,7 @@ pkg-fmt = "zip"
 
 [dependencies]
 cargo = { version = "0.66.0", features = ["vendored-openssl"] }
+clap_complete = { version = "4.1.5" }
 cargo_metadata = "0.15.2"
 clap = { version = "4.0.32", features = ["derive"] }
 env_logger = "0.10.0"

--- a/cargo-espflash/Cargo.toml
+++ b/cargo-espflash/Cargo.toml
@@ -22,7 +22,6 @@ pkg-fmt = "zip"
 
 [dependencies]
 cargo = { version = "0.66.0", features = ["vendored-openssl"] }
-clap_complete = { version = "4.1.5" }
 cargo_metadata = "0.15.2"
 clap = { version = "4.0.32", features = ["derive"] }
 env_logger = "0.10.0"

--- a/cargo-espflash/README.md
+++ b/cargo-espflash/README.md
@@ -54,6 +54,7 @@ Usage: cargo espflash <COMMAND>
 
 Commands:
   board-info       Display information about the connected board and exit without flashing
+  completions      Generate completions for the given shell. Resulting completions have to be appended to cargo's completions
   flash            Flash an application to a target device
   monitor          Open the serial monitor without flashing
   partition-table  Operations for partitions tables

--- a/cargo-espflash/src/main.rs
+++ b/cargo-espflash/src/main.rs
@@ -33,7 +33,7 @@ mod error;
 mod package_metadata;
 
 #[derive(Debug, Parser)]
-#[clap(version, bin_name = "cargo", propagate_version = true)]
+#[clap(version, propagate_version = true)]
 struct Cli {
     #[clap(subcommand)]
     subcommand: CargoSubcommand,
@@ -95,6 +95,7 @@ struct BuildArgs {
     pub flash_config_args: FlashConfigArgs,
 }
 
+/// Generate completions for the given shell
 #[derive(Debug, Args)]
 pub struct CompletionsArgs {
     /// Shell to generate completions for.

--- a/cargo-espflash/src/main.rs
+++ b/cargo-espflash/src/main.rs
@@ -6,13 +6,12 @@ use std::{
 
 use cargo_metadata::Message;
 use clap::{Args, CommandFactory, Parser, Subcommand};
-use clap_complete::Shell;
 use espflash::{
     cli::{
-        self, board_info, config::Config, connect, erase_partitions, flash_elf_image,
+        self, board_info, completions, config::Config, connect, erase_partitions, flash_elf_image,
         monitor::monitor, parse_partition_table, partition_table, print_board_info,
-        save_elf_as_image, serial_monitor, ConnectArgs, EspflashProgress, FlashConfigArgs,
-        MonitorArgs, PartitionTableArgs,
+        save_elf_as_image, serial_monitor, CompletionsArgs, ConnectArgs, EspflashProgress,
+        FlashConfigArgs, MonitorArgs, PartitionTableArgs,
     },
     image_format::ImageFormatKind,
     logging::initialize_logger,
@@ -95,14 +94,6 @@ struct BuildArgs {
     pub flash_config_args: FlashConfigArgs,
 }
 
-/// Generate completions for the given shell.
-/// Resulting completions have to be appended to cargo's completions.
-#[derive(Debug, Args)]
-pub struct CompletionsArgs {
-    /// Shell to generate completions for.
-    pub shell: Shell,
-}
-
 /// Build and flash an application to a target device
 #[derive(Debug, Args)]
 struct FlashArgs {
@@ -147,7 +138,7 @@ fn main() -> Result<()> {
     // associated arguments.
     match args {
         Commands::BoardInfo(args) => board_info(&args, &config),
-        Commands::Completions(args) => completions(&args, &mut Cli::command()),
+        Commands::Completions(args) => completions(&args, &mut Cli::command(), "cargo"),
         Commands::Flash(args) => flash(args, &config),
         Commands::Monitor(args) => serial_monitor(args, &config),
         Commands::PartitionTable(args) => partition_table(args),
@@ -412,13 +403,6 @@ fn build(
     };
 
     Ok(build_ctx)
-}
-
-/// Generate shell completions for the given shell
-fn completions(args: &CompletionsArgs, app: &mut clap::Command) -> Result<()> {
-    clap_complete::generate(args.shell, app, "cargo", &mut std::io::stdout());
-
-    Ok(())
 }
 
 fn save_image(args: SaveImageArgs) -> Result<()> {

--- a/cargo-espflash/src/main.rs
+++ b/cargo-espflash/src/main.rs
@@ -95,7 +95,8 @@ struct BuildArgs {
     pub flash_config_args: FlashConfigArgs,
 }
 
-/// Generate completions for the given shell
+/// Generate completions for the given shell.
+/// Resulting completions have to be appended to cargo's completions.
 #[derive(Debug, Args)]
 pub struct CompletionsArgs {
     /// Shell to generate completions for.

--- a/cargo-espflash/src/main.rs
+++ b/cargo-espflash/src/main.rs
@@ -5,7 +5,8 @@ use std::{
 };
 
 use cargo_metadata::Message;
-use clap::{Args, Parser, Subcommand};
+use clap::{Args, CommandFactory, Parser, Subcommand};
+use clap_complete::Shell;
 use espflash::{
     cli::{
         self, board_info, config::Config, connect, erase_partitions, flash_elf_image,
@@ -50,6 +51,7 @@ enum CargoSubcommand {
 #[derive(Debug, Subcommand)]
 enum Commands {
     BoardInfo(ConnectArgs),
+    Completions(CompletionsArgs),
     Flash(FlashArgs),
     Monitor(MonitorArgs),
     PartitionTable(PartitionTableArgs),
@@ -91,6 +93,12 @@ struct BuildArgs {
 
     #[clap(flatten)]
     pub flash_config_args: FlashConfigArgs,
+}
+
+#[derive(Debug, Args)]
+pub struct CompletionsArgs {
+    /// Shell to generate completions for.
+    pub shell: Shell,
 }
 
 /// Build and flash an application to a target device
@@ -137,6 +145,7 @@ fn main() -> Result<()> {
     // associated arguments.
     match args {
         Commands::BoardInfo(args) => board_info(&args, &config),
+        Commands::Completions(args) => completions(&args, &mut Cli::command()),
         Commands::Flash(args) => flash(args, &config),
         Commands::Monitor(args) => serial_monitor(args, &config),
         Commands::PartitionTable(args) => partition_table(args),
@@ -401,6 +410,13 @@ fn build(
     };
 
     Ok(build_ctx)
+}
+
+/// Generate shell completions for the given shell
+fn completions(args: &CompletionsArgs, app: &mut clap::Command) -> Result<()> {
+    clap_complete::generate(args.shell, app, "cargo", &mut std::io::stdout());
+
+    Ok(())
 }
 
 fn save_image(args: SaveImageArgs) -> Result<()> {

--- a/espflash/Cargo.toml
+++ b/espflash/Cargo.toml
@@ -29,6 +29,7 @@ base64 = "0.21.0"
 binread = "2.2.0"
 bytemuck = { version = "1.12.3", features = ["derive"] }
 clap = { version = "4.0.32", features = ["derive", "env"], optional = true }
+clap_complete = { version = "4.1.5", optional = true }
 comfy-table = { version = "6.1.4", optional = true }
 crossterm = { version = "0.26.1", optional = true }
 ctrlc = "3.2.5"
@@ -60,6 +61,7 @@ default = ["cli"]
 cli = [
     "dep:addr2line",
     "dep:clap",
+    "dep:clap_complete",
     "dep:comfy-table",
     "dep:crossterm",
     "dep:dialoguer",

--- a/espflash/Cargo.toml
+++ b/espflash/Cargo.toml
@@ -28,7 +28,11 @@ addr2line = { version = "0.19.0", optional = true }
 base64 = "0.21.0"
 binread = "2.2.0"
 bytemuck = { version = "1.12.3", features = ["derive"] }
-clap = { version = "4.0.32", features = ["derive", "env"], optional = true }
+clap = { version = "4.0.32", features = [
+    "derive",
+    "env",
+    "cargo",
+], optional = true }
 clap_complete = { version = "4.1.5", optional = true }
 comfy-table = { version = "6.1.4", optional = true }
 crossterm = { version = "0.26.1", optional = true }

--- a/espflash/Cargo.toml
+++ b/espflash/Cargo.toml
@@ -28,11 +28,7 @@ addr2line = { version = "0.19.0", optional = true }
 base64 = "0.21.0"
 binread = "2.2.0"
 bytemuck = { version = "1.12.3", features = ["derive"] }
-clap = { version = "4.0.32", features = [
-    "derive",
-    "env",
-    "cargo",
-], optional = true }
+clap = { version = "4.0.32", features = ["derive", "env"], optional = true }
 clap_complete = { version = "4.1.5", optional = true }
 comfy-table = { version = "6.1.4", optional = true }
 crossterm = { version = "0.26.1", optional = true }

--- a/espflash/README.md
+++ b/espflash/README.md
@@ -54,7 +54,8 @@ A command-line tool for flashing Espressif devices over serial
 Usage: espflash <COMMAND>
 
 Commands:
-  board-info       Display information about the connected board and exit without flashing
+  board-info       Establish a connection with a target device
+  completions      Generate completions for the given shell
   flash            Flash an application to a target device
   monitor          Open the serial monitor without flashing
   partition-table  Operations for partitions tables
@@ -63,8 +64,8 @@ Commands:
   help             Print this message or the help of the given subcommand(s)
 
 Options:
-  -h, --help     Print help information
-  -V, --version  Print version information
+  -h, --help     Print help
+  -V, --version  Print version
 ```
 
 ### Cargo Runner

--- a/espflash/src/bin/espflash.rs
+++ b/espflash/src/bin/espflash.rs
@@ -5,13 +5,13 @@ use std::{
     path::PathBuf,
 };
 
-use clap::{Args, Parser, Subcommand};
+use clap::{Args, CommandFactory, Parser, Subcommand};
 use espflash::{
     cli::{
-        self, board_info, config::Config, connect, erase_partitions, flash_elf_image,
+        self, board_info, completions, config::Config, connect, erase_partitions, flash_elf_image,
         monitor::monitor, parse_partition_table, partition_table, print_board_info,
-        save_elf_as_image, serial_monitor, ConnectArgs, EspflashProgress, FlashConfigArgs,
-        MonitorArgs, PartitionTableArgs,
+        save_elf_as_image, serial_monitor, CompletionsArgs, ConnectArgs, EspflashProgress,
+        FlashConfigArgs, MonitorArgs, PartitionTableArgs,
     },
     image_format::ImageFormatKind,
     logging::initialize_logger,
@@ -22,15 +22,16 @@ use log::{debug, LevelFilter};
 use miette::{IntoDiagnostic, Result, WrapErr};
 
 #[derive(Debug, Parser)]
-#[clap(about, version, propagate_version = true)]
-struct Cli {
-    #[clap(subcommand)]
+#[command(about, version, propagate_version = true)]
+pub struct Cli {
+    #[command(subcommand)]
     subcommand: Commands,
 }
 
 #[derive(Debug, Subcommand)]
 enum Commands {
     BoardInfo(ConnectArgs),
+    Completions(CompletionsArgs),
     Flash(FlashArgs),
     Monitor(MonitorArgs),
     PartitionTable(PartitionTableArgs),
@@ -107,6 +108,7 @@ fn main() -> Result<()> {
     // associated arguments.
     match args {
         Commands::BoardInfo(args) => board_info(&args, &config),
+        Commands::Completions(args) => completions(&args, &mut Cli::command()),
         Commands::Flash(args) => flash(args, &config),
         Commands::Monitor(args) => serial_monitor(args, &config),
         Commands::PartitionTable(args) => partition_table(args),

--- a/espflash/src/bin/espflash.rs
+++ b/espflash/src/bin/espflash.rs
@@ -108,7 +108,7 @@ fn main() -> Result<()> {
     // associated arguments.
     match args {
         Commands::BoardInfo(args) => board_info(&args, &config),
-        Commands::Completions(args) => completions(&args, &mut Cli::command()),
+        Commands::Completions(args) => completions(&args, &mut Cli::command(), "espflash"),
         Commands::Flash(args) => flash(args, &config),
         Commands::Monitor(args) => serial_monitor(args, &config),
         Commands::PartitionTable(args) => partition_table(args),

--- a/espflash/src/cli/mod.rs
+++ b/espflash/src/cli/mod.rs
@@ -230,7 +230,7 @@ pub fn board_info(args: &ConnectArgs, config: &Config) -> Result<()> {
 
 /// Connect to a target device and print information about its chip
 pub fn completions(args: &CompletionsArgs, app: &mut clap::Command) -> Result<()> {
-    clap_complete::generate(args.shell, app, "espflash", &mut std::io::stdout());
+    clap_complete::generate(args.shell, app, clap::crate_name!(), &mut std::io::stdout());
 
     Ok(())
 }

--- a/espflash/src/cli/mod.rs
+++ b/espflash/src/cli/mod.rs
@@ -226,8 +226,8 @@ pub fn board_info(args: &ConnectArgs, config: &Config) -> Result<()> {
 }
 
 /// Generate shell completions for the given shell
-pub fn completions(args: &CompletionsArgs, app: &mut clap::Command) -> Result<()> {
-    clap_complete::generate(args.shell, app, "espflash", &mut std::io::stdout());
+pub fn completions(args: &CompletionsArgs, app: &mut clap::Command, bin_name: &str) -> Result<()> {
+    clap_complete::generate(args.shell, app, bin_name, &mut std::io::stdout());
 
     Ok(())
 }

--- a/espflash/src/cli/mod.rs
+++ b/espflash/src/cli/mod.rs
@@ -63,9 +63,6 @@ pub struct ConnectArgs {
 /// Generate completions for the given shell
 #[derive(Debug, Args)]
 pub struct CompletionsArgs {
-    /// Verbosity level of the logs.
-    #[arg(short = 'l', long, default_value = "info", value_parser = ["debug", "info", "warn", "error"])]
-    pub log_level: String,
     /// Shell to generate completions for.
     pub shell: Shell,
 }

--- a/espflash/src/cli/mod.rs
+++ b/espflash/src/cli/mod.rs
@@ -225,9 +225,9 @@ pub fn board_info(args: &ConnectArgs, config: &Config) -> Result<()> {
     Ok(())
 }
 
-/// Connect to a target device and print information about its chip
+/// Generate shell completions for the given shell
 pub fn completions(args: &CompletionsArgs, app: &mut clap::Command) -> Result<()> {
-    clap_complete::generate(args.shell, app, clap::crate_name!(), &mut std::io::stdout());
+    clap_complete::generate(args.shell, app, "espflash", &mut std::io::stdout());
 
     Ok(())
 }

--- a/espflash/src/cli/mod.rs
+++ b/espflash/src/cli/mod.rs
@@ -15,6 +15,7 @@ use std::{
 };
 
 use clap::Args;
+use clap_complete::Shell;
 use comfy_table::{modifiers, presets::UTF8_FULL, Attribute, Cell, Color, Table};
 use esp_idf_part::{DataType, Partition, PartitionTable};
 use indicatif::{style::ProgressStyle, HumanCount, ProgressBar};
@@ -57,6 +58,16 @@ pub struct ConnectArgs {
     /// Do not use the RAM stub for loading
     #[arg(long)]
     pub no_stub: bool,
+}
+
+/// Generate completions for the given shell
+#[derive(Debug, Args)]
+pub struct CompletionsArgs {
+    /// Verbosity level of the logs.
+    #[arg(short = 'l', long, default_value = "info", value_parser = ["debug", "info", "warn", "error"])]
+    pub log_level: String,
+    /// Shell to generate completions for.
+    pub shell: Shell,
 }
 
 /// Configure communication with the target device's flash
@@ -213,6 +224,13 @@ pub fn connect(args: &ConnectArgs, config: &Config) -> Result<Flasher> {
 pub fn board_info(args: &ConnectArgs, config: &Config) -> Result<()> {
     let mut flasher = connect(args, config)?;
     print_board_info(&mut flasher)?;
+
+    Ok(())
+}
+
+/// Connect to a target device and print information about its chip
+pub fn completions(args: &CompletionsArgs, app: &mut clap::Command) -> Result<()> {
+    clap_complete::generate(args.shell, app, "espflash", &mut std::io::stdout());
 
     Ok(())
 }


### PR DESCRIPTION
Uses `clap_complete` to generate shell completions. Usage example:
```
espflash completions bash > /usr/share/bash-completion/completions/espflash.bash
```
**Note for `cargo-espflash` the completions have to be appended to the cargo completions**

## Test
These are the test that I did in my environment (using Linux and fish shell).
### espflash
1. Install the crate from my branch:
    ```sh
    cargo install espflash --git https://github.com/SergioGasquez/espflash --branch feature/shell-completions
    ```
2. Generate completions:
    ```sh
    espflash completions fish > espflash.fish
    ```
3. Move the generated completions:
    ```sh
    sudo mv espflash.fish /usr/share/fish/completions/espflash.fish
    ```
4. Here is the result of writing `espflash` and tabbing:
    ```sh
    ❯ espflash
    board-info                    (Establish a connection with a target device)
    completions                      (Generate completions for the given shell)
    flash                             (Flash an application to a target device)
    help            (Print this message or the help of the given subcommand(s))
    monitor                          (Open the serial monitor without flashing)
    partition-table                          (Operations for partitions tables)
    save-image           (Save the image to disk instead of flashing to device)
    write-bin  (Writes a binary file to a specific address in the chip's flash)
    ```

### cargo-espflash
1. Install the crate from my branch:
    ```sh
    cargo install cargo-espflash --git https://github.com/SergioGasquez/espflash --branch feature/shell-completions
    ```
2. Generate completions:
    ```sh
    cargo espflash completions fish > cargo-espflash.fish
    ```
3. Append the generated completions to cargo's completions:
    ```sh
    sudo cat cargo-espflash.fish >> /usr/share/fish/completions/cargo.fish
    ```
4. Here is the result of writting `cargo espflash` and tabbing:
    ```sh
    ❯ cargo espflash completions fish > cargo-espflash.fish
    board-info           (Establish a connection with a target device)
    completions             (Generate completions for the given shell)
    flash          (Build and flash an application to a target device)
    help   (Print this message or the help of the given subcommand(s))
    monitor                 (Open the serial monitor without flashing)
    partition-table                 (Operations for partitions tables)
    save-image  (Save the image to disk instead of flashing to device)
    ```
