### PR TITLE
Avoid updating clap to newer minor versions

### DIFF
--- a/espflash/Cargo.toml
+++ b/espflash/Cargo.toml
@@ -35,8 +35,8 @@ addr2line = { version = "0.20.0", optional = true }
 base64 = "0.21.2"
 binread = "2.2.0"
 bytemuck = { version = "1.13.1", features = ["derive"] }
-clap = { version = "4.3.11", features = ["derive", "env", "wrap_help"], optional = true }
-clap_complete = { version = "4.3.2", optional = true }
+clap = { version = "4.3.*", features = ["derive", "env", "wrap_help"], optional = true }
+clap_complete = { version = "4.3.*", optional = true }
 comfy-table = { version = "7.0.1", optional = true }
 crossterm = { version = "0.25.0", optional = true } # 0.26.x causes issues on Windows
 ctrlc = { version = "3.4.0", optional = true }

--- a/espflash/src/elf.rs
+++ b/espflash/src/elf.rs
@@ -220,7 +220,7 @@ impl PartialEq for CodeSegment<'_> {
 
 impl PartialOrd for CodeSegment<'_> {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        self.addr.partial_cmp(&other.addr)
+        Some(self.cmp(other))
     }
 }
 

--- a/espflash/src/targets/esp8266.rs
+++ b/espflash/src/targets/esp8266.rs
@@ -13,6 +13,7 @@ use crate::{
 
 const CHIP_DETECT_MAGIC_VALUES: &[u32] = &[0xfff0_c101];
 
+#[allow(clippy::single_range_in_vec_init)]
 const FLASH_RANGES: &[Range<u32>] = &[
     0x40200000..0x40300000, // IROM
 ];


### PR DESCRIPTION
`clap_complete` 4.4.0 raised MSRV to 1.70, breaking CI due to espflash only specifying 1.65.

As per https://github.com/clap-rs/clap/issues/5087 the clap project treats MSRV breaks as minor changes. While this is also what cargo suggests, it's simpler to lock clap to patch releases than to keep bumping MSRV every 6 weeks.

I've also resolved two clippy lint issues, at least one of them affecting CI.

Hopefully, along with #465 this will fix the current CI woes.