### PR TITLE
Add defmt feature to cargo-espflash

### DIFF
--- a/cargo-espflash/Cargo.toml
+++ b/cargo-espflash/Cargo.toml
@@ -41,3 +41,6 @@ cargo = { version = "0.73.1", features = ["vendored-openssl"] }
 
 [target.'cfg(windows)'.dependencies]
 cargo = "0.73.1"
+
+[features]
+defmt = ["espflash/defmt"]


### PR DESCRIPTION
This was missed when I undefaulted the feature