### PR TITLE
Add `checksum-md5` command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add --chip argument for flash and write-bin commands (#514)
 - Add --partition-table-offset argument for specifying the partition table offset (#516)
 - Add `Serialize` and `Deserialize` to `FlashFrequency`, `FlashMode` and `FlashSize`. (#528)
+- Add `checksum-md5` command (#536)
 
 ### Fixed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -126,12 +126,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bddcadddf5e9015d310179a59bb28c4d4b9920ad0f11e8e14dbadf654890c9a6"
 
 [[package]]
-name = "array-init"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d62b7694a562cdf5a74227903507c56ab2cc8bdd1f781ed5cb4cf9c9f810bfc"
-
-[[package]]
 name = "arrayvec"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -193,30 +187,6 @@ name = "base64ct"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
-
-[[package]]
-name = "binrw"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e8318fda24dc135cdd838f57a2b5ccb6e8f04ff6b6c65528c4bd9b5fcdc5cf6"
-dependencies = [
- "array-init",
- "binrw_derive",
- "bytemuck",
-]
-
-[[package]]
-name = "binrw_derive"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db0832bed83248115532dfb25af54fae1c83d67a2e4e3e2f591c13062e372e7e"
-dependencies = [
- "either",
- "owo-colors",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
 
 [[package]]
 name = "bitflags"
@@ -1099,7 +1069,6 @@ version = "3.0.0-dev"
 dependencies = [
  "addr2line",
  "base64",
- "binrw",
  "bytemuck",
  "clap",
  "clap_complete",

--- a/cargo-espflash/src/main.rs
+++ b/cargo-espflash/src/main.rs
@@ -8,11 +8,11 @@ use cargo_metadata::Message;
 use clap::{Args, CommandFactory, Parser, Subcommand};
 use espflash::{
     cli::{
-        self, board_info, completions, config::Config, connect, erase_flash, erase_partitions,
-        erase_region, flash_elf_image, monitor::monitor, parse_partition_table, partition_table,
-        print_board_info, save_elf_as_image, serial_monitor, CompletionsArgs, ConnectArgs,
-        EraseFlashArgs, EraseRegionArgs, EspflashProgress, FlashConfigArgs, MonitorArgs,
-        PartitionTableArgs,
+        self, board_info, checksum_md5, completions, config::Config, connect, erase_flash,
+        erase_partitions, erase_region, flash_elf_image, monitor::monitor, parse_partition_table,
+        partition_table, print_board_info, save_elf_as_image, serial_monitor, ChecksumMd5Args,
+        CompletionsArgs, ConnectArgs, EraseFlashArgs, EraseRegionArgs, EspflashProgress,
+        FlashConfigArgs, MonitorArgs, PartitionTableArgs,
     },
     error::Error as EspflashError,
     image_format::ImageFormatKind,
@@ -106,6 +106,8 @@ enum Commands {
     /// Otherwise, each segment will be saved as individual binaries, prefixed
     /// with their intended addresses in flash.
     SaveImage(SaveImageArgs),
+    /// Calculate the MD5 checksum of the given region
+    ChecksumMd5(ChecksumMd5Args),
 }
 
 #[derive(Debug, Args)]
@@ -217,6 +219,7 @@ fn main() -> Result<()> {
         Commands::Monitor(args) => serial_monitor(args, &config),
         Commands::PartitionTable(args) => partition_table(args),
         Commands::SaveImage(args) => save_image(args),
+        Commands::ChecksumMd5(args) => checksum_md5(&args, &config),
     }
 }
 

--- a/espflash/Cargo.toml
+++ b/espflash/Cargo.toml
@@ -25,7 +25,6 @@ required-features = ["cli"]
 [dependencies]
 addr2line = { version = "0.21.0", optional = true }
 base64 = "0.21.4"
-binrw = "0.12.0"
 bytemuck = { version = "1.14.0", features = ["derive"] }
 clap = { version = "4.4.6", features = ["derive", "env", "wrap_help"], optional = true }
 clap_complete = { version = "4.4.3", optional = true }

--- a/espflash/src/bin/espflash.rs
+++ b/espflash/src/bin/espflash.rs
@@ -1,18 +1,17 @@
 use std::{
     fs::{self, File},
     io::Read,
-    num::ParseIntError,
     path::PathBuf,
 };
 
 use clap::{Args, CommandFactory, Parser, Subcommand};
 use espflash::{
     cli::{
-        self, board_info, completions, config::Config, connect, erase_flash, erase_partitions,
-        erase_region, flash_elf_image, monitor::monitor, parse_partition_table, parse_uint32,
-        partition_table, print_board_info, save_elf_as_image, serial_monitor, CompletionsArgs,
-        ConnectArgs, EraseFlashArgs, EraseRegionArgs, EspflashProgress, FlashConfigArgs,
-        MonitorArgs, PartitionTableArgs,
+        self, board_info, checksum_md5, completions, config::Config, connect, erase_flash,
+        erase_partitions, erase_region, flash_elf_image, monitor::monitor, parse_partition_table,
+        parse_uint32, partition_table, print_board_info, save_elf_as_image, serial_monitor,
+        ChecksumMd5Args, CompletionsArgs, ConnectArgs, EraseFlashArgs, EraseRegionArgs,
+        EspflashProgress, FlashConfigArgs, MonitorArgs, PartitionTableArgs,
     },
     error::Error,
     image_format::ImageFormatKind,
@@ -147,24 +146,6 @@ struct WriteBinArgs {
     /// Connection configuration
     #[clap(flatten)]
     connect_args: ConnectArgs,
-}
-
-#[derive(Debug, Args)]
-#[non_exhaustive]
-struct ChecksumMd5Args {
-    /// Start address
-    #[clap(short, long, value_parser=parse_u32)]
-    address: u32,
-    /// Length
-    #[clap(short, long, value_parser=parse_u32)]
-    length: u32,
-    /// Connection configuration
-    #[clap(flatten)]
-    connect_args: ConnectArgs,
-}
-
-pub fn parse_u32(input: &str) -> Result<u32, ParseIntError> {
-    parse_int::parse(input)
 }
 
 fn main() -> Result<()> {
@@ -353,16 +334,6 @@ fn write_bin(args: WriteBinArgs, config: &Config) -> Result<()> {
     f.read_to_end(&mut buffer).into_diagnostic()?;
 
     flasher.write_bin_to_flash(args.addr, &buffer, Some(&mut EspflashProgress::default()))?;
-
-    Ok(())
-}
-
-/// Connect to a target device and calculate the checksum of the given region
-fn checksum_md5(args: &ChecksumMd5Args, config: &Config) -> Result<()> {
-    let mut flasher = connect(&args.connect_args, config)?;
-
-    let checksum = flasher.checksum_md5(args.address, args.length)?;
-    println!("0x{:x}", checksum);
 
     Ok(())
 }

--- a/espflash/src/bin/espflash.rs
+++ b/espflash/src/bin/espflash.rs
@@ -8,11 +8,11 @@ use std::{
 use clap::{Args, CommandFactory, Parser, Subcommand};
 use espflash::{
     cli::{
-        self, board_info, completions, config::Config, connect, erase_flash,
-        erase_partitions, erase_region, flash_elf_image, monitor::monitor, parse_partition_table,
-        parse_uint32, partition_table, print_board_info, save_elf_as_image, serial_monitor,
-        CompletionsArgs, ConnectArgs, EraseFlashArgs, EraseRegionArgs, EspflashProgress,
-        FlashConfigArgs, MonitorArgs, PartitionTableArgs,
+        self, board_info, completions, config::Config, connect, erase_flash, erase_partitions,
+        erase_region, flash_elf_image, monitor::monitor, parse_partition_table, parse_uint32,
+        partition_table, print_board_info, save_elf_as_image, serial_monitor, CompletionsArgs,
+        ConnectArgs, EraseFlashArgs, EraseRegionArgs, EspflashProgress, FlashConfigArgs,
+        MonitorArgs, PartitionTableArgs,
     },
     error::Error,
     image_format::ImageFormatKind,

--- a/espflash/src/bin/espflash.rs
+++ b/espflash/src/bin/espflash.rs
@@ -1,17 +1,18 @@
 use std::{
     fs::{self, File},
     io::Read,
+    num::ParseIntError,
     path::PathBuf,
 };
 
 use clap::{Args, CommandFactory, Parser, Subcommand};
 use espflash::{
     cli::{
-        self, board_info, completions, config::Config, connect, erase_flash, erase_partitions,
-        erase_region, flash_elf_image, monitor::monitor, parse_partition_table, parse_uint32,
-        partition_table, print_board_info, save_elf_as_image, serial_monitor, CompletionsArgs,
-        ConnectArgs, EraseFlashArgs, EraseRegionArgs, EspflashProgress, FlashConfigArgs,
-        MonitorArgs, PartitionTableArgs,
+        self, board_info, completions, config::Config, connect, erase_flash,
+        erase_partitions, erase_region, flash_elf_image, monitor::monitor, parse_partition_table,
+        parse_uint32, partition_table, print_board_info, save_elf_as_image, serial_monitor,
+        CompletionsArgs, ConnectArgs, EraseFlashArgs, EraseRegionArgs, EspflashProgress,
+        FlashConfigArgs, MonitorArgs, PartitionTableArgs,
     },
     error::Error,
     image_format::ImageFormatKind,
@@ -83,6 +84,8 @@ enum Commands {
     SaveImage(SaveImageArgs),
     /// Write a binary file to a specific address in a target device's flash
     WriteBin(WriteBinArgs),
+    /// Calculate the MD5 checksum of the given region
+    ChecksumMd5(ChecksumMd5Args),
 }
 
 /// Erase named partitions based on provided partition table
@@ -146,6 +149,24 @@ struct WriteBinArgs {
     connect_args: ConnectArgs,
 }
 
+#[derive(Debug, Args)]
+#[non_exhaustive]
+struct ChecksumMd5Args {
+    /// Start address
+    #[clap(short, long, value_parser=parse_u32)]
+    address: u32,
+    /// Length
+    #[clap(short, long, value_parser=parse_u32)]
+    length: u32,
+    /// Connection configuration
+    #[clap(flatten)]
+    connect_args: ConnectArgs,
+}
+
+pub fn parse_u32(input: &str) -> Result<u32, ParseIntError> {
+    parse_int::parse(input)
+}
+
 fn main() -> Result<()> {
     miette::set_panic_hook();
     initialize_logger(LevelFilter::Info);
@@ -176,6 +197,7 @@ fn main() -> Result<()> {
         Commands::PartitionTable(args) => partition_table(args),
         Commands::SaveImage(args) => save_image(args),
         Commands::WriteBin(args) => write_bin(args, &config),
+        Commands::ChecksumMd5(args) => checksum_md5(&args, &config),
     }
 }
 
@@ -331,6 +353,16 @@ fn write_bin(args: WriteBinArgs, config: &Config) -> Result<()> {
     f.read_to_end(&mut buffer).into_diagnostic()?;
 
     flasher.write_bin_to_flash(args.addr, &buffer, Some(&mut EspflashProgress::default()))?;
+
+    Ok(())
+}
+
+/// Connect to a target device and calculate the checksum of the given region
+fn checksum_md5(args: &ChecksumMd5Args, config: &Config) -> Result<()> {
+    let mut flasher = connect(&args.connect_args, config)?;
+
+    let checksum = flasher.checksum_md5(args.address, args.length)?;
+    println!("0x{:x}", checksum);
 
     Ok(())
 }

--- a/espflash/src/cli/mod.rs
+++ b/espflash/src/cli/mod.rs
@@ -231,6 +231,24 @@ pub struct MonitorArgs {
     pub log_format: LogFormat,
 }
 
+#[derive(Debug, Args)]
+#[non_exhaustive]
+pub struct ChecksumMd5Args {
+    /// Start address
+    #[clap(short, long, value_parser=parse_u32)]
+    address: u32,
+    /// Length
+    #[clap(short, long, value_parser=parse_u32)]
+    length: u32,
+    /// Connection configuration
+    #[clap(flatten)]
+    connect_args: ConnectArgs,
+}
+
+pub fn parse_u32(input: &str) -> Result<u32, ParseIntError> {
+    parse_int::parse(input)
+}
+
 /// Select a serial port and establish a connection with a target device
 pub fn connect(args: &ConnectArgs, config: &Config) -> Result<Flasher> {
     let port_info = get_serial_port_info(args, config)?;
@@ -280,6 +298,16 @@ pub fn connect(args: &ConnectArgs, config: &Config) -> Result<Flasher> {
 pub fn board_info(args: &ConnectArgs, config: &Config) -> Result<()> {
     let mut flasher = connect(args, config)?;
     print_board_info(&mut flasher)?;
+
+    Ok(())
+}
+
+/// Connect to a target device and calculate the checksum of the given region
+pub fn checksum_md5(args: &ChecksumMd5Args, config: &Config) -> Result<()> {
+    let mut flasher = connect(&args.connect_args, config)?;
+
+    let checksum = flasher.checksum_md5(args.address, args.length)?;
+    println!("0x{:x}", checksum);
 
     Ok(())
 }

--- a/espflash/src/command.rs
+++ b/espflash/src/command.rs
@@ -14,6 +14,7 @@ const ERASE_CHIP_TIMEOUT: Duration = Duration::from_secs(120);
 const MEM_END_TIMEOUT: Duration = Duration::from_millis(50);
 const SYNC_TIMEOUT: Duration = Duration::from_millis(100);
 const FLASH_DEFLATE_END_TIMEOUT: Duration = Duration::from_secs(10);
+const FLASH_MD5_TIMEOUT: Duration = Duration::from_secs(8);
 
 /// Types of commands that can be sent to a target device
 #[derive(Copy, Clone, Debug, Display)]
@@ -51,6 +52,7 @@ impl CommandType {
             CommandType::Sync => SYNC_TIMEOUT,
             CommandType::EraseFlash => ERASE_CHIP_TIMEOUT,
             CommandType::FlashDeflateEnd => FLASH_DEFLATE_END_TIMEOUT,
+            CommandType::FlashMd5 => FLASH_MD5_TIMEOUT,
             _ => DEFAULT_TIMEOUT,
         }
     }

--- a/espflash/src/command.rs
+++ b/espflash/src/command.rs
@@ -162,7 +162,7 @@ pub enum Command<'a> {
     FlashMd5 {
         offset: u32,
         size: u32,
-    }
+    },
 }
 
 impl<'a> Command<'a> {
@@ -376,7 +376,7 @@ impl<'a> Command<'a> {
                 writer.write_all(&size.to_le_bytes())?;
                 writer.write_all(&(0u32.to_le_bytes()))?;
                 writer.write_all(&(0u32.to_le_bytes()))?;
-            },
+            }
         };
         Ok(())
     }

--- a/espflash/src/command.rs
+++ b/espflash/src/command.rs
@@ -159,6 +159,10 @@ pub enum Command<'a> {
         offset: u32,
         size: u32,
     },
+    FlashMd5 {
+        offset: u32,
+        size: u32,
+    }
 }
 
 impl<'a> Command<'a> {
@@ -184,6 +188,7 @@ impl<'a> Command<'a> {
             Command::FlashDetect => CommandType::FlashDetect,
             Command::EraseFlash { .. } => CommandType::EraseFlash,
             Command::EraseRegion { .. } => CommandType::EraseRegion,
+            Command::FlashMd5 { .. } => CommandType::FlashMd5,
         }
     }
 
@@ -361,6 +366,17 @@ impl<'a> Command<'a> {
                 writer.write_all(&offset.to_le_bytes())?;
                 writer.write_all(&size.to_le_bytes())?;
             }
+            Command::FlashMd5 { offset, size } => {
+                // length
+                writer.write_all(&(16u16.to_le_bytes()))?;
+                // checksum
+                writer.write_all(&(0u32.to_le_bytes()))?;
+                // data
+                writer.write_all(&offset.to_le_bytes())?;
+                writer.write_all(&size.to_le_bytes())?;
+                writer.write_all(&(0u32.to_le_bytes()))?;
+                writer.write_all(&(0u32.to_le_bytes()))?;
+            },
         };
         Ok(())
     }

--- a/espflash/src/connection/mod.rs
+++ b/espflash/src/connection/mod.rs
@@ -261,7 +261,7 @@ impl Connection {
                     resp: response[0],
                     return_op: response[1],
                     return_length: u16::from_le_bytes(response[2..][..2].try_into().unwrap()),
-                    value: value,
+                    value,
                     error: response[response.len() - status_len],
                     status: response[response.len() - status_len + 1],
                 };

--- a/espflash/src/connection/mod.rs
+++ b/espflash/src/connection/mod.rs
@@ -225,7 +225,13 @@ impl Connection {
                 // here is what esptool does: https://github.com/espressif/esptool/blob/master/esptool/loader.py#L458
                 // from esptool: things are a bit weird here, bear with us
 
-                // we rely on the known and expected response sizes
+                // we rely on the known and expected response sizes which should be fine for now - if that changes we need to pass the command type
+                // we are parsing the response for
+                // for most commands the response length is 10 (for the stub) or 12 (for ROM code)
+                // the MD5 command response is 44 for ROM loader, 26 for the stub
+                // see https://docs.espressif.com/projects/esptool/en/latest/esp32/advanced-topics/serial-protocol.html?highlight=md5#response-packet
+                // see https://docs.espressif.com/projects/esptool/en/latest/esp32/advanced-topics/serial-protocol.html?highlight=md5#status-bytes
+                // see https://docs.espressif.com/projects/esptool/en/latest/esp32/advanced-topics/serial-protocol.html?highlight=md5#verifying-uploaded-data
                 let status_len = if response.len() == 10 || response.len() == 26 {
                     2
                 } else {

--- a/espflash/src/error.rs
+++ b/espflash/src/error.rs
@@ -179,16 +179,13 @@ pub enum Error {
     #[error(transparent)]
     #[diagnostic(transparent)]
     Defmt(#[from] DefmtError),
+
+    #[error("Internal Error")]
+    InternalError,
 }
 
 impl From<io::Error> for Error {
     fn from(err: io::Error) -> Self {
-        Self::Connection(err.into())
-    }
-}
-
-impl From<binrw::Error> for Error {
-    fn from(err: binrw::Error) -> Self {
         Self::Connection(err.into())
     }
 }
@@ -258,15 +255,6 @@ pub enum ConnectionError {
 impl From<io::Error> for ConnectionError {
     fn from(err: io::Error) -> Self {
         from_error_kind(err.kind(), err)
-    }
-}
-
-impl From<binrw::Error> for ConnectionError {
-    fn from(err: binrw::Error) -> Self {
-        match err {
-            binrw::Error::Io(e) => ConnectionError::from(e),
-            _ => unreachable!(),
-        }
     }
 }
 

--- a/espflash/src/flasher/mod.rs
+++ b/espflash/src/flasher/mod.rs
@@ -891,11 +891,14 @@ impl Flasher {
     /// Get MD5 of region
     pub fn checksum_md5(&mut self, addr: u32, length: u32) -> Result<u128, Error> {
         self.connection
-            .command(crate::command::Command::FlashMd5 {
-                offset: addr,
-                size: length,
-            })?
-            .try_into()
+            .with_timeout(CommandType::FlashMd5.timeout(), |connection| {
+                connection
+                    .command(crate::command::Command::FlashMd5 {
+                        offset: addr,
+                        size: length,
+                    })?
+                    .try_into()
+            })
     }
 
     /// Load an ELF image to flash and execute it

--- a/espflash/src/flasher/mod.rs
+++ b/espflash/src/flasher/mod.rs
@@ -890,13 +890,12 @@ impl Flasher {
 
     /// Get MD5 of region
     pub fn checksum_md5(&mut self, addr: u32, length: u32) -> Result<u128, Error> {
-        Ok(self
-            .connection
+        self.connection
             .command(crate::command::Command::FlashMd5 {
                 offset: addr,
                 size: length,
             })?
-            .try_into()?)
+            .try_into()
     }
 
     /// Load an ELF image to flash and execute it

--- a/espflash/src/flasher/mod.rs
+++ b/espflash/src/flasher/mod.rs
@@ -888,6 +888,17 @@ impl Flasher {
         Ok(())
     }
 
+    /// Get MD5 of region
+    pub fn checksum_md5(&mut self, addr: u32, length: u32) -> Result<u128, Error> {
+        Ok(self
+            .connection
+            .command(crate::command::Command::FlashMd5 {
+                offset: addr,
+                size: length,
+            })?
+            .try_into()?)
+    }
+
     /// Load an ELF image to flash and execute it
     pub fn load_elf_to_flash(
         &mut self,


### PR DESCRIPTION
This adds a `checksum-md5` command to espflash.

e.g.
```
❯ espflash checksum-md5 --address 0x10000 --length 0x1000 --no-stub
[2023-12-27T11:39:27Z INFO ] Serial port: 'COM22'
[2023-12-27T11:39:27Z INFO ] Connecting...
[2023-12-27T11:39:27Z WARN ] Setting baud rate higher than 115,200 can cause issues
0x95d0df6456de4ac114251a67a5f85
```

While this is not too exciting on its own, it's the ground work for #259 and #479

It's very unfortunate that the Rust flasher-stub currently doesn't implement the required command while the ROM code and the C based flasher stub does. (Verified by temporarily reverting the stubs locally). Maybe we should revert the change to use the Rust flasher-stub (but use it based on a feature at build time) until it's supported there

I checked the result with reading a flash region with `esptool` and running `md5sum` on it.
