### PR TITLE
Re-calculate the bootloader's SHA256

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed `defmt` parsing when data is read in parts (#503)
 - Use partition table instead of hard-coded values for the location of partitions (#516)
 - Fixed a missed `flush` call that may be causing communication errors (#521)
+- Fix "SHA-256 comparison failed: [...] attempting to boot anyway..." (#567)
 
 ### Changed
 - Created `FlashData`, `FlashDataBuilder` and `FlashSettings` structs to reduce number of input arguments in some functions (#512, #566)

--- a/espflash/src/image_format/idf_bootloader.rs
+++ b/espflash/src/image_format/idf_bootloader.rs
@@ -73,6 +73,13 @@ impl<'a> IdfBootloaderFormat<'a> {
             bytes_of(&header).iter().copied(),
         );
 
+        // re-calculate hash of the bootloader - needed since we modified the header
+        let bootloader_len = bootloader.len();
+        let mut hasher = Sha256::new();
+        hasher.update(&bootloader[..bootloader_len - 32]);
+        let hash = hasher.finalize();
+        bootloader.to_mut()[bootloader_len - 32..].copy_from_slice(&hash);
+
         // write the header of the app
         // use the same settings as the bootloader
         // just update the entry point


### PR DESCRIPTION
Fixes #206 

We modify the ESP-IDF booloader's header - then we also need to re-calculate it's SHA256
