### PR TITLE
Downgrade `crossterm` to `0.25.0`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -451,7 +451,7 @@ version = "6.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e7b787b0dc42e8111badfdbe4c3059158ccb2db8780352fa1b01e8ccf45cc4d"
 dependencies = [
- "crossterm 0.25.0",
+ "crossterm",
  "strum",
  "strum_macros",
  "unicode-width",
@@ -562,22 +562,6 @@ name = "crossterm"
 version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e64e6c0fbe2c17357405f7c758c1ef960fce08bdfb2c03d88d2a18d7e09c4b67"
-dependencies = [
- "bitflags",
- "crossterm_winapi",
- "libc",
- "mio",
- "parking_lot",
- "signal-hook",
- "signal-hook-mio",
- "winapi",
-]
-
-[[package]]
-name = "crossterm"
-version = "0.26.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a84cda67535339806297f1b331d6dd6320470d2a0fe65381e79ee9e156dd3d13"
 dependencies = [
  "bitflags",
  "crossterm_winapi",
@@ -952,7 +936,7 @@ dependencies = [
  "clap",
  "clap_complete",
  "comfy-table",
- "crossterm 0.26.1",
+ "crossterm",
  "ctrlc",
  "dialoguer",
  "directories-next",

--- a/espflash/Cargo.toml
+++ b/espflash/Cargo.toml
@@ -31,7 +31,7 @@ bytemuck = { version = "1.12.3", features = ["derive"] }
 clap = { version = "4.0.32", features = ["derive", "env"], optional = true }
 clap_complete = { version = "4.1.5", optional = true }
 comfy-table = { version = "6.1.4", optional = true }
-crossterm = { version = "0.26.1", optional = true }
+crossterm = { version = "0.25.0", optional = true } # 0.26.x causes issues on Windows
 ctrlc = { version = "3.2.5", optional = true }
 dialoguer = { version = "0.10.2", optional = true }
 directories-next = { version = "2.0.0", optional = true }


### PR DESCRIPTION
Computers were a mistake

(using `0.26.x` somehow breaks things on Windows in weird circumstances)