### PR TITLE
Add issue templates

### DIFF
--- a/.github/workflows/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/workflows/ISSUE_TEMPLATE/bug_report.md
@@ -11,7 +11,8 @@ assignees: ''
 
 <!-- A clear and concise description of what the bug is. -->
 
-- Would you like to work on a fix? [y/n]
+- [ ] I have searched the existing issues (closed & open) to make sure the issue hasn't already been reported
+- [ ] Check this box if you would like to work on a fix
 
 ## To Reproduce
 
@@ -22,9 +23,7 @@ Steps to reproduce the behavior:
 3. ...
 4. ...
 
-<!-- Make sure you are able to reproduce the bug in the main branch, too. -->
-<!-- Make sure the issue is not already reported. -->
-
+- [ ] I have reproduced the bug in main branch too
 
 ## Expected behavior
 

--- a/.github/workflows/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/workflows/ISSUE_TEMPLATE/bug_report.md
@@ -38,7 +38,7 @@ Steps to reproduce the behavior:
 <!-- Please fill the following information. -->
 
 - OS: [e.g. Ubuntu 20.04]
-- esfpaslh/cargo-espflash version: [e.g. 0.1.0]
+- espflash/cargo-espflash version: [e.g. 0.1.0]
 - Target: [e.g. ESP32-C3]
 
 ## Additional context

--- a/.github/workflows/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/workflows/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,46 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: bug
+assignees: ''
+
+---
+
+## Bug description
+
+<!-- A clear and concise description of what the bug is. -->
+
+- Would you like to work on a fix? [y/n]
+
+## To Reproduce
+
+Steps to reproduce the behavior:
+
+1. ...
+2. ...
+3. ...
+4. ...
+
+<!-- Make sure you are able to reproduce the bug in the main branch, too. -->
+<!-- Make sure the issue is not already reported. -->
+
+
+## Expected behavior
+
+<!-- A clear and concise description of what you expected to happen. -->
+
+## Screenshots
+
+<!-- If applicable, add screenshots to help explain your problem. -->
+
+## Environment
+
+<!-- Please fill the following information. -->
+
+- OS: [e.g. Ubuntu 20.04]
+- crate version: [e.g. 0.1.0]
+
+## Additional context
+
+<!-- Add any other context about the problem here. -->

--- a/.github/workflows/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/workflows/ISSUE_TEMPLATE/bug_report.md
@@ -39,7 +39,8 @@ Steps to reproduce the behavior:
 <!-- Please fill the following information. -->
 
 - OS: [e.g. Ubuntu 20.04]
-- crate version: [e.g. 0.1.0]
+- esfpaslh/cargo-espflash version: [e.g. 0.1.0]
+- Target: [e.g. ESP32-C3]
 
 ## Additional context
 

--- a/.github/workflows/ISSUE_TEMPLATE/config.yml
+++ b/.github/workflows/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: true

--- a/.github/workflows/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/workflows/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,28 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: ''
+labels: enhancement
+assignees: ''
+
+---
+
+## Motivations
+
+<!--
+If your feature request is related to a problem, please describe it.
+-->
+
+- Would you like to implement this feature? [y/n]
+
+## Solution
+
+<!-- Describe the solution you'd like. -->
+
+## Alternatives
+
+<!-- Describe any alternative solutions or features you've considered. -->
+
+## Additional context
+
+<!-- Add any other context or screenshots about the feature request here. -->


### PR DESCRIPTION
I haven't been able to test it in my fork, but basically they are copied from https://github.com/esp-rs/espup/tree/main/.github/ISSUE_TEMPLATE where it works fine