### PR TITLE
Add `-c/--chip` argument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Added reset strategies (#487)
-
 - Read esp-println generated defmt messages (#466)
 - Add --target-app-partition argument to flash command (#461)
 - Add --confirm-port argument to flash command (#455)
+- Add --chip argument for flash and write-bin commands (#514)
 
 ### Fixed
 

--- a/espflash/src/cli/mod.rs
+++ b/espflash/src/cli/mod.rs
@@ -49,11 +49,14 @@ pub struct ConnectArgs {
     /// Baud rate at which to communicate with target device
     #[arg(short = 'b', long, env = "ESPFLASH_BAUD")]
     pub baud: Option<u32>,
+    /// Target device
+    #[arg(short = 'c', long)]
+    pub chip: Option<Chip>,
     /// Serial port connected to target device
     #[arg(short = 'p', long, env = "ESPFLASH_PORT")]
     pub port: Option<String>,
     /// Require confirmation before auto-connecting to a recognized device.
-    #[arg(short = 'c', long)]
+    #[arg(short = 'C', long)]
     pub confirm_port: bool,
     /// DTR pin to use for the internal UART hardware. Uses BCM numbering.
     #[cfg(feature = "raspberry")]
@@ -247,6 +250,7 @@ pub fn connect(args: &ConnectArgs, config: &Config) -> Result<Flasher> {
         port_info,
         args.baud,
         !args.no_stub,
+        args.chip,
     )?)
 }
 

--- a/espflash/src/cli/mod.rs
+++ b/espflash/src/cli/mod.rs
@@ -52,12 +52,15 @@ pub struct ConnectArgs {
     /// Target device
     #[arg(short = 'c', long)]
     pub chip: Option<Chip>,
-    /// Serial port connected to target device
-    #[arg(short = 'p', long, env = "ESPFLASH_PORT")]
-    pub port: Option<String>,
     /// Require confirmation before auto-connecting to a recognized device.
     #[arg(short = 'C', long)]
     pub confirm_port: bool,
+    /// Do not use the RAM stub for loading
+    #[arg(long)]
+    pub no_stub: bool,
+    /// Serial port connected to target device
+    #[arg(short = 'p', long, env = "ESPFLASH_PORT")]
+    pub port: Option<String>,
     /// DTR pin to use for the internal UART hardware. Uses BCM numbering.
     #[cfg(feature = "raspberry")]
     #[cfg_attr(feature = "raspberry", clap(long))]
@@ -66,9 +69,6 @@ pub struct ConnectArgs {
     #[cfg(feature = "raspberry")]
     #[cfg_attr(feature = "raspberry", clap(long))]
     pub rts: Option<u8>,
-    /// Do not use the RAM stub for loading
-    #[arg(long)]
-    pub no_stub: bool,
 }
 
 /// Generate completions for the given shell
@@ -92,11 +92,9 @@ pub struct EraseRegionArgs {
     /// Connection configuration
     #[clap(flatten)]
     pub connect_args: ConnectArgs,
-
     /// Offset to start erasing from
     #[arg(value_name = "OFFSET", value_parser = parse_uint32)]
     pub addr: u32,
-
     /// Size of the region to erase
     #[arg(value_name = "SIZE", value_parser = parse_uint32)]
     pub size: u32,
@@ -132,6 +130,9 @@ pub struct FlashArgs {
     /// Image format to flash
     #[arg(long, value_enum)]
     pub format: Option<ImageFormatKind>,
+    /// Logging format.
+    #[arg(long, short = 'L', default_value = "serial", requires = "monitor")]
+    pub log_format: LogFormat,
     /// Open a serial monitor after flashing
     #[arg(short = 'M', long)]
     pub monitor: bool,
@@ -147,9 +148,6 @@ pub struct FlashArgs {
     /// Load the application to RAM instead of Flash
     #[arg(long)]
     pub ram: bool,
-    /// Logging format.
-    #[arg(long, short = 'L', default_value = "serial", requires = "monitor")]
-    pub log_format: LogFormat,
 }
 
 /// Operations for partitions tables
@@ -198,12 +196,12 @@ pub struct SaveImageArgs {
 /// Open the serial monitor without flashing
 #[derive(Debug, Args)]
 pub struct MonitorArgs {
-    /// Optional file name of the ELF image to load the symbols from
-    #[arg(short = 'e', long, value_name = "FILE")]
-    elf: Option<PathBuf>,
     /// Connection configuration
     #[clap(flatten)]
     connect_args: ConnectArgs,
+    /// Optional file name of the ELF image to load the symbols from
+    #[arg(short = 'e', long, value_name = "FILE")]
+    elf: Option<PathBuf>,
     /// Logging format.
     #[arg(long, short = 'L', default_value = "serial")]
     pub log_format: LogFormat,

--- a/espflash/src/error.rs
+++ b/espflash/src/error.rs
@@ -39,6 +39,13 @@ pub enum Error {
     )]
     ChipDetectError(u32),
 
+    #[error("Chip provided ({0}) with `-c/--chip` does not match the detected chip ({1})")]
+    #[diagnostic(
+        code(espflash::chip_missmatch),
+        help("Ensure that the correct chip is selected, or remove the `-c/--chip` option to autodetect the chip")
+    )]
+    ChipMismatch(String, String),
+
     #[error("Supplied ELF image can not be run from RAM, as it includes segments mapped to ROM addresses")]
     #[diagnostic(
         code(espflash::not_ram_loadable),


### PR DESCRIPTION

When trying to build a C6 with and passing the `--chip esp32h2` arg: 
```
espflash/espflash on  feat/chip-arg [!?] is 📦 v3.0.0-dev via 🦀 v1.76.0-nightly took 7s 
❯ cargo r -r -- flash --monitor --chip esp32h2 esp32h2-app
   Compiling espflash v3.0.0-dev (/home/sergio/Documents/Espressif/forks/espflash/espflash)
    Finished release [optimized] target(s) in 6.84s
     Running `/home/sergio/Documents/Espressif/forks/espflash/target/release/espflash flash --monitor --chip esp32h2 esp32h2`
[2023-11-20T14:16:55Z INFO ] Serial port: '/dev/ttyUSB0'
[2023-11-20T14:16:55Z INFO ] Connecting...
Error: espflash::chip_missmatch

  × Chip provided (esp32h2) with `-c/--chip` does not match the detected chip (esp32c6)
  help: Ensure that the correct chip is selected, or remove the `-c/--chip` option to autodetect the chip
```