### PR TITLE
Windows USB serial workaround: set DTR after RTS

### DIFF
--- a/espflash/src/connection/reset.rs
+++ b/espflash/src/connection/reset.rs
@@ -92,24 +92,24 @@ impl ResetStrategy for ClassicReset {
             "Using Classic reset strategy with delay of {}ms",
             self.delay
         );
-        self.set_dtr(interface, false)?;
         self.set_rts(interface, false)?;
+        self.set_dtr(interface, false)?;
 
-        self.set_dtr(interface, true)?;
         self.set_rts(interface, true)?;
+        self.set_dtr(interface, true)?;
 
-        self.set_dtr(interface, false)?; // IO0 = HIGH
         self.set_rts(interface, true)?; // EN = LOW, chip in reset
+        self.set_dtr(interface, false)?; // IO0 = HIGH
 
         sleep(Duration::from_millis(100));
 
-        self.set_dtr(interface, true)?; // IO0 = LOW
         self.set_rts(interface, false)?; // EN = HIGH, chip out of reset
+        self.set_dtr(interface, true)?; // IO0 = LOW
 
         sleep(Duration::from_millis(self.delay));
 
-        self.set_dtr(interface, false)?; // IO0 = HIGH, done
         self.set_rts(interface, false)?;
+        self.set_dtr(interface, false)?; // IO0 = HIGH, done
 
         Ok(())
     }


### PR DESCRIPTION
When setting DTR before RTS, espflash can't connect to a USB serial device on Windows:

![image](https://github.com/esp-rs/espflash/assets/179065/dfaae4d8-254b-418d-89ee-33a1aabcefc7)

After changing the order, it can:

![image](https://github.com/esp-rs/espflash/assets/179065/4bb73c84-f0a4-46b1-a104-a59eb1f8a59f)

Strange but true!

esptool itself [features a similar workaround](https://github.com/espressif/esptool/blob/16e4faeeaa3f95c6b24dfdcc498ffc33924d5f5f/esptool/reset.py#L59-L62) - it additionally sets DTR to its last known state whenever RTS is set. For our purposes though, it seems good enough to just switch the order we set the pins.