### PR TITLE
Override the flash size in `Flasher` if provided via command-line argument

### DIFF
--- a/cargo-espflash/src/main.rs
+++ b/cargo-espflash/src/main.rs
@@ -158,9 +158,17 @@ fn flash(args: FlashArgs, config: &Config) -> Result<()> {
     let cargo_config = CargoConfig::load(&metadata.workspace_root, &metadata.package_root);
 
     let mut flasher = connect(&args.connect_args, config)?;
+
+    // If the user has provided a flash size via a command-line argument, we'll
+    // override the detected (or default) value with this.
+    if let Some(flash_size) = args.build_args.flash_config_args.flash_size {
+        flasher.set_flash_size(flash_size);
+    }
+
     let chip = flasher.chip();
     let target = chip.into_target();
     let target_xtal_freq = target.crystal_freq(flasher.connection())?;
+
     flasher.disable_watchdog()?;
 
     let build_ctx =

--- a/espflash/src/bin/espflash.rs
+++ b/espflash/src/bin/espflash.rs
@@ -119,6 +119,13 @@ fn main() -> Result<()> {
 
 fn flash(args: FlashArgs, config: &Config) -> Result<()> {
     let mut flasher = connect(&args.connect_args, config)?;
+
+    // If the user has provided a flash size via a command-line argument, we'll
+    // override the detected (or default) value with this.
+    if let Some(flash_size) = args.flash_config_args.flash_size {
+        flasher.set_flash_size(flash_size);
+    }
+
     print_board_info(&mut flasher)?;
 
     let chip = flasher.chip();

--- a/espflash/src/flasher/mod.rs
+++ b/espflash/src/flasher/mod.rs
@@ -401,6 +401,10 @@ impl Flasher {
         Ok(flasher)
     }
 
+    pub fn set_flash_size(&mut self, flash_size: FlashSize) {
+        self.flash_size = flash_size;
+    }
+
     pub fn disable_watchdog(&mut self) -> Result<(), Error> {
         let mut target = self.chip.flash_target(self.spi_params, self.use_stub);
         target.begin(&mut self.connection).flashing()?;


### PR DESCRIPTION
Closes #396 (I think..?)

@dragazo @MabezDev please confirm this fixes the issue, but as far as I can tell we just were never passing the command-line argument to the `Flasher` struct when it was provided.