### PR TITLE
Add error for cases when we cant read the serial monitor trying to decode the bootmode

### DIFF
--- a/espflash/src/connection/mod.rs
+++ b/espflash/src/connection/mod.rs
@@ -176,7 +176,7 @@ impl Connection {
 
             let read_slice = from_utf8(&buff[..read_bytes as usize]).map_err(|err| {
                 debug!("Error: {}", err);
-                return Error::InvalidSerialRead;
+                Error::InvalidSerialRead
             })?;
 
             let pattern = Regex::new(r"boot:(0x[0-9a-fA-F]+)(.*waiting for download)?").unwrap();

--- a/espflash/src/error.rs
+++ b/espflash/src/error.rs
@@ -99,7 +99,7 @@ pub enum Error {
     #[error("Invalid byte sequence read from the serial port while trying to detect Boot Mode")]
     #[diagnostic(
         code(espflash::invalid_serial_read),
-        help("This migth be caused by a xtal frequency missmatch")
+        help("This might be caused by a xtal frequency mismatch")
     )]
     InvalidSerialRead,
 

--- a/espflash/src/error.rs
+++ b/espflash/src/error.rs
@@ -96,6 +96,10 @@ pub enum Error {
     #[error("The provided bootloader binary is invalid")]
     InvalidBootloader,
 
+    #[error("Invalid byte sequence read from the serial port while trying to detect Boot Mode")]
+    #[diagnostic(code(espflash::invalid_serial_read))]
+    InvalidSerialRead,
+
     #[error("Specified bootloader path is not a .bin file")]
     #[diagnostic(code(espflash::invalid_bootloader_path))]
     InvalidBootloaderPath,

--- a/espflash/src/error.rs
+++ b/espflash/src/error.rs
@@ -97,7 +97,10 @@ pub enum Error {
     InvalidBootloader,
 
     #[error("Invalid byte sequence read from the serial port while trying to detect Boot Mode")]
-    #[diagnostic(code(espflash::invalid_serial_read))]
+    #[diagnostic(
+        code(espflash::invalid_serial_read),
+        help("This migth be caused by a xtal frequency missmatch")
+    )]
     InvalidSerialRead,
 
     #[error("Specified bootloader path is not a .bin file")]
@@ -108,8 +111,8 @@ pub enum Error {
     #[diagnostic(
         code(espflash::invalid_direct_boot),
         help(
-            "See the following page for documentation on how to set up your binary for direct boot:\
-             https://github.com/espressif/esp32c3-direct-boot-example"
+                "See the following page for documentation on how to set up your binary for direct boot:\
+                https://github.com/espressif/esp32c3-direct-boot-example"
         )
     )]
     InvalidDirectBootBinary,


### PR DESCRIPTION
In some (weird cases), like flashing a 26MHz C2 instead of 40Mhz target, https://github.com/esp-rs/espflash/issues/570 would happen. It should be an error, but the error should mean something, so I just added a custom error for the case.