### PR TITLE
update 'cargo' dependency to 0.72

### DIFF
--- a/cargo-espflash/Cargo.toml
+++ b/cargo-espflash/Cargo.toml
@@ -37,7 +37,7 @@ thiserror = "1.0.40"
 toml = "0.7.4"
 
 [target.'cfg(unix)'.dependencies]
-cargo = { version = "0.71.0", features = ["vendored-openssl"] }
+cargo = { version = "0.72.0", features = ["vendored-openssl"] }
 
 [target.'cfg(windows)'.dependencies]
-cargo = "0.71.0"
+cargo = "0.72.0"


### PR DESCRIPTION
In #444, I reported that `cargo install` of cargo-espflash started failing for me this morning due to a build failure in the "cargo" dependency:

```
> cd cargo-espflash
> cargo install --path .
…
error[E0063]: missing field `rust_version` in initializer of `NewCrate`
   --> /Users/myk/.cargo/registry/src/index.crates.io-6f17d22bba15001f/cargo-0.71.0/src/cargo/ops/registry.rs:383:14
    |
383 |             &NewCrate {
    |              ^^^^^^^^ missing `rust_version`

For more information about this error, try `rustc --explain E0063`.
error: could not compile `cargo` (lib) due to previous error
error: failed to compile `cargo-espflash v2.0.1-dev (/Users/myk/Projects/espflash/cargo-espflash)`, intermediate artifacts can be found at `/Users/myk/Projects/espflash/target`
```

This branch fixes that problem by updating the dependency to 0.72, which was just published this morning (https://crates.io/crates/cargo/versions). Unfortunately, I can't find any info about the changes that were made. There isn't even a tag in the repo for the crate (https://github.com/rust-lang/cargo/tags). So I'm not sure what the issue is nor how updating the dependency fixes it.

However, I also see that Rust 1.71 was released today (https://blog.rust-lang.org/2023/07/13/Rust-1.71.0.html), so maybe it's something to do with that.
