### PR TITLE
Add `min_chip_rev` argument

### DIFF
--- a/cargo-espflash/src/main.rs
+++ b/cargo-espflash/src/main.rs
@@ -330,6 +330,7 @@ fn flash(args: FlashArgs, config: &Config) -> Result<()> {
             args.build_args.flash_config_args.flash_size,
             args.build_args.flash_config_args.flash_freq,
             args.flash_args.partition_table_offset,
+            args.flash_args.min_chip_rev,
         )?;
     }
 
@@ -557,6 +558,7 @@ fn save_image(args: SaveImageArgs) -> Result<()> {
 
     save_elf_as_image(
         args.save_image_args.chip,
+        args.save_image_args.min_chip_rev,
         &elf_data,
         args.save_image_args.file,
         args.format.or(metadata.format),

--- a/cargo-espflash/src/main.rs
+++ b/cargo-espflash/src/main.rs
@@ -259,6 +259,7 @@ fn flash(args: FlashArgs, config: &Config) -> Result<()> {
     let cargo_config = CargoConfig::load(&metadata.workspace_root, &metadata.package_root);
 
     let mut flasher = connect(&args.connect_args, config)?;
+    flasher.verify_minimum_revision(args.flash_args.min_chip_rev)?;
 
     // If the user has provided a flash size via a command-line argument, we'll
     // override the detected (or default) value with this.

--- a/espflash/src/bin/espflash.rs
+++ b/espflash/src/bin/espflash.rs
@@ -252,6 +252,7 @@ fn flash(args: FlashArgs, config: &Config) -> Result<()> {
             args.flash_config_args.flash_size,
             args.flash_config_args.flash_freq,
             args.flash_args.partition_table_offset,
+            args.flash_args.min_chip_rev,
         )?;
     }
 
@@ -300,6 +301,7 @@ fn save_image(args: SaveImageArgs) -> Result<()> {
 
     save_elf_as_image(
         args.save_image_args.chip,
+        args.save_image_args.min_chip_rev,
         &elf_data,
         args.save_image_args.file,
         args.format,

--- a/espflash/src/bin/espflash.rs
+++ b/espflash/src/bin/espflash.rs
@@ -197,6 +197,7 @@ pub fn erase_parts(args: ErasePartsArgs, config: &Config) -> Result<()> {
 
 fn flash(args: FlashArgs, config: &Config) -> Result<()> {
     let mut flasher = connect(&args.connect_args, config)?;
+    flasher.verify_minimum_revision(args.flash_args.min_chip_rev)?;
 
     // If the user has provided a flash size via a command-line argument, we'll
     // override the detected (or default) value with this.

--- a/espflash/src/cli/mod.rs
+++ b/espflash/src/cli/mod.rs
@@ -133,6 +133,9 @@ pub struct FlashArgs {
     /// Logging format.
     #[arg(long, short = 'L', default_value = "serial", requires = "monitor")]
     pub log_format: LogFormat,
+    /// Minimum chip revision supported by image, in format: major * 100 + minor
+    #[arg(long, default_value = "0")]
+    pub min_chip_rev: u16,
     /// Open a serial monitor after flashing
     #[arg(short = 'M', long)]
     pub monitor: bool,
@@ -182,6 +185,9 @@ pub struct SaveImageArgs {
     pub chip: Chip,
     /// File name to save the generated image to
     pub file: PathBuf,
+    /// Minimum chip revision supported by image, in format: major * 100 + minor
+    #[arg(long, default_value = "0")]
+    pub min_chip_rev: u16,
     /// Boolean flag to merge binaries into single binary
     #[arg(long)]
     pub merge: bool,

--- a/espflash/src/cli/mod.rs
+++ b/espflash/src/cli/mod.rs
@@ -336,6 +336,7 @@ pub fn serial_monitor(args: MonitorArgs, config: &Config) -> Result<()> {
 /// Convert the provided firmware image from ELF to binary
 pub fn save_elf_as_image(
     chip: Chip,
+    min_rev_full: u16,
     elf_data: &[u8],
     image_path: PathBuf,
     image_format: Option<ImageFormatKind>,
@@ -391,6 +392,7 @@ pub fn save_elf_as_image(
             target_app_partition,
             image_format,
             None,
+            min_rev_full,
             flash_mode,
             flash_size,
             flash_freq,
@@ -433,6 +435,7 @@ pub fn save_elf_as_image(
             None,
             image_format,
             None,
+            min_rev_full,
             flash_mode,
             flash_size,
             flash_freq,
@@ -551,6 +554,7 @@ pub fn flash_elf_image(
     flash_size: Option<FlashSize>,
     flash_freq: Option<FlashFrequency>,
     partition_table_offset: Option<u32>,
+    min_rev_full: u16,
 ) -> Result<()> {
     // If the '--bootloader' option is provided, load the binary file at the
     // specified path.
@@ -575,6 +579,7 @@ pub fn flash_elf_image(
         flash_size,
         flash_freq,
         partition_table_offset,
+        min_rev_full,
         Some(&mut EspflashProgress::default()),
     )?;
     info!("Flashing has completed!");

--- a/espflash/src/cli/mod.rs
+++ b/espflash/src/cli/mod.rs
@@ -133,7 +133,7 @@ pub struct FlashArgs {
     /// Logging format.
     #[arg(long, short = 'L', default_value = "serial", requires = "monitor")]
     pub log_format: LogFormat,
-    /// Minimum chip revision supported by image, in format: major * 100 + minor
+    /// Minimum chip revision supported by image, in format: major.minor
     #[arg(long, default_value = "0", value_parser = parse_chip_rev)]
     pub min_chip_rev: u16,
     /// Open a serial monitor after flashing
@@ -185,7 +185,7 @@ pub struct SaveImageArgs {
     pub chip: Chip,
     /// File name to save the generated image to
     pub file: PathBuf,
-    /// Minimum chip revision supported by image, in format: major * 100 + minor
+    /// Minimum chip revision supported by image, in format: major.minor
     #[arg(long, default_value = "0", value_parser = parse_chip_rev)]
     pub min_chip_rev: u16,
     /// Boolean flag to merge binaries into single binary

--- a/espflash/src/cli/mod.rs
+++ b/espflash/src/cli/mod.rs
@@ -134,7 +134,7 @@ pub struct FlashArgs {
     #[arg(long, short = 'L', default_value = "serial", requires = "monitor")]
     pub log_format: LogFormat,
     /// Minimum chip revision supported by image, in format: major.minor
-    #[arg(long, default_value = "0", value_parser = parse_chip_rev)]
+    #[arg(long, default_value = "0.0", value_parser = parse_chip_rev)]
     pub min_chip_rev: u16,
     /// Open a serial monitor after flashing
     #[arg(short = 'M', long)]
@@ -186,7 +186,7 @@ pub struct SaveImageArgs {
     /// File name to save the generated image to
     pub file: PathBuf,
     /// Minimum chip revision supported by image, in format: major.minor
-    #[arg(long, default_value = "0", value_parser = parse_chip_rev)]
+    #[arg(long, default_value = "0.0", value_parser = parse_chip_rev)]
     pub min_chip_rev: u16,
     /// Boolean flag to merge binaries into single binary
     #[arg(long)]

--- a/espflash/src/error.rs
+++ b/espflash/src/error.rs
@@ -138,6 +138,10 @@ pub enum Error {
         frequency: FlashFrequency,
     },
 
+    #[error("Minimum supported revision is {minimum}, connected device's revision is {found}")]
+    #[diagnostic(code(espflash::unsupported_chip_revision))]
+    UnsupportedChipRevision { minimum: u16, found: u16 },
+
     #[error("Error while connecting to device")]
     #[diagnostic(transparent)]
     Connection(#[source] ConnectionError),

--- a/espflash/src/error.rs
+++ b/espflash/src/error.rs
@@ -138,9 +138,20 @@ pub enum Error {
         frequency: FlashFrequency,
     },
 
-    #[error("Minimum supported revision is {minimum}, connected device's revision is {found}")]
+    #[error(
+        "Minimum supported revision is {major}.{minor}, connected device's revision is {found_major}.{found_minor}"
+    )]
     #[diagnostic(code(espflash::unsupported_chip_revision))]
-    UnsupportedChipRevision { minimum: u16, found: u16 },
+    UnsupportedChipRevision {
+        major: u16,
+        minor: u16,
+        found_major: u16,
+        found_minor: u16,
+    },
+
+    #[error("Failed to parse chip revision: {chip_rev}. Chip revision must be in the format `major.minor`")]
+    #[diagnostic(code(espflash::cli::parse_chip_rev_error))]
+    ParseChipRevError { chip_rev: String },
 
     #[error("Error while connecting to device")]
     #[diagnostic(transparent)]

--- a/espflash/src/flasher/mod.rs
+++ b/espflash/src/flasher/mod.rs
@@ -784,6 +784,7 @@ impl Flasher {
         flash_size: Option<FlashSize>,
         flash_freq: Option<FlashFrequency>,
         partition_table_offset: Option<u32>,
+        min_rev_full: u16,
         mut progress: Option<&mut dyn ProgressCallbacks>,
     ) -> Result<(), Error> {
         let image = ElfFirmwareImage::try_from(elf_data)?;
@@ -810,6 +811,7 @@ impl Flasher {
             target_app_partition,
             image_format,
             chip_revision,
+            min_rev_full,
             flash_mode,
             flash_size.or(Some(self.flash_size)),
             flash_freq,
@@ -872,6 +874,7 @@ impl Flasher {
         flash_size: Option<FlashSize>,
         flash_freq: Option<FlashFrequency>,
         partition_table_offset: Option<u32>,
+        min_rev_full: u16,
         progress: Option<&mut dyn ProgressCallbacks>,
     ) -> Result<(), Error> {
         self.load_elf_to_flash_with_format(
@@ -884,6 +887,7 @@ impl Flasher {
             flash_size,
             flash_freq,
             partition_table_offset,
+            min_rev_full,
             progress,
         )
     }

--- a/espflash/src/flasher/mod.rs
+++ b/espflash/src/flasher/mod.rs
@@ -951,6 +951,20 @@ impl Flasher {
         Ok(())
     }
 
+    pub fn verify_minimum_revision(&mut self, minimum: u16) -> Result<(), Error> {
+        let (major, minor) = self.chip.into_target().chip_revision(self.connection())?;
+        let revision = (major * 100 + minor) as u16;
+
+        if revision < minimum {
+            return Err(Error::UnsupportedChipRevision {
+                minimum,
+                found: revision,
+            });
+        }
+
+        Ok(())
+    }
+
     pub fn into_interface(self) -> Interface {
         self.connection.into_interface()
     }

--- a/espflash/src/flasher/mod.rs
+++ b/espflash/src/flasher/mod.rs
@@ -958,11 +958,12 @@ impl Flasher {
     pub fn verify_minimum_revision(&mut self, minimum: u16) -> Result<(), Error> {
         let (major, minor) = self.chip.into_target().chip_revision(self.connection())?;
         let revision = (major * 100 + minor) as u16;
-
         if revision < minimum {
             return Err(Error::UnsupportedChipRevision {
-                minimum,
-                found: revision,
+                major: minimum / 100,
+                minor: minimum % 100,
+                found_major: revision / 100,
+                found_minor: revision % 100,
             });
         }
 

--- a/espflash/src/image_format/idf_bootloader.rs
+++ b/espflash/src/image_format/idf_bootloader.rs
@@ -34,6 +34,7 @@ impl<'a> IdfBootloaderFormat<'a> {
     pub fn new(
         image: &'a dyn FirmwareImage<'a>,
         chip: Chip,
+        min_rev_full: u16,
         params: Esp32Params,
         partition_table: Option<PartitionTable>,
         target_app_partition: Option<String>,
@@ -80,6 +81,7 @@ impl<'a> IdfBootloaderFormat<'a> {
 
         header.wp_pin = WP_PIN_DISABLED;
         header.chip_id = params.chip_id;
+        header.min_chip_rev_full = min_rev_full;
         header.append_digest = 1;
 
         let mut data = bytes_of(&header).to_vec();
@@ -364,6 +366,7 @@ pub mod tests {
         let flash_image = IdfBootloaderFormat::new(
             &image,
             Chip::Esp32,
+            0,
             PARAMS,
             None,
             None,

--- a/espflash/src/image_format/mod.rs
+++ b/espflash/src/image_format/mod.rs
@@ -56,7 +56,7 @@ struct ImageHeader {
     gd_wp_drv: u8,
     chip_id: u16,
     min_rev: u8,
-    /// Minimal chip revision supported by image, in format: major * 100 + minor
+    /// Minimum chip revision supported by image, in format: major * 100 + minor
     min_chip_rev_full: u16,
     /// Maximal chip revision supported by image, in format: major * 100 + minor
     max_chip_rev_full: u16,

--- a/espflash/src/targets/esp32.rs
+++ b/espflash/src/targets/esp32.rs
@@ -158,6 +158,7 @@ impl Target for Esp32 {
         target_app_partition: Option<String>,
         image_format: Option<ImageFormatKind>,
         _chip_revision: Option<(u32, u32)>,
+        min_rev_full: u16,
         flash_mode: Option<FlashMode>,
         flash_size: Option<FlashSize>,
         flash_freq: Option<FlashFrequency>,
@@ -169,6 +170,7 @@ impl Target for Esp32 {
             ImageFormatKind::EspBootloader => Ok(Box::new(IdfBootloaderFormat::new(
                 image,
                 Chip::Esp32,
+                min_rev_full,
                 PARAMS,
                 partition_table,
                 target_app_partition,

--- a/espflash/src/targets/esp32c2.rs
+++ b/espflash/src/targets/esp32c2.rs
@@ -92,6 +92,7 @@ impl Target for Esp32c2 {
         target_app_partition: Option<String>,
         image_format: Option<ImageFormatKind>,
         _chip_revision: Option<(u32, u32)>,
+        min_rev_full: u16,
         flash_mode: Option<FlashMode>,
         flash_size: Option<FlashSize>,
         flash_freq: Option<FlashFrequency>,
@@ -103,6 +104,7 @@ impl Target for Esp32c2 {
             ImageFormatKind::EspBootloader => Ok(Box::new(IdfBootloaderFormat::new(
                 image,
                 Chip::Esp32c2,
+                min_rev_full,
                 PARAMS,
                 partition_table,
                 target_app_partition,

--- a/espflash/src/targets/esp32c3.rs
+++ b/espflash/src/targets/esp32c3.rs
@@ -79,6 +79,7 @@ impl Target for Esp32c3 {
         target_app_partition: Option<String>,
         image_format: Option<ImageFormatKind>,
         chip_revision: Option<(u32, u32)>,
+        min_rev_full: u16,
         flash_mode: Option<FlashMode>,
         flash_size: Option<FlashSize>,
         flash_freq: Option<FlashFrequency>,
@@ -90,6 +91,7 @@ impl Target for Esp32c3 {
             (ImageFormatKind::EspBootloader, _) => Ok(Box::new(IdfBootloaderFormat::new(
                 image,
                 Chip::Esp32c3,
+                min_rev_full,
                 PARAMS,
                 partition_table,
                 target_app_partition,

--- a/espflash/src/targets/esp32c6.rs
+++ b/espflash/src/targets/esp32c6.rs
@@ -76,6 +76,7 @@ impl Target for Esp32c6 {
         target_app_partition: Option<String>,
         image_format: Option<ImageFormatKind>,
         _chip_revision: Option<(u32, u32)>,
+        min_rev_full: u16,
         flash_mode: Option<FlashMode>,
         flash_size: Option<FlashSize>,
         flash_freq: Option<FlashFrequency>,
@@ -87,6 +88,7 @@ impl Target for Esp32c6 {
             ImageFormatKind::EspBootloader => Ok(Box::new(IdfBootloaderFormat::new(
                 image,
                 Chip::Esp32c6,
+                min_rev_full,
                 PARAMS,
                 partition_table,
                 target_app_partition,

--- a/espflash/src/targets/esp32h2.rs
+++ b/espflash/src/targets/esp32h2.rs
@@ -84,6 +84,7 @@ impl Target for Esp32h2 {
         target_app_partition: Option<String>,
         image_format: Option<ImageFormatKind>,
         _chip_revision: Option<(u32, u32)>,
+        min_rev_full: u16,
         flash_mode: Option<FlashMode>,
         flash_size: Option<FlashSize>,
         flash_freq: Option<FlashFrequency>,
@@ -95,6 +96,7 @@ impl Target for Esp32h2 {
             ImageFormatKind::EspBootloader => Ok(Box::new(IdfBootloaderFormat::new(
                 image,
                 Chip::Esp32h2,
+                min_rev_full,
                 PARAMS,
                 partition_table,
                 target_app_partition,

--- a/espflash/src/targets/esp32s2.rs
+++ b/espflash/src/targets/esp32s2.rs
@@ -144,6 +144,7 @@ impl Target for Esp32s2 {
         target_app_partition: Option<String>,
         image_format: Option<ImageFormatKind>,
         _chip_revision: Option<(u32, u32)>,
+        min_rev_full: u16,
         flash_mode: Option<FlashMode>,
         flash_size: Option<FlashSize>,
         flash_freq: Option<FlashFrequency>,
@@ -155,6 +156,7 @@ impl Target for Esp32s2 {
             ImageFormatKind::EspBootloader => Ok(Box::new(IdfBootloaderFormat::new(
                 image,
                 Chip::Esp32s2,
+                min_rev_full,
                 PARAMS,
                 partition_table,
                 target_app_partition,

--- a/espflash/src/targets/esp32s3.rs
+++ b/espflash/src/targets/esp32s3.rs
@@ -98,6 +98,7 @@ impl Target for Esp32s3 {
         target_app_partition: Option<String>,
         image_format: Option<ImageFormatKind>,
         _chip_revision: Option<(u32, u32)>,
+        min_rev_full: u16,
         flash_mode: Option<FlashMode>,
         flash_size: Option<FlashSize>,
         flash_freq: Option<FlashFrequency>,
@@ -109,6 +110,7 @@ impl Target for Esp32s3 {
             ImageFormatKind::EspBootloader => Ok(Box::new(IdfBootloaderFormat::new(
                 image,
                 Chip::Esp32s3,
+                min_rev_full,
                 PARAMS,
                 partition_table,
                 target_app_partition,

--- a/espflash/src/targets/esp8266.rs
+++ b/espflash/src/targets/esp8266.rs
@@ -78,6 +78,7 @@ impl Target for Esp8266 {
         _target_app_partition: Option<String>,
         image_format: Option<ImageFormatKind>,
         _chip_revision: Option<(u32, u32)>,
+        _min_rev_full: u16,
         flash_mode: Option<FlashMode>,
         flash_size: Option<FlashSize>,
         flash_freq: Option<FlashFrequency>,

--- a/espflash/src/targets/mod.rs
+++ b/espflash/src/targets/mod.rs
@@ -300,6 +300,7 @@ pub trait Target: ReadEFuse {
         target_app_partition: Option<String>,
         image_format: Option<ImageFormatKind>,
         chip_revision: Option<(u32, u32)>,
+        min_rev_full: u16,
         flash_mode: Option<FlashMode>,
         flash_size: Option<FlashSize>,
         flash_freq: Option<FlashFrequency>,


### PR DESCRIPTION
With these changes, when using the argument and specifying a `--min-chip-rev ` greater that the chip revision you get:
```
     Running `/home/sergio/Documents/Espressif/forks/espflash/target/release/espflash flash --min-chip-rev 5 esp32c3`
[2023-11-30T15:26:40Z INFO ] Serial port: '/dev/ttyACM0'
[2023-11-30T15:26:40Z INFO ] Connecting...
[2023-11-30T15:26:40Z INFO ] Using flash stub
[2023-11-30T15:26:40Z WARN ] Setting baud rate higher than 115,200 can cause issues
Error: espflash::unsupported_chip_revision

  × Minimum supported revision is 5, connected device's revision is 3

```