### PR TITLE
Make the default flashing frequency target specific

### DIFF
--- a/espflash/src/image_format/idf_bootloader.rs
+++ b/espflash/src/image_format/idf_bootloader.rs
@@ -303,6 +303,7 @@ pub mod tests {
         0x1_0000,
         0x3f_0000,
         0,
+        FlashFrequency::_40Mhz,
         include_bytes!("../../resources/bootloaders/esp32-bootloader.bin"),
     );
 

--- a/espflash/src/image_format/idf_bootloader.rs
+++ b/espflash/src/image_format/idf_bootloader.rs
@@ -61,7 +61,7 @@ impl<'a> IdfBootloaderFormat<'a> {
 
         header.write_flash_config(
             flash_size.unwrap_or_default(),
-            flash_freq.unwrap_or_default(),
+            flash_freq.unwrap_or(params.flash_freq),
             chip,
         )?;
 

--- a/espflash/src/targets/esp32.rs
+++ b/espflash/src/targets/esp32.rs
@@ -23,6 +23,7 @@ const PARAMS: Esp32Params = Esp32Params::new(
     0x1_0000,
     0x3f_0000,
     0,
+    FlashFrequency::_40Mhz,
     include_bytes!("../../resources/bootloaders/esp32-bootloader.bin"),
 );
 

--- a/espflash/src/targets/esp32c2.rs
+++ b/espflash/src/targets/esp32c2.rs
@@ -26,6 +26,7 @@ const PARAMS: Esp32Params = Esp32Params::new(
     0x1_0000,
     0x1f_0000,
     12,
+    FlashFrequency::_20Mhz,
     include_bytes!("../../resources/bootloaders/esp32c2-bootloader.bin"),
 );
 

--- a/espflash/src/targets/esp32c2.rs
+++ b/espflash/src/targets/esp32c2.rs
@@ -26,7 +26,7 @@ const PARAMS: Esp32Params = Esp32Params::new(
     0x1_0000,
     0x1f_0000,
     12,
-    FlashFrequency::_20Mhz,
+    FlashFrequency::_30Mhz,
     include_bytes!("../../resources/bootloaders/esp32c2-bootloader.bin"),
 );
 

--- a/espflash/src/targets/esp32c3.rs
+++ b/espflash/src/targets/esp32c3.rs
@@ -26,6 +26,7 @@ const PARAMS: Esp32Params = Esp32Params::new(
     0x1_0000,
     0x3f_0000,
     5,
+    FlashFrequency::_40Mhz,
     include_bytes!("../../resources/bootloaders/esp32c3-bootloader.bin"),
 );
 

--- a/espflash/src/targets/esp32c6.rs
+++ b/espflash/src/targets/esp32c6.rs
@@ -23,6 +23,7 @@ const PARAMS: Esp32Params = Esp32Params::new(
     0x1_0000,
     0x3f_0000,
     13,
+    FlashFrequency::_40Mhz,
     include_bytes!("../../resources/bootloaders/esp32c6-bootloader.bin"),
 );
 

--- a/espflash/src/targets/esp32h2.rs
+++ b/espflash/src/targets/esp32h2.rs
@@ -24,7 +24,7 @@ const PARAMS: Esp32Params = Esp32Params::new(
     0x1_0000,
     0x3f_0000,
     16,
-    FlashFrequency::_20Mhz,
+    FlashFrequency::_24Mhz,
     include_bytes!("../../resources/bootloaders/esp32h2-bootloader.bin"),
 );
 

--- a/espflash/src/targets/esp32h2.rs
+++ b/espflash/src/targets/esp32h2.rs
@@ -24,6 +24,7 @@ const PARAMS: Esp32Params = Esp32Params::new(
     0x1_0000,
     0x3f_0000,
     16,
+    FlashFrequency::_20Mhz,
     include_bytes!("../../resources/bootloaders/esp32h2-bootloader.bin"),
 );
 

--- a/espflash/src/targets/esp32s2.rs
+++ b/espflash/src/targets/esp32s2.rs
@@ -25,6 +25,7 @@ const PARAMS: Esp32Params = Esp32Params::new(
     0x1_0000,
     0x10_0000,
     2,
+    FlashFrequency::_40Mhz,
     include_bytes!("../../resources/bootloaders/esp32s2-bootloader.bin"),
 );
 

--- a/espflash/src/targets/esp32s3.rs
+++ b/espflash/src/targets/esp32s3.rs
@@ -23,6 +23,7 @@ const PARAMS: Esp32Params = Esp32Params::new(
     0x1_0000,
     0x10_0000,
     9,
+    FlashFrequency::_40Mhz,
     include_bytes!("../../resources/bootloaders/esp32s3-bootloader.bin"),
 );
 

--- a/espflash/src/targets/mod.rs
+++ b/espflash/src/targets/mod.rs
@@ -133,6 +133,7 @@ pub struct Esp32Params {
     pub app_addr: u32,
     pub app_size: u32,
     pub chip_id: u16,
+    pub flash_freq: FlashFrequency,
     pub default_bootloader: &'static [u8],
 }
 
@@ -142,6 +143,7 @@ impl Esp32Params {
         app_addr: u32,
         app_size: u32,
         chip_id: u16,
+        flash_freq: FlashFrequency,
         bootloader: &'static [u8],
     ) -> Self {
         Self {
@@ -154,6 +156,7 @@ impl Esp32Params {
             app_addr,
             app_size,
             chip_id,
+            flash_freq,
             default_bootloader: bootloader,
         }
     }


### PR DESCRIPTION
I've implemented the third solution proposed by @maxwase in #375:
- Add `flash_freq` to `Esp32Params` so we can define a default flashing frequency per target.
- Specify the default flashing frequency for all the targets.