### PR TITLE
Add missing import when using `linux` and `musl`

### DIFF
--- a/espflash/src/cli/serial.rs
+++ b/espflash/src/cli/serial.rs
@@ -114,6 +114,8 @@ fn detect_usb_serial_ports() -> Result<Vec<SerialPortInfo>> {
         path::PathBuf,
     };
 
+    use serialport::UsbPortInfo;
+
     let ports = available_ports().into_diagnostic()?;
     let ports = ports
         .into_iter()


### PR DESCRIPTION
Found this when updating the `release` workflow, will have to update our CI to check `musl` as well (I'll take care of that in another PR)