### PR TITLE
Update log-format flag and merge monitor methods

### DIFF
--- a/cargo-espflash/src/main.rs
+++ b/cargo-espflash/src/main.rs
@@ -9,10 +9,10 @@ use clap::{Args, CommandFactory, Parser, Subcommand};
 use espflash::{
     cli::{
         self, board_info, completions, config::Config, connect, erase_flash, erase_partitions,
-        erase_region, flash_elf_image, monitor::monitor_with, parse_partition_table,
-        partition_table, print_board_info, save_elf_as_image, serial_monitor, CompletionsArgs,
-        ConnectArgs, EraseFlashArgs, EraseRegionArgs, EspflashProgress, FlashConfigArgs,
-        MonitorArgs, PartitionTableArgs,
+        erase_region, flash_elf_image, monitor::monitor, parse_partition_table, partition_table,
+        print_board_info, save_elf_as_image, serial_monitor, CompletionsArgs, ConnectArgs,
+        EraseFlashArgs, EraseRegionArgs, EspflashProgress, FlashConfigArgs, MonitorArgs,
+        PartitionTableArgs,
     },
     error::Error as EspflashError,
     image_format::ImageFormatKind,
@@ -342,7 +342,7 @@ fn flash(args: FlashArgs, config: &Config) -> Result<()> {
                 115_200
             };
 
-        monitor_with(
+        monitor(
             flasher.into_interface(),
             Some(&elf_data),
             pid,

--- a/espflash/src/bin/espflash.rs
+++ b/espflash/src/bin/espflash.rs
@@ -8,7 +8,7 @@ use clap::{Args, CommandFactory, Parser, Subcommand};
 use espflash::{
     cli::{
         self, board_info, completions, config::Config, connect, erase_flash, erase_partitions,
-        erase_region, flash_elf_image, monitor::monitor_with, parse_partition_table, parse_uint32,
+        erase_region, flash_elf_image, monitor::monitor, parse_partition_table, parse_uint32,
         partition_table, print_board_info, save_elf_as_image, serial_monitor, CompletionsArgs,
         ConnectArgs, EraseFlashArgs, EraseRegionArgs, EspflashProgress, FlashConfigArgs,
         MonitorArgs, PartitionTableArgs,
@@ -264,7 +264,7 @@ fn flash(args: FlashArgs, config: &Config) -> Result<()> {
                 115_200
             };
 
-        monitor_with(
+        monitor(
             flasher.into_interface(),
             Some(&elf_data),
             pid,

--- a/espflash/src/cli/mod.rs
+++ b/espflash/src/cli/mod.rs
@@ -142,7 +142,7 @@ pub struct FlashArgs {
     #[arg(long)]
     pub ram: bool,
     /// Logging format.
-    #[arg(long, short = 'f', default_value = "serial", requires = "monitor")]
+    #[arg(long, short = 'L', default_value = "serial", requires = "monitor")]
     pub log_format: LogFormat,
 }
 
@@ -199,7 +199,7 @@ pub struct MonitorArgs {
     #[clap(flatten)]
     connect_args: ConnectArgs,
     /// Logging format.
-    #[arg(long, short = 'f', default_value = "serial")]
+    #[arg(long, short = 'L', default_value = "serial")]
     pub log_format: LogFormat,
 }
 

--- a/espflash/src/cli/mod.rs
+++ b/espflash/src/cli/mod.rs
@@ -26,7 +26,7 @@ use serialport::{SerialPortType, UsbPortInfo};
 
 use self::{
     config::Config,
-    monitor::{monitor_with, LogFormat},
+    monitor::{monitor, LogFormat},
     serial::get_serial_port_info,
 };
 use crate::{
@@ -307,7 +307,7 @@ pub fn serial_monitor(args: MonitorArgs, config: &Config) -> Result<()> {
         115_200
     };
 
-    monitor_with(
+    monitor(
         flasher.into_interface(),
         elf.as_deref(),
         pid,

--- a/espflash/src/cli/monitor/mod.rs
+++ b/espflash/src/cli/monitor/mod.rs
@@ -63,18 +63,8 @@ impl Drop for RawModeGuard {
     }
 }
 
-/// Open a serial monitor on the given interface
-pub fn monitor(
-    serial: Interface,
-    elf: Option<&[u8]>,
-    pid: u16,
-    baud: u32,
-) -> serialport::Result<()> {
-    monitor_with(serial, elf, pid, baud, LogFormat::Serial)
-}
-
 /// Open a serial monitor on the given interface, using the given input parser.
-pub fn monitor_with(
+pub fn monitor(
     mut serial: Interface,
     elf: Option<&[u8]>,
     pid: u16,


### PR DESCRIPTION
- The flag `f` was already being used by [`flash-freq`](https://github.com/esp-rs/espflash/blob/39fbdacebaaa74a88e5d447a118f188be7d2e9bb/espflash/src/cli/mod.rs#L104), updated log-format to use `L`
- Since the PR was intended to be released in a minor version, we created `monitor_with` method to avoid changing `monitor`, now it can be modified