### PR TITLE
Add serialport feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add `checksum-md5` command (#536)
 - Add verify and skipping of unchanged flash regions - add `--no-verify` and `--no-skip` (#538)
 - Add --min-chip-rev argument to specify minimum chip revision (#252)
+- Add `serialport` feature. (#535)
 
 ### Fixed
 

--- a/espflash/Cargo.toml
+++ b/espflash/Cargo.toml
@@ -20,7 +20,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 [[bin]]
 name              = "espflash"
 path              = "./src/bin/espflash.rs"
-required-features = ["cli"]
+required-features = ["cli, serialport"]
 
 [dependencies]
 addr2line = { version = "0.21.0", optional = true }
@@ -49,7 +49,7 @@ parse_int = { version = "0.6.0", optional = true }
 regex = { version = "1.9.6", optional = true }
 rppal = { version = "0.14.1", optional = true }
 serde = { version = "1.0.188", features = ["derive"] }
-serialport = "4.2.2"
+serialport = { version = "4.2.2", optional = true }
 sha2 = "0.10.8"
 slip-codec = "0.3.4"
 strum = { version = "0.25.0", features = ["derive"] }
@@ -62,7 +62,7 @@ xmas-elf        = "0.9.0"
 libc = "0.2.101"
 
 [features]
-default = ["cli"]
+default = ["cli", "serialport"]
 cli = [
     "dep:addr2line",
     "dep:clap",
@@ -80,7 +80,9 @@ cli = [
     "dep:lazy_static",
     "dep:parse_int",
     "dep:regex",
+    "dep:serialport",
     "dep:update-informer",
 ]
+serialport = ["dep:serialport"]
 
 raspberry = ["dep:rppal"]

--- a/espflash/src/error.rs
+++ b/espflash/src/error.rs
@@ -194,6 +194,8 @@ impl From<io::Error> for Error {
     }
 }
 
+#[cfg(feature = "serialport")]
+#[cfg_attr(docsrs, doc(cfg(feature = "serialport")))]
 impl From<serialport::Error> for Error {
     fn from(err: serialport::Error) -> Self {
         Self::Connection(err.into())
@@ -251,6 +253,7 @@ pub enum ConnectionError {
     #[diagnostic(code(espflash::timeout))]
     Timeout(TimedOutCommand),
 
+    #[cfg(feature = "serialport")]
     #[error("IO error while using serial port: {0}")]
     #[diagnostic(code(espflash::serial_error))]
     Serial(#[source] serialport::Error),
@@ -262,6 +265,8 @@ impl From<io::Error> for ConnectionError {
     }
 }
 
+#[cfg(feature = "serialport")]
+#[cfg_attr(docsrs, doc(cfg(feature = "serialport")))]
 impl From<serialport::Error> for ConnectionError {
     fn from(err: serialport::Error) -> Self {
         use serialport::ErrorKind;
@@ -544,6 +549,8 @@ impl<T> ResultExt for Result<T, Error> {
     }
 }
 
+#[cfg(feature = "serialport")]
+#[cfg_attr(docsrs, doc(cfg(feature = "serialport")))]
 fn from_error_kind<E>(kind: io::ErrorKind, err: E) -> ConnectionError
 where
     E: Into<serialport::Error>,

--- a/espflash/src/lib.rs
+++ b/espflash/src/lib.rs
@@ -51,11 +51,17 @@
 #[cfg_attr(docsrs, doc(cfg(feature = "cli")))]
 pub mod cli;
 pub mod command;
+#[cfg(feature = "serialport")]
+#[cfg_attr(docsrs, doc(cfg(feature = "serialport")))]
 pub mod connection;
 pub mod elf;
 pub mod error;
+#[cfg(feature = "serialport")]
+#[cfg_attr(docsrs, doc(cfg(feature = "serialport")))]
 pub mod flasher;
 pub mod image_format;
+#[cfg(feature = "serialport")]
+#[cfg_attr(docsrs, doc(cfg(feature = "serialport")))]
 pub mod interface;
 pub mod targets;
 


### PR DESCRIPTION
This tries to avoid always pulling `libudev`, see #500. Not sure if it is the best approach, though.