### PR TITLE
Add before and after reset arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add `--min-chip-rev` argument to specify minimum chip revision (#525)
 - Add `serialport` feature. (#535)
 - Add support for 26 MHz bootloader for ESP32 and ESP32-C2 (#553)
+- Add `--before` and `--after` reset arguments (#561)
 
 ### Fixed
 

--- a/cargo-espflash/src/main.rs
+++ b/cargo-espflash/src/main.rs
@@ -252,8 +252,11 @@ pub fn erase_parts(args: ErasePartsArgs, config: &Config) -> Result<()> {
     };
 
     info!("Erasing the following partitions: {:?}", args.erase_parts);
+    let chip: Chip = flash.chip();
     erase_partitions(&mut flash, partition_table, Some(args.erase_parts), None)?;
-    flash.connection().reset()?;
+    flash
+        .connection()
+        .reset_after(!args.connect_args.no_stub, chip)?;
 
     Ok(())
 }

--- a/espflash/src/bin/espflash.rs
+++ b/espflash/src/bin/espflash.rs
@@ -196,6 +196,7 @@ pub fn erase_parts(args: ErasePartsArgs, config: &Config) -> Result<()> {
 
     info!("Erasing the following partitions: {:?}", args.erase_parts);
     erase_partitions(&mut flash, partition_table, Some(args.erase_parts), None)?;
+    // TODO: reset after?
     flash.connection().reset()?;
 
     Ok(())

--- a/espflash/src/bin/espflash.rs
+++ b/espflash/src/bin/espflash.rs
@@ -195,9 +195,11 @@ pub fn erase_parts(args: ErasePartsArgs, config: &Config) -> Result<()> {
     };
 
     info!("Erasing the following partitions: {:?}", args.erase_parts);
+    let chip = flash.chip();
     erase_partitions(&mut flash, partition_table, Some(args.erase_parts), None)?;
-    // TODO: reset after?
-    flash.connection().reset()?;
+    flash
+        .connection()
+        .reset_after(!args.connect_args.no_stub, chip)?;
 
     Ok(())
 }

--- a/espflash/src/cli/mod.rs
+++ b/espflash/src/cli/mod.rs
@@ -567,7 +567,6 @@ pub fn erase_flash(args: EraseFlashArgs, config: &Config) -> Result<()> {
 
     info!("Erasing Flash...");
     flash.erase_flash()?;
-    // Reset after? https://github.com/espressif/esptool/blob/3a82d7a2d31f509038a5947ae73c3e488be5d664/esptool/__init__.py#L931-L944
     let chip = flash.chip();
     flash
         .connection()

--- a/espflash/src/cli/mod.rs
+++ b/espflash/src/cli/mod.rs
@@ -588,7 +588,10 @@ pub fn erase_region(args: EraseRegionArgs, config: &Config) -> Result<()> {
         args.addr, args.size
     );
     flash.erase_region(args.addr, args.size)?;
-    flash.connection().reset()?;
+    let chip = flash.chip();
+    flash
+        .connection()
+        .reset_after(!args.connect_args.no_stub, chip)?;
 
     Ok(())
 }

--- a/espflash/src/command.rs
+++ b/espflash/src/command.rs
@@ -42,6 +42,8 @@ pub enum CommandType {
     // Some commands supported by stub only
     EraseFlash = 0xd0,
     EraseRegion = 0xd1,
+    // https://github.com/espressif/esptool/blob/3a82d7a2d31f509038a5947ae73c3e488be5d664/esptool/loader.py#L221
+    RunUserCode = 0xd3,
 }
 
 impl CommandType {
@@ -165,6 +167,7 @@ pub enum Command<'a> {
         offset: u32,
         size: u32,
     },
+    RunUserCode,
 }
 
 impl<'a> Command<'a> {
@@ -191,6 +194,7 @@ impl<'a> Command<'a> {
             Command::EraseFlash { .. } => CommandType::EraseFlash,
             Command::EraseRegion { .. } => CommandType::EraseRegion,
             Command::FlashMd5 { .. } => CommandType::FlashMd5,
+            Command::RunUserCode { .. } => CommandType::RunUserCode,
         }
     }
 
@@ -378,6 +382,9 @@ impl<'a> Command<'a> {
                 writer.write_all(&size.to_le_bytes())?;
                 writer.write_all(&(0u32.to_le_bytes()))?;
                 writer.write_all(&(0u32.to_le_bytes()))?;
+            }
+            Command::RunUserCode => {
+                write_basic(writer, &[], 0)?;
             }
         };
         Ok(())

--- a/espflash/src/command.rs
+++ b/espflash/src/command.rs
@@ -42,7 +42,6 @@ pub enum CommandType {
     // Some commands supported by stub only
     EraseFlash = 0xd0,
     EraseRegion = 0xd1,
-    // https://github.com/espressif/esptool/blob/3a82d7a2d31f509038a5947ae73c3e488be5d664/esptool/loader.py#L221
     RunUserCode = 0xd3,
 }
 

--- a/espflash/src/connection/mod.rs
+++ b/espflash/src/connection/mod.rs
@@ -202,20 +202,18 @@ impl Connection {
             ResetAfterOperation::SoftReset => {
                 soft_reset(self, false, is_stub, chip)?;
                 println!("Soft resetting");
-                return Ok(());
+                Ok(())
             }
             ResetAfterOperation::NoReset => {
                 soft_reset(self, true, is_stub, chip)?;
                 println!("Staying in flasher stub");
-                return Ok(());
+                Ok(())
             }
             ResetAfterOperation::NoResetNoStub => {
                 println!("Staying in flasher stub");
-                return Ok(());
+                Ok(())
             }
-        };
-
-        Ok(())
+        }
     }
 
     // Reset the device to flash mode

