### PR TITLE
Flush buffer after writing command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed printing panic backtraces when using `esp-println` and `defmt` (#496)
 - Fixed defmt parsing when data is read in parts (#503)
 - Use partition table instead of hard-coded values for the location of partitions (#516)
+- Fixed a missed `flush` call that may be causing communication errors (#521)
 
 ### Changed
 

--- a/espflash/src/connection/mod.rs
+++ b/espflash/src/connection/mod.rs
@@ -4,7 +4,12 @@
 //! sending/decoding of commands, and provides higher-level operations with the
 //! device.
 
-use std::{io::BufWriter, iter::zip, thread::sleep, time::Duration};
+use std::{
+    io::{BufWriter, Write},
+    iter::zip,
+    thread::sleep,
+    time::Duration,
+};
 
 use binrw::{io::Cursor, BinRead, BinReaderExt};
 use log::debug;
@@ -207,6 +212,7 @@ impl Connection {
         let mut encoder = SlipEncoder::new(&mut writer)?;
         command.write(&mut encoder)?;
         encoder.finish()?;
+        writer.flush()?;
         Ok(())
     }
 


### PR DESCRIPTION
Dropping `BufWriter` flushes the internal buffers, but doesn't flush the inner stream. Calling `flush` directly does both _and_ also propagates any IO errors back to the caller.

May fix (or may not fix) issues like #450