### PR TITLE
Tolerate some non-utf8 data when detecting boot mode over serial

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed a missed `flush` call that may be causing communication errors (#521)
 - Fix "SHA-256 comparison failed: [...] attempting to boot anyway..." (#567)
 - Windows: Update RST/DTR order to avoid issues.
+- Tolerate non-utf8 data in boot detection (#573)
 
 ### Changed
 - Created `FlashData`, `FlashDataBuilder` and `FlashSettings` structs to reduce number of input arguments in some functions (#512, #566)

--- a/espflash/src/connection/mod.rs
+++ b/espflash/src/connection/mod.rs
@@ -174,6 +174,9 @@ impl Connection {
             }
 
             let read_slice = String::from_utf8_lossy(&buff[..read_bytes as usize]).into_owned();
+            if !read_slice.contains("boot") {
+                return Err(Error::InvalidSerialRead);
+            }
 
             let pattern = Regex::new(r"boot:(0x[0-9a-fA-F]+)(.*waiting for download)?").unwrap();
 

--- a/espflash/src/connection/mod.rs
+++ b/espflash/src/connection/mod.rs
@@ -7,7 +7,6 @@
 use std::{
     io::{BufWriter, Write},
     iter::zip,
-    str::from_utf8,
     thread::sleep,
     time::Duration,
 };
@@ -156,7 +155,7 @@ impl Connection {
             return Ok(());
         }
         let mut download_mode: bool = false;
-        let mut boot_mode: &str = "";
+        let mut boot_mode = String::new();
         let mut boot_log_detected = false;
         let mut buff: Vec<u8>;
         if self.before_operation != ResetBeforeOperation::NoReset {
@@ -174,18 +173,19 @@ impl Connection {
                 )));
             }
 
-            let read_slice = from_utf8(&buff[..read_bytes as usize]).map_err(|err| {
-                debug!("Error: {}", err);
-                Error::InvalidSerialRead
-            })?;
+            let read_slice = String::from_utf8_lossy(&buff[..read_bytes as usize]).into_owned();
 
             let pattern = Regex::new(r"boot:(0x[0-9a-fA-F]+)(.*waiting for download)?").unwrap();
 
             // Search for the pattern in the read data
-            if let Some(data) = pattern.captures(read_slice) {
+            if let Some(data) = pattern.captures(&read_slice) {
                 boot_log_detected = true;
                 // Boot log detected
-                boot_mode = data.get(1).map(|m| m.as_str()).unwrap_or_default();
+                boot_mode = data
+                    .get(1)
+                    .map(|m| m.as_str())
+                    .unwrap_or_default()
+                    .to_string();
                 download_mode = data.get(2).is_some();
 
                 // Further processing or printing the results


### PR DESCRIPTION
My ESP32-WROOM is sending some non-utf8 data just after reset, causing boot mode detection to fail.

This commit uses `String::from_utf8_lossy` to ignore these bytes.

Tested on macOS, boards: ESP32-WROOM-32, ESP32-WROOM-32D, ESP32-C3-MINI-1, ESP32-C3-12F.