### PR TITLE
Require --elf arg for --log-format arg in monitor subcommand

### DIFF
--- a/espflash/src/cli/mod.rs
+++ b/espflash/src/cli/mod.rs
@@ -203,7 +203,7 @@ pub struct MonitorArgs {
     #[arg(short = 'e', long, value_name = "FILE")]
     elf: Option<PathBuf>,
     /// Logging format.
-    #[arg(long, short = 'L', default_value = "serial")]
+    #[arg(long, short = 'L', default_value = "serial", requires = "elf")]
     pub log_format: LogFormat,
 }
 


### PR DESCRIPTION
If we use `monitor --log-format defmt`  but don't provide the elf file, we won't be able to interpret the logs.