### PR TITLE
Fix CI checks

### DIFF
--- a/.github/actions/setup-arm/action.yml
+++ b/.github/actions/setup-arm/action.yml
@@ -33,7 +33,7 @@ runs:
     - uses: Swatinem/rust-cache@v2
 
     - name: Install Cross-Compile Support
-      uses: cyberjunk/gha-ubuntu-cross@v3
+      uses: junelife/gha-ubuntu-cross@v4
       with:
         arch: ${{ inputs.arch }}
 

--- a/.github/actions/setup-arm/action.yml
+++ b/.github/actions/setup-arm/action.yml
@@ -33,7 +33,7 @@ runs:
     - uses: Swatinem/rust-cache@v2
 
     - name: Install Cross-Compile Support
-      uses: junelife/gha-ubuntu-cross@v4
+      uses: junelife/gha-ubuntu-cross@v6
       with:
         arch: ${{ inputs.arch }}
 

--- a/espflash/Cargo.toml
+++ b/espflash/Cargo.toml
@@ -35,8 +35,8 @@ addr2line = { version = "0.20.0", optional = true }
 base64 = "0.21.2"
 binread = "2.2.0"
 bytemuck = { version = "1.13.1", features = ["derive"] }
-clap = { version = "4.3.11", features = ["derive", "env", "wrap_help"], optional = true }
-clap_complete = { version = "4.3.2", optional = true }
+clap = { version = "4.3.*", features = ["derive", "env", "wrap_help"], optional = true }
+clap_complete = { version = "4.3.*", optional = true }
 comfy-table = { version = "7.0.1", optional = true }
 crossterm = { version = "0.25.0", optional = true } # 0.26.x causes issues on Windows
 ctrlc = { version = "3.4.0", optional = true }

--- a/espflash/src/elf.rs
+++ b/espflash/src/elf.rs
@@ -220,7 +220,7 @@ impl PartialEq for CodeSegment<'_> {
 
 impl PartialOrd for CodeSegment<'_> {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        self.addr.partial_cmp(&other.addr)
+        Some(self.cmp(other))
     }
 }
 

--- a/espflash/src/targets/esp8266.rs
+++ b/espflash/src/targets/esp8266.rs
@@ -13,6 +13,7 @@ use crate::{
 
 const CHIP_DETECT_MAGIC_VALUES: &[u32] = &[0xfff0_c101];
 
+#[allow(clippy::single_range_in_vec_init)]
 const FLASH_RANGES: &[Range<u32>] = &[
     0x40200000..0x40300000, // IROM
 ];


### PR DESCRIPTION
I investigated the CI failures and discovered it was a non-zero exit code from a call to `apt-get update` that was causing the workflow to fail.  In order to fix this, I had to fork the `gha-ubuntu-cross` repo and apply the fix there.  I'm working to get this fix upstreamed in https://github.com/cyberjunk/gha-ubuntu-cross/pull/6.  Once it is, we can revert this reference back to the original repo.

I also fixed a clippy warning that was added 1.72.0.  https://rust-lang.github.io/rust-clippy/master/index.html#/single_range_in_vec_init  The page says "this is almost always incorrect", but it seems clear that this is quite intentional in our case here.  So I silenced the warning by adding an `#[allow` annotation.