### PR TITLE
Fix compile with cli feature disabled

### DIFF
--- a/espflash/src/bin/espflash.rs
+++ b/espflash/src/bin/espflash.rs
@@ -8,13 +8,13 @@ use clap::{Args, CommandFactory, Parser, Subcommand};
 use espflash::{
     cli::{
         self, board_info, checksum_md5, completions, config::Config, connect, erase_flash,
-        erase_partitions, erase_region, flash_elf_image, monitor::monitor, parse_partition_table,
-        parse_uint32, partition_table, print_board_info, save_elf_as_image, serial_monitor,
-        ChecksumMd5Args, CompletionsArgs, ConnectArgs, EraseFlashArgs, EraseRegionArgs,
-        EspflashProgress, FlashConfigArgs, MonitorArgs, PartitionTableArgs,
+        erase_partitions, erase_region, flash_elf_image, monitor::monitor, parse_uint32,
+        partition_table, print_board_info, save_elf_as_image, serial_monitor, ChecksumMd5Args,
+        CompletionsArgs, ConnectArgs, EraseFlashArgs, EraseRegionArgs, EspflashProgress,
+        FlashConfigArgs, MonitorArgs, PartitionTableArgs,
     },
     error::Error,
-    flasher::{FlashData, FlashSettings},
+    flasher::{parse_partition_table, FlashData, FlashSettings},
     image_format::ImageFormatKind,
     logging::initialize_logger,
     targets::Chip,

--- a/espflash/src/cli/mod.rs
+++ b/espflash/src/cli/mod.rs
@@ -11,12 +11,7 @@
 //! [espflash]: https://crates.io/crates/espflash
 
 use std::num::ParseIntError;
-use std::{
-    collections::HashMap,
-    fs,
-    io::Write,
-    path::{Path, PathBuf},
-};
+use std::{collections::HashMap, fs, io::Write, path::PathBuf};
 
 use clap::Args;
 use clap_complete::Shell;
@@ -35,7 +30,10 @@ use self::{
 use crate::{
     elf::ElfFirmwareImage,
     error::{Error, MissingPartition, MissingPartitionTable},
-    flasher::{FlashData, FlashFrequency, FlashMode, FlashSize, Flasher, ProgressCallbacks},
+    flasher::{
+        parse_partition_table, FlashData, FlashFrequency, FlashMode, FlashSize, Flasher,
+        ProgressCallbacks,
+    },
     image_format::ImageFormatKind,
     interface::Interface,
     targets::Chip,
@@ -580,15 +578,6 @@ pub fn flash_elf_image(
     info!("Flashing has completed!");
 
     Ok(())
-}
-
-/// Parse a [PartitionTable] from the provided path
-pub fn parse_partition_table(path: &Path) -> Result<PartitionTable> {
-    let data = fs::read(path)
-        .into_diagnostic()
-        .wrap_err("Failed to open partition table")?;
-
-    PartitionTable::try_from(data).into_diagnostic()
 }
 
 /// Erase one or more partitions by label or [DataType]

--- a/espflash/src/error.rs
+++ b/espflash/src/error.rs
@@ -11,7 +11,6 @@ use strum::{FromRepr, VariantNames};
 use thiserror::Error;
 
 use crate::{
-    cli::monitor::parser::esp_defmt::DefmtError,
     command::CommandType,
     flasher::{FlashFrequency, FlashSize},
     image_format::ImageFormatKind,
@@ -176,9 +175,10 @@ pub enum Error {
     #[diagnostic(transparent)]
     UnsupportedImageFormat(#[from] UnsupportedImageFormatError),
 
+    #[cfg(feature = "cli")]
     #[error(transparent)]
     #[diagnostic(transparent)]
-    Defmt(#[from] DefmtError),
+    Defmt(#[from] crate::cli::monitor::parser::esp_defmt::DefmtError),
 
     #[error("Verification of flash content failed")]
     #[diagnostic(code(espflash::verify_failed))]

--- a/espflash/src/flasher/mod.rs
+++ b/espflash/src/flasher/mod.rs
@@ -9,14 +9,13 @@ use std::{borrow::Cow, fs, path::Path, str::FromStr, thread::sleep};
 use bytemuck::{Pod, Zeroable, __core::time::Duration};
 use esp_idf_part::PartitionTable;
 use log::{debug, info, warn};
-use miette::{IntoDiagnostic, Result};
+use miette::{Context, IntoDiagnostic, Result};
 use serde::{Deserialize, Serialize};
 use serialport::UsbPortInfo;
 use strum::{Display, EnumIter, EnumVariantNames};
 
 use self::stubs::FlashStub;
 use crate::{
-    cli::parse_partition_table,
     command::{Command, CommandType},
     connection::Connection,
     elf::{ElfFirmwareImage, FirmwareImage, RomSegment},
@@ -333,6 +332,15 @@ impl FlashData {
             min_chip_rev,
         })
     }
+}
+
+/// Parse a [PartitionTable] from the provided path
+pub fn parse_partition_table(path: &Path) -> Result<PartitionTable> {
+    let data = fs::read(path)
+        .into_diagnostic()
+        .wrap_err("Failed to open partition table")?;
+
+    PartitionTable::try_from(data).into_diagnostic()
 }
 
 /// Parameters of the attached SPI flash chip (sizes, etc).


### PR DESCRIPTION
espflash does not currently compile with the `cli` feature disabled. This PR fixes that