--- a/espflash/src/connection/mod.rs
+++ b/espflash/src/connection/mod.rs
@@ -141,7 +141,6 @@ impl Connection {
             //TODO:  Implement https://github.com/espressif/esptool/blob/3a82d7a2d31f509038a5947ae73c3e488be5d664/esptool/loader.py#L565-L574 ?
         }
 
-        reset_strategy.reset(&mut self.serial)?;
         for _ in 0..MAX_SYNC_ATTEMPTS {
             self.flush()?;
 

--- a/espflash/src/connection/mod.rs
+++ b/espflash/src/connection/mod.rs
@@ -11,7 +11,7 @@ use std::{
     time::Duration,
 };
 
-use log::debug;
+use log::{debug, info};
 use regex::Regex;
 use serialport::UsbPortInfo;
 use slip_codec::SlipDecoder;
@@ -237,18 +237,18 @@ impl Connection {
         match self.after_operation {
             ResetAfterOperation::HardReset => HardReset.reset(&mut self.serial),
             ResetAfterOperation::SoftReset => {
-                println!("Soft resetting");
+                info!("Soft resetting");
                 soft_reset(self, false, is_stub, chip)?;
                 Ok(())
             }
             ResetAfterOperation::NoReset => {
-                println!("Staying in bootloader");
+                info!("Staying in bootloader");
                 soft_reset(self, true, is_stub, chip)?;
 
                 Ok(())
             }
             ResetAfterOperation::NoResetNoStub => {
-                println!("Staying in flasher stub");
+                info!("Staying in flasher stub");
                 Ok(())
             }
         }

--- a/espflash/src/connection/mod.rs
+++ b/espflash/src/connection/mod.rs
@@ -142,8 +142,6 @@ impl Connection {
             // Reset the chip to bootloader (download mode)
             reset_strategy.reset(&mut self.serial)?;
 
-            // //TODO:  Implement https://github.com/espressif/esptool/blob/3a82d7a2d31f509038a5947ae73c3e488be5d664/esptool/loader.py#L565-L574 ?
-
             let available_bytes = self.serial.serial_port_mut().bytes_to_read()?;
             buff = vec![0; available_bytes as usize];
             let read_bytes = self.serial.serial_port_mut().read(&mut buff)? as u32;
@@ -475,7 +473,6 @@ pub fn reset_after_flash(serial: &mut Interface, pid: u16) -> Result<(), serialp
 
         serial.write_request_to_send(false)?;
     } else {
-        // THIS IS SAME AS HARD_RESET https://github.com/espressif/esptool/blob/3a82d7a2d31f509038a5947ae73c3e488be5d664/esptool/reset.py#L124-L135
         serial.write_request_to_send(true)?;
 
         sleep(Duration::from_millis(100));

--- a/espflash/src/connection/mod.rs
+++ b/espflash/src/connection/mod.rs
@@ -192,21 +192,20 @@ impl Connection {
 
         Ok(())
     }
-    // Reset the device
-    // Implement https://github.com/espressif/esptool/blob/3a82d7a2d31f509038a5947ae73c3e488be5d664/esptool/__init__.py#L931-L944
 
+    // Reset the device taking into account the reset after argument
     pub fn reset_after(&mut self, is_stub: bool, chip: Chip) -> Result<(), Error> {
-        // TODO: verfify that we are not using --ram flag. Only in FlashArgs
         match self.after_operation {
             ResetAfterOperation::HardReset => HardReset.reset(&mut self.serial),
             ResetAfterOperation::SoftReset => {
-                soft_reset(self, false, is_stub, chip)?;
                 println!("Soft resetting");
+                soft_reset(self, false, is_stub, chip)?;
                 Ok(())
             }
             ResetAfterOperation::NoReset => {
+                println!("Staying in bootloader");
                 soft_reset(self, true, is_stub, chip)?;
-                println!("Staying in flasher stub");
+
                 Ok(())
             }
             ResetAfterOperation::NoResetNoStub => {

--- a/espflash/src/connection/reset.rs
+++ b/espflash/src/connection/reset.rs
@@ -247,7 +247,6 @@ pub fn soft_reset(
                     supports_encryption: false,
                 })
             })?;
-            // flash_end(false)
             connection.with_timeout(CommandType::FlashEnd.timeout(), |connection| {
                 connection.write_command(Command::FlashEnd { reboot: false })
             })?;

--- a/espflash/src/error.rs
+++ b/espflash/src/error.rs
@@ -253,12 +253,23 @@ pub enum ConnectionError {
     #[error("Invalid stub handshake response received")]
     InvalidStubHandshake,
 
+    #[error("Download mode successfully detected, but getting no sync reply")]
+    #[diagnostic(
+        code(espflash::no_sync_reply),
+        help("The serial TX path seems to be down")
+    )]
+    NoSyncReply,
+
     #[error("Received packet to large for buffer")]
     #[diagnostic(
         code(espflash::oversized_packet),
         help("Try hard-resetting the device and try again, if the error persists your ROM may be corrupted")
     )]
     OverSizedPacket,
