### PR TITLE
Revert to depending on cargo 0.71

### DIFF
--- a/cargo-espflash/Cargo.toml
+++ b/cargo-espflash/Cargo.toml
@@ -37,7 +37,7 @@ thiserror = "1.0.43"
 toml = "0.7.6"
 
 [target.'cfg(unix)'.dependencies]
-cargo = { version = "0.72.0", features = ["vendored-openssl"] }
+cargo = { version = "0.71.0", features = ["vendored-openssl"] }
 
 [target.'cfg(windows)'.dependencies]
-cargo = "0.72.0"
+cargo = "0.71.0"


### PR DESCRIPTION
The cargo team still hasn't published version 0.72.1 to crates.io since pulling 0.72, so it's currently impossible to install cargo-espflash.

However, in the meantime, they appear to have fixed installing cargo-espflash with 0.71. So perhaps it's worth reverting the dependency to that version.

This reverts commit 7ce1ca203b54021fe681d08944b0c83c8d4ab57c.