### PR TITLE
Do not require the `--partition-table` argument when erasing partitions

### DIFF
--- a/espflash/src/cli/mod.rs
+++ b/espflash/src/cli/mod.rs
@@ -89,21 +89,10 @@ pub struct FlashArgs {
     #[arg(long, value_name = "FILE")]
     pub bootloader: Option<PathBuf>,
     /// Erase partitions by label
-    #[arg(
-        long,
-        requires = "partition_table",
-        value_name = "LABELS",
-        value_delimiter = ','
-    )]
+    #[arg(long, value_name = "LABELS", value_delimiter = ',')]
     pub erase_parts: Option<Vec<String>>,
     /// Erase specified data partitions
-    #[arg(
-        long,
-        requires = "partition_table",
-        value_name = "PARTS",
-        value_enum,
-        value_delimiter = ','
-    )]
+    #[arg(long, value_name = "PARTS", value_enum, value_delimiter = ',')]
     pub erase_data_parts: Option<Vec<DataType>>,
     /// Image format to flash
     #[arg(long, value_enum)]

--- a/espflash/src/error.rs
+++ b/espflash/src/error.rs
@@ -387,8 +387,11 @@ impl From<String> for MissingPartition {
 }
 
 #[derive(Debug, Error, Diagnostic)]
-#[error("No partition table could be found at the specified path")]
-#[diagnostic(code(espflash::partition_table::missing_partition_table))]
+#[error("No partition table could be found")]
+#[diagnostic(
+    code(espflash::partition_table::missing_partition_table),
+    help("Try providing a CSV or binary paritition table with the `--partition-table` argument.")
+)]
 pub struct MissingPartitionTable;
 
 #[derive(Debug, Error)]


### PR DESCRIPTION
Rather than perform error handling within `clap` for this, we just move the check (which already existed) into `espflash` instead, after any package metadata has been read. This will still return an error if no partition table was able to be found, however it should be able to pick up partition tables provided via cargo metadata just fine.

Closes #390