### PR TITLE
Add interactive flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Read esp-println generated defmt messages (#466)
 - Add --target-app-partition argument to flash command (#461)
+- Add --confirm-port argument to flash command (#455)
 
 ### Fixed
 

--- a/espflash/src/cli/mod.rs
+++ b/espflash/src/cli/mod.rs
@@ -52,6 +52,9 @@ pub struct ConnectArgs {
     /// Serial port connected to target device
     #[arg(short = 'p', long, env = "ESPFLASH_PORT")]
     pub port: Option<String>,
+    /// Require confirmation before auto-connecting to a recognized device.
+    #[arg(short = 'i', long)]
+    pub interactive: bool,
     /// DTR pin to use for the internal UART hardware. Uses BCM numbering.
     #[cfg(feature = "raspberry")]
     #[cfg_attr(feature = "raspberry", clap(long))]

--- a/espflash/src/cli/mod.rs
+++ b/espflash/src/cli/mod.rs
@@ -53,8 +53,8 @@ pub struct ConnectArgs {
     #[arg(short = 'p', long, env = "ESPFLASH_PORT")]
     pub port: Option<String>,
     /// Require confirmation before auto-connecting to a recognized device.
-    #[arg(short = 'i', long)]
-    pub interactive: bool,
+    #[arg(short = 'c', long)]
+    pub confirm_port: bool,
     /// DTR pin to use for the internal UART hardware. Uses BCM numbering.
     #[cfg(feature = "raspberry")]
     #[cfg_attr(feature = "raspberry", clap(long))]

--- a/espflash/src/cli/serial.rs
+++ b/espflash/src/cli/serial.rs
@@ -40,7 +40,7 @@ pub fn get_serial_port_info(
     } else if let Some(serial) = &config.connection.serial {
         find_serial_port(&ports, serial)
     } else {
-        let (port, matches) = select_serial_port(ports, config, matches.interactive)?;
+        let (port, matches) = select_serial_port(ports, config, matches.confirm_port)?;
 
         match &port.port_type {
             SerialPortType::UsbPort(usb_info) if !matches => {
@@ -202,7 +202,7 @@ const KNOWN_DEVICES: &[UsbDevice] = &[
 fn select_serial_port(
     mut ports: Vec<SerialPortInfo>,
     config: &Config,
-    force_interactive: bool,
+    force_confirm_port: bool,
 ) -> Result<(SerialPortInfo, bool), Error> {
     // Does this port match a known one?
     let matches = |port: &SerialPortInfo| match &port.port_type {
@@ -221,7 +221,7 @@ fn select_serial_port(
         .as_slice()
     {
         // There is a unique recognized device.
-        if !force_interactive {
+        if !force_confirm_port {
             return Ok(((*port).to_owned(), true));
         }
     }

--- a/espflash/src/cli/serial.rs
+++ b/espflash/src/cli/serial.rs
@@ -40,7 +40,7 @@ pub fn get_serial_port_info(
     } else if let Some(serial) = &config.connection.serial {
         find_serial_port(&ports, serial)
     } else {
-        let (port, matches) = select_serial_port(ports, config)?;
+        let (port, matches) = select_serial_port(ports, config, matches.interactive)?;
 
         match &port.port_type {
             SerialPortType::UsbPort(usb_info) if !matches => {
@@ -202,6 +202,7 @@ const KNOWN_DEVICES: &[UsbDevice] = &[
 fn select_serial_port(
     mut ports: Vec<SerialPortInfo>,
     config: &Config,
+    force_interactive: bool,
 ) -> Result<(SerialPortInfo, bool), Error> {
     // Does this port match a known one?
     let matches = |port: &SerialPortInfo| match &port.port_type {
@@ -220,8 +221,12 @@ fn select_serial_port(
         .as_slice()
     {
         // There is a unique recognized device.
-        Ok(((*port).to_owned(), true))
-    } else if ports.len() > 1 {
+        if !force_interactive {
+            return Ok(((*port).to_owned(), true));
+        }
+    }
+
+    if ports.len() > 1 {
         // Multiple serial ports detected.
         info!("Detected {} serial ports", ports.len());
         info!("Ports which match a known common dev board are highlighted");


### PR DESCRIPTION
Adds an `--interactive` (or `-i`) flag that prevents auto-connection to a recognized device, even if it is the only recognized one.