+
+    #[error("Failed to read the available bytes on the serial port. Available bytes: {0}, Read bytes: {1}")]
+    #[diagnostic(code(espflash::read_missmatch))]
+    ReadMissmatch(u32, u32),
 
     #[error("Timeout while running {0}command")]
     #[diagnostic(code(espflash::timeout))]
@@ -268,6 +279,10 @@ pub enum ConnectionError {
     #[error("IO error while using serial port: {0}")]
     #[diagnostic(code(espflash::serial_error))]
     Serial(#[source] serialport::Error),
+
+    #[error("Wrong boot mode detected ({0})! The chip needs to be in download mode.")]
+    #[diagnostic(code(espflash::wrong_boot_mode))]
+    WrongBootMode(String),
 }
 
 impl From<io::Error> for ConnectionError {

--- a/espflash/src/error.rs
+++ b/espflash/src/error.rs
@@ -116,6 +116,10 @@ pub enum Error {
     )]
     SerialNotFound(String),
 
+    #[error("Soft reseting is currently only supported on ESP8266")]
+    #[diagnostic(code(espflash::soft_reset_not_available))]
+    SoftResetNotAvailable,
+
     #[error("Unrecognized image format '{0}'")]
     #[diagnostic(
         code(espflash::unknown_format),

--- a/espflash/src/error.rs
+++ b/espflash/src/error.rs
@@ -47,6 +47,13 @@ pub enum Error {
     )]
     ChipMismatch(String, String),
 
+    #[error("Chip not argument provided, this is required when using the `--before no-reset-no-sync` option")]
+    #[diagnostic(
+        code(espflash::chip_not_provided),
+        help("Ensure that you provide the `-c/--chip` option with the proper chip")
+    )]
+    ChipNotProvided,
+
     #[error("Supplied ELF image can not be run from RAM, as it includes segments mapped to ROM addresses")]
     #[diagnostic(
         code(espflash::not_ram_loadable),

--- a/espflash/src/flasher/mod.rs
+++ b/espflash/src/flasher/mod.rs
@@ -18,7 +18,10 @@ use self::stubs::FlashStub;
 use crate::{
     cli::parse_partition_table,
     command::{Command, CommandType},
-    connection::Connection,
+    connection::{
+        reset::{ResetAfterOperation, ResetBeforeOperation},
+        Connection,
+    },
     elf::{ElfFirmwareImage, FirmwareImage, RomSegment},
     error::{ConnectionError, Error, ResultExt},
     image_format::ImageFormatKind,
@@ -507,10 +510,12 @@ impl Flasher {
         verify: bool,
         skip: bool,
         chip: Option<Chip>,
+        after_operation: ResetAfterOperation,
+        before_operation: ResetBeforeOperation,
     ) -> Result<Self, Error> {
         // Establish a connection to the device using the default baud rate of 115,200
         // and timeout of 3 seconds.
-        let mut connection = Connection::new(serial, port_info);
+        let mut connection = Connection::new(serial, port_info, after_operation, before_operation);
         connection.begin()?;
         connection.set_timeout(DEFAULT_TIMEOUT)?;
 

--- a/espflash/src/targets/flash_target/esp32.rs
+++ b/espflash/src/targets/flash_target/esp32.rs
@@ -248,7 +248,7 @@ impl FlashTarget for Esp32Target {
         }
 
         if reboot {
-            connection.reset()?;
+            connection.reset_after(self.use_stub, self.chip)?;
         }
 
         Ok(())


### PR DESCRIPTION
- Adds the `-b/--before` argument
- Adds the `-a/--after` argument

This also solves #346 as `espflash monitor --before no-reset-no-sync --chip esp32c3` can monitor a target without resetting it.