### PR TITLE
Add log-format argument

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -30,10 +30,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a30b2e23b9e17a9f90641c7ab1549cd9b44f296d3ccbf309d2863cfe398a0cb"
 dependencies = [
  "cpp_demangle",
- "fallible-iterator 0.3.0",
- "gimli 0.28.0",
+ "fallible-iterator",
+ "gimli",
  "memmap2",
- "object 0.32.1",
+ "object",
  "rustc-demangle",
  "smallvec",
 ]
@@ -163,7 +163,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "miniz_oxide",
- "object 0.32.1",
+ "object",
  "rustc-demangle",
 ]
 
@@ -834,9 +834,9 @@ dependencies = [
 
 [[package]]
 name = "defmt-decoder"
-version = "0.3.8"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69494bdf0927405e6d22641d1307c664ad3e9483452b85078940529883945044"
+checksum = "5cc8c950fcaefdfce609498332b92c9b235c431d85c6c71908142cbb55709140"
 dependencies = [
  "anyhow",
  "byteorder",
@@ -844,10 +844,10 @@ dependencies = [
  "defmt-json-schema",
  "defmt-parser",
  "dissimilar",
- "gimli 0.27.3",
+ "gimli",
  "log",
  "nom",
- "object 0.31.1",
+ "object",
  "ryu",
  "serde",
  "serde_json",
@@ -1134,12 +1134,6 @@ dependencies = [
 
 [[package]]
 name = "fallible-iterator"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4443176a9f2c162692bd3d352d745ef9413eec5782a80d8fd6f8a1ac692a07f7"
-
-[[package]]
-name = "fallible-iterator"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
@@ -1330,21 +1324,11 @@ dependencies = [
 
 [[package]]
 name = "gimli"
-version = "0.27.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6c80984affa11d98d1b88b66ac8853f143217b399d3c74116778ff8fdb4ed2e"
-dependencies = [
- "fallible-iterator 0.2.0",
- "stable_deref_trait",
-]
-
-[[package]]
-name = "gimli"
 version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6fb8d784f27acf97159b40fc4db5ecd8aa23b9ad5ef69cdd136d3bc80665f0c0"
 dependencies = [
- "fallible-iterator 0.3.0",
+ "fallible-iterator",
  "stable_deref_trait",
 ]
 
@@ -2720,15 +2704,6 @@ name = "number_prefix"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
-
-[[package]]
-name = "object"
-version = "0.31.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bda667d9f2b5051b8833f59f3bf748b28ef54f850f4fcb389a252aa383866d1"
-dependencies = [
- "memchr",
-]
 
 [[package]]
 name = "object"

--- a/cargo-espflash/Cargo.toml
+++ b/cargo-espflash/Cargo.toml
@@ -41,6 +41,3 @@ cargo = { version = "0.73.1", features = ["vendored-openssl"] }
 
 [target.'cfg(windows)'.dependencies]
 cargo = "0.73.1"
-
-[features]
-defmt = ["espflash/defmt"]

--- a/cargo-espflash/src/main.rs
+++ b/cargo-espflash/src/main.rs
@@ -6,13 +6,13 @@ use std::{
 
 use cargo_metadata::Message;
 use clap::{Args, CommandFactory, Parser, Subcommand};
-use espflash::cli::{erase_flash, erase_region, EraseFlashArgs, EraseRegionArgs};
 use espflash::{
     cli::{
-        self, board_info, completions, config::Config, connect, erase_partitions, flash_elf_image,
-        monitor::monitor, parse_partition_table, partition_table, print_board_info,
-        save_elf_as_image, serial_monitor, CompletionsArgs, ConnectArgs, EspflashProgress,
-        FlashConfigArgs, MonitorArgs, PartitionTableArgs,
+        self, board_info, completions, config::Config, connect, erase_flash, erase_partitions,
+        erase_region, flash_elf_image, monitor::monitor_with, parse_partition_table,
+        partition_table, print_board_info, save_elf_as_image, serial_monitor, CompletionsArgs,
+        ConnectArgs, EraseFlashArgs, EraseRegionArgs, EspflashProgress, FlashConfigArgs,
+        MonitorArgs, PartitionTableArgs,
     },
     error::Error as EspflashError,
     image_format::ImageFormatKind,
@@ -341,11 +341,12 @@ fn flash(args: FlashArgs, config: &Config) -> Result<()> {
                 115_200
             };
 
-        monitor(
+        monitor_with(
             flasher.into_interface(),
             Some(&elf_data),
             pid,
             args.flash_args.monitor_baud.unwrap_or(default_baud),
+            args.flash_args.defmt,
         )
         .into_diagnostic()?;
     }

--- a/cargo-espflash/src/main.rs
+++ b/cargo-espflash/src/main.rs
@@ -346,7 +346,7 @@ fn flash(args: FlashArgs, config: &Config) -> Result<()> {
             Some(&elf_data),
             pid,
             args.flash_args.monitor_baud.unwrap_or(default_baud),
-            args.flash_args.defmt,
+            args.flash_args.log_format,
         )
         .into_diagnostic()?;
     }

--- a/espflash/Cargo.toml
+++ b/espflash/Cargo.toml
@@ -40,8 +40,8 @@ clap_complete = { version = "4.4.3", optional = true }
 comfy-table = { version = "7.0.1", optional = true }
 crossterm = { version = "0.25.0", optional = true } # 0.26.x causes issues on Windows
 ctrlc = { version = "3.4.0", optional = true }
-defmt-decoder = { version = "=0.3.8", features = ["unstable"], optional = true }
-defmt-parser = { version = "=0.3.3", features = ["unstable"], optional = true }
+defmt-decoder = { version = "0.3.9", features = ["unstable"], optional = true }
+defmt-parser = { version = "0.3.3", features = ["unstable"], optional = true }
 dialoguer = { version = "0.10.4", optional = true }
 directories = { version = "5.0.1", optional = true }
 env_logger = { version = "0.10.0", optional = true }
@@ -74,6 +74,8 @@ cli = [
     "dep:comfy-table",
     "dep:crossterm",
     "dep:ctrlc",
+    "dep:defmt-decoder",
+    "dep:defmt-parser",
     "dep:dialoguer",
     "dep:directories",
     "dep:env_logger",
@@ -84,8 +86,5 @@ cli = [
     "dep:regex",
     "dep:update-informer",
 ]
-defmt = [
-    "dep:defmt-decoder",
-    "dep:defmt-parser",
-]
+
 raspberry = ["dep:rppal"]

--- a/espflash/Cargo.toml
+++ b/espflash/Cargo.toml
@@ -40,7 +40,7 @@ clap_complete = { version = "4.4.3", optional = true }
 comfy-table = { version = "7.0.1", optional = true }
 crossterm = { version = "0.25.0", optional = true } # 0.26.x causes issues on Windows
 ctrlc = { version = "3.4.0", optional = true }
-# defmt dependencies are pinned since defmt does not guarantees MSRV even for patch releases
+# defmt dependencies are pinned since defmt does not guarantee MSRV even for patch releases
 defmt-decoder = { version = "=0.3.9", features = ["unstable"], optional = true }
 defmt-parser = { version = "=0.3.3", features = ["unstable"], optional = true }
 dialoguer = { version = "0.10.4", optional = true }

--- a/espflash/Cargo.toml
+++ b/espflash/Cargo.toml
@@ -40,8 +40,9 @@ clap_complete = { version = "4.4.3", optional = true }
 comfy-table = { version = "7.0.1", optional = true }
 crossterm = { version = "0.25.0", optional = true } # 0.26.x causes issues on Windows
 ctrlc = { version = "3.4.0", optional = true }
-defmt-decoder = { version = "0.3.9", features = ["unstable"], optional = true }
-defmt-parser = { version = "0.3.3", features = ["unstable"], optional = true }
+# defmt dependencies are pinned since defmt does not guarantees MSRV even for patch releases
+defmt-decoder = { version = "=0.3.9", features = ["unstable"], optional = true }
+defmt-parser = { version = "=0.3.3", features = ["unstable"], optional = true }
 dialoguer = { version = "0.10.4", optional = true }
 directories = { version = "5.0.1", optional = true }
 env_logger = { version = "0.10.0", optional = true }

--- a/espflash/src/bin/espflash.rs
+++ b/espflash/src/bin/espflash.rs
@@ -268,7 +268,7 @@ fn flash(args: FlashArgs, config: &Config) -> Result<()> {
             Some(&elf_data),
             pid,
             args.flash_args.monitor_baud.unwrap_or(default_baud),
-            args.flash_args.defmt,
+            args.flash_args.log_format,
         )
         .into_diagnostic()?;
     }

--- a/espflash/src/bin/espflash.rs
+++ b/espflash/src/bin/espflash.rs
@@ -8,7 +8,7 @@ use clap::{Args, CommandFactory, Parser, Subcommand};
 use espflash::{
     cli::{
         self, board_info, completions, config::Config, connect, erase_flash, erase_partitions,
-        erase_region, flash_elf_image, monitor::monitor, parse_partition_table, parse_uint32,
+        erase_region, flash_elf_image, monitor::monitor_with, parse_partition_table, parse_uint32,
         partition_table, print_board_info, save_elf_as_image, serial_monitor, CompletionsArgs,
         ConnectArgs, EraseFlashArgs, EraseRegionArgs, EspflashProgress, FlashConfigArgs,
         MonitorArgs, PartitionTableArgs,
@@ -263,11 +263,12 @@ fn flash(args: FlashArgs, config: &Config) -> Result<()> {
                 115_200
             };
 
-        monitor(
+        monitor_with(
             flasher.into_interface(),
             Some(&elf_data),
             pid,
             args.flash_args.monitor_baud.unwrap_or(default_baud),
+            args.flash_args.defmt,
         )
         .into_diagnostic()?;
     }

--- a/espflash/src/cli/mod.rs
+++ b/espflash/src/cli/mod.rs
@@ -24,7 +24,11 @@ use log::{debug, info};
 use miette::{IntoDiagnostic, Result, WrapErr};
 use serialport::{SerialPortType, UsbPortInfo};
 
-use self::{config::Config, monitor::monitor_with, serial::get_serial_port_info};
+use self::{
+    config::Config,
+    monitor::{monitor_with, LogFormat},
+    serial::get_serial_port_info,
+};
 use crate::{
     elf::ElfFirmwareImage,
     error::{Error, MissingPartition, MissingPartitionTable},
@@ -134,9 +138,9 @@ pub struct FlashArgs {
     /// Load the application to RAM instead of Flash
     #[arg(long)]
     pub ram: bool,
-    /// Defmt
-    #[arg(long, short = 'd', requires = "monitor")]
-    pub defmt: bool,
+    /// Logging format.
+    #[arg(long, short = 'f', requires = "monitor")]
+    pub log_format: LogFormat,
 }
 
 /// Operations for partitions tables
@@ -188,9 +192,9 @@ pub struct MonitorArgs {
     /// Connection configuration
     #[clap(flatten)]
     connect_args: ConnectArgs,
-    /// Defmt
-    #[arg(long, short = 'd')]
-    defmt: bool,
+    /// Logging format.
+    #[arg(long, short = 'f')]
+    pub log_format: LogFormat,
 }
 
 /// Select a serial port and establish a connection with a target device
@@ -302,7 +306,7 @@ pub fn serial_monitor(args: MonitorArgs, config: &Config) -> Result<()> {
         elf.as_deref(),
         pid,
         args.connect_args.baud.unwrap_or(default_baud),
-        args.defmt,
+        args.log_format,
     )
     .into_diagnostic()?;
 

--- a/espflash/src/cli/mod.rs
+++ b/espflash/src/cli/mod.rs
@@ -139,7 +139,7 @@ pub struct FlashArgs {
     #[arg(long)]
     pub ram: bool,
     /// Logging format.
-    #[arg(long, short = 'f', requires = "monitor")]
+    #[arg(long, short = 'f', default_value = "serial", requires = "monitor")]
     pub log_format: LogFormat,
 }
 
@@ -193,7 +193,7 @@ pub struct MonitorArgs {
     #[clap(flatten)]
     connect_args: ConnectArgs,
     /// Logging format.
-    #[arg(long, short = 'f')]
+    #[arg(long, short = 'f', default_value = "serial")]
     pub log_format: LogFormat,
 }
 

--- a/espflash/src/cli/mod.rs
+++ b/espflash/src/cli/mod.rs
@@ -24,7 +24,7 @@ use log::{debug, info};
 use miette::{IntoDiagnostic, Result, WrapErr};
 use serialport::{SerialPortType, UsbPortInfo};
 
-use self::{config::Config, monitor::monitor, serial::get_serial_port_info};
+use self::{config::Config, monitor::monitor_with, serial::get_serial_port_info};
 use crate::{
     elf::ElfFirmwareImage,
     error::{Error, MissingPartition, MissingPartitionTable},
@@ -134,6 +134,9 @@ pub struct FlashArgs {
     /// Load the application to RAM instead of Flash
     #[arg(long)]
     pub ram: bool,
+    /// Defmt
+    #[arg(long, short = 'd', requires = "monitor")]
+    pub defmt: bool,
 }
 
 /// Operations for partitions tables
@@ -185,6 +188,9 @@ pub struct MonitorArgs {
     /// Connection configuration
     #[clap(flatten)]
     connect_args: ConnectArgs,
+    /// Defmt
+    #[arg(long, short = 'd')]
+    defmt: bool,
 }
 
 /// Select a serial port and establish a connection with a target device
@@ -291,11 +297,12 @@ pub fn serial_monitor(args: MonitorArgs, config: &Config) -> Result<()> {
         115_200
     };
 
-    monitor(
+    monitor_with(
         flasher.into_interface(),
         elf.as_deref(),
         pid,
         args.connect_args.baud.unwrap_or(default_baud),
+        args.defmt,
     )
     .into_diagnostic()?;
 

--- a/espflash/src/cli/monitor/parser/mod.rs
+++ b/espflash/src/cli/monitor/parser/mod.rs
@@ -1,4 +1,3 @@
-#[cfg(feature = "defmt")]
 pub mod esp_defmt;
 pub mod serial;
 


### PR DESCRIPTION
~Add `-d/--defmt` flag for `monitor` and `flash` subcommands.~
Add `-f/--log-format` argument for `monitor` and `flash` subcommands.

cc @bugadani since you added this feature

~Draft until properly tested.~ Did some testing and seems to be working fine! 

We still need to figure out if we want opt-in or opt-out of defmt