### PR TITLE
Include license texts in packaged crates

### DIFF
--- a/cargo-espflash/LICENSE-APACHE
+++ b/cargo-espflash/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../LICENSE-APACHE

--- a/cargo-espflash/LICENSE-MIT
+++ b/cargo-espflash/LICENSE-MIT
@@ -1,0 +1,1 @@
+../LICENSE-MIT

--- a/espflash/LICENSE-APACHE
+++ b/espflash/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../LICENSE-APACHE

--- a/espflash/LICENSE-MIT
+++ b/espflash/LICENSE-MIT
@@ -1,0 +1,1 @@
+../LICENSE-MIT


### PR DESCRIPTION
Ensure the license files are included in the crates when they're published.