### PR TITLE
Updated ESP32-C6 valid targets

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -313,7 +313,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-espflash"
-version = "2.0.0-rc.4"
+version = "2.0.0-rc.5"
 dependencies = [
  "cargo",
  "cargo_metadata",
@@ -898,7 +898,7 @@ dependencies = [
 
 [[package]]
 name = "espflash"
-version = "2.0.0-rc.4"
+version = "2.0.0-rc.5"
 dependencies = [
  "addr2line",
  "base64 0.21.0",

--- a/cargo-espflash/Cargo.toml
+++ b/cargo-espflash/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-espflash"
-version = "2.0.0-rc.4"
+version = "2.0.0-rc.5"
 authors = ["Robin Appelman <robin@icewind.nl>", "Jesse Braham <jesse@beta7.io>"]
 edition = "2021"
 rust-version = "1.64"
@@ -26,7 +26,7 @@ cargo_metadata = "0.15.2"
 clap = { version = "4.0.32", features = ["derive"] }
 env_logger = "0.10.0"
 esp-idf-part = "0.2.0"
-espflash = { version = "=2.0.0-rc.4", path = "../espflash" }
+espflash = { version = "=2.0.0-rc.5", path = "../espflash" }
 log = "0.4.17"
 miette = { version = "5.5.0", features = ["fancy"] }
 serde = { version = "1.0.152", features = ["derive"] }

--- a/espflash/Cargo.toml
+++ b/espflash/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "espflash"
-version = "2.0.0-rc.4"
+version = "2.0.0-rc.5"
 authors = ["Robin Appelman <robin@icewind.nl>", "Jesse Braham <jesse@beta7.io>"]
 edition = "2021"
 rust-version = "1.64"

--- a/espflash/src/targets/esp32c6.rs
+++ b/espflash/src/targets/esp32c6.rs
@@ -115,8 +115,7 @@ impl Target for Esp32c6 {
     fn supported_build_targets(&self) -> &[&str] {
         &[
             "riscv32imac-unknown-none-elf",
-            "riscv32imc-esp-espidf",
-            "riscv32imc-unknown-none-elf",
+            "riscv32imac-esp-espidf",
         ]
     }
 }


### PR DESCRIPTION
Removed incompatible targets of ESP32-C6 and added only IMAC ones
Updated to RC5