### PR TITLE
Improve resolving symbols

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `espflash` will now exit with an error if `defmt` is selected but not usable (#524)
 - Unify configuration methods (#551)
 - MSRV bumped to `1.73.0` (#578)
+- Improved symbol resolving (#581)
 
 ### Removed
 

--- a/espflash/src/cli/monitor/parser/mod.rs
+++ b/espflash/src/cli/monitor/parser/mod.rs
@@ -38,14 +38,17 @@ fn resolve_addresses(
         let name = symbols.get_name(addr);
         let location = symbols.get_location(addr);
 
-        let name = name.as_deref().unwrap_or("??");
-        let output = if let Some((file, line_num)) = location {
-            format!("{matched} - {name}\r\n    at {file}:{line_num}\r\n")
-        } else {
-            format!("{matched} - {name}\r\n    at ??:??\r\n")
+        match name {
+            Some(name) => {
+                let output = if let Some((file, line_num)) = location {
+                    format!("{matched} - {name}\r\n    at {file}:{line_num}\r\n")
+                } else {
+                    format!("{matched} - {name}\r\n    at ??:??\r\n")
+                };
+                out.queue(PrintStyledContent(output.with(Color::Yellow)))?;
+            }
+            None => (),
         };
-
-        out.queue(PrintStyledContent(output.with(Color::Yellow)))?;
     }
 
     Ok(())

--- a/espflash/src/cli/monitor/parser/mod.rs
+++ b/espflash/src/cli/monitor/parser/mod.rs
@@ -38,17 +38,14 @@ fn resolve_addresses(
         let name = symbols.get_name(addr);
         let location = symbols.get_location(addr);
 
-        match name {
-            Some(name) => {
-                let output = if let Some((file, line_num)) = location {
-                    format!("{matched} - {name}\r\n    at {file}:{line_num}\r\n")
-                } else {
-                    format!("{matched} - {name}\r\n    at ??:??\r\n")
-                };
-                out.queue(PrintStyledContent(output.with(Color::Yellow)))?;
-            }
-            None => (),
-        };
+        if let Some(name) = name {
+            let output = if let Some((file, line_num)) = location {
+                format!("{matched} - {name}\r\n    at {file}:{line_num}\r\n")
+            } else {
+                format!("{matched} - {name}\r\n    at ??:??\r\n")
+            };
+            out.queue(PrintStyledContent(output.with(Color::Yellow)))?;
+        }
     }
 
     Ok(())

--- a/espflash/src/cli/monitor/parser/mod.rs
+++ b/espflash/src/cli/monitor/parser/mod.rs
@@ -45,12 +45,10 @@ fn resolve_addresses(
                 } else {
                     format!("{name}\r\n    at ??:??\r\n")
                 }
+            } else if let Some((file, line_num)) = location {
+                format!("{matched} - {name}\r\n    at {file}:{line_num}\r\n")
             } else {
-                if let Some((file, line_num)) = location {
-                    format!("{matched} - {name}\r\n    at {file}:{line_num}\r\n")
-                } else {
-                    format!("{matched} - {name}\r\n    at ??:??\r\n")
-                }
+                format!("{matched} - {name}\r\n    at ??:??\r\n")
             };
 
             out.queue(PrintStyledContent(output.with(Color::Yellow)))?;

--- a/espflash/src/cli/monitor/parser/mod.rs
+++ b/espflash/src/cli/monitor/parser/mod.rs
@@ -39,11 +39,20 @@ fn resolve_addresses(
         let location = symbols.get_location(addr);
 
         if let Some(name) = name {
-            let output = if let Some((file, line_num)) = location {
-                format!("{matched} - {name}\r\n    at {file}:{line_num}\r\n")
+            let output = if line.trim() == format!("0x{:x}", addr) {
+                if let Some((file, line_num)) = location {
+                    format!("{name}\r\n    at {file}:{line_num}\r\n")
+                } else {
+                    format!("{name}\r\n    at ??:??\r\n")
+                }
             } else {
-                format!("{matched} - {name}\r\n    at ??:??\r\n")
+                if let Some((file, line_num)) = location {
+                    format!("{matched} - {name}\r\n    at {file}:{line_num}\r\n")
+                } else {
+                    format!("{matched} - {name}\r\n    at ??:??\r\n")
+                }
             };
+
             out.queue(PrintStyledContent(output.with(Color::Yellow)))?;
         }
     }


### PR DESCRIPTION
This turns this
```
Exception 'Illegal instruction' mepc=0x420001ba, mtval=0x0000a488
0x420001ba - embassy_hello_world::__run_task::{{closure}}
    at C:\projects\esp\esp-hal\esp32c3-hal\examples\embassy_hello_world.rs:19
0x0000a488 - ??
    at ??:??
TrapFrame
PC=0x420001ba         RA/x1=0x420001b2      SP/x2=0x3fc81778      GP/x3=0x3fccfee0      TP/x4=0x00000000
0x420001ba - embassy_hello_world::__run_task::{{closure}}
    at C:\projects\esp\esp-hal\esp32c3-hal\examples\embassy_hello_world.rs:19
0x420001b2 - embassy_hello_world::__run_task::{{closure}}
    at C:\projects\esp\esp-hal\esp32c3-hal\examples\embassy_hello_world.rs:19
0x3fc81778 - _ZN7esp_hal3rmt6asynch5WAKER17h7d00025adc6b0189E
    at ??:??
0x3fccfee0 - _ZN7esp_hal3rmt6asynch5WAKER17h7d00025adc6b0189E
    at ??:??
0x00000000 - core::num::<impl u64>::wrapping_add
    at C:\Users\Bjoern\.cargo\registry\src\index.crates.io-6f17d22bba15001f\compiler_builtins-0.1.105\src\macros.rs:499
T0/x5=0x42003e1c      T1/x6=0x42003e1c      T2/x7=0x00000000      S0/FP/x8=0x3fccff30   S1/x9=0x3fc80fd8
0x42003e1c - embassy_executor::raw::waker::wake
    at C:\Users\Bjoern\.cargo\registry\src\index.crates.io-6f17d22bba15001f\embassy-executor-0.5.0\src\raw\waker.rs:12
0x42003e1c - embassy_executor::raw::waker::wake
    at C:\Users\Bjoern\.cargo\registry\src\index.crates.io-6f17d22bba15001f\embassy-executor-0.5.0\src\raw\waker.rs:12
0x00000000 - core::num::<impl u64>::wrapping_add
    at C:\Users\Bjoern\.cargo\registry\src\index.crates.io-6f17d22bba15001f\compiler_builtins-0.1.105\src\macros.rs:499
0x3fccff30 - _ZN7esp_hal3rmt6asynch5WAKER17h7d00025adc6b0189E
    at ??:??
0x3fc80fd8 - _ZN19embassy_hello_world3run4POOL17h14065b770df81ec3E
    at ??:??
A0/x10=0x00000001     A1/x11=0x00000000     A2/x12=0x3fc80fd8     A3/x13=0x00000000     A4/x14=0x011af2ed
0x00000001 - core::num::<impl u64>::wrapping_add
    at C:\Users\Bjoern\.cargo\registry\src\index.crates.io-6f17d22bba15001f\compiler_builtins-0.1.105\src\macros.rs:499
0x00000000 - core::num::<impl u64>::wrapping_add
    at C:\Users\Bjoern\.cargo\registry\src\index.crates.io-6f17d22bba15001f\compiler_builtins-0.1.105\src\macros.rs:499
0x3fc80fd8 - _ZN19embassy_hello_world3run4POOL17h14065b770df81ec3E
    at ??:??
0x00000000 - core::num::<impl u64>::wrapping_add
    at C:\Users\Bjoern\.cargo\registry\src\index.crates.io-6f17d22bba15001f\compiler_builtins-0.1.105\src\macros.rs:499
0x011af2ed - ??
    at ??:??
A5/x15=0x00000000     A6/x16=0x42004000     A7/x17=0x00000000     S2/x18=0x3fc80ff8     S3/x19=0x00000000
0x00000000 - core::num::<impl u64>::wrapping_add
    at C:\Users\Bjoern\.cargo\registry\src\index.crates.io-6f17d22bba15001f\compiler_builtins-0.1.105\src\macros.rs:499
0x42004000 - embassy_executor::raw::util::SyncUnsafeCell<T>::get
    at C:\Users\Bjoern\.cargo\registry\src\index.crates.io-6f17d22bba15001f\embassy-executor-0.5.0\src\raw\util.rs:55
0x00000000 - core::num::<impl u64>::wrapping_add
    at C:\Users\Bjoern\.cargo\registry\src\index.crates.io-6f17d22bba15001f\compiler_builtins-0.1.105\src\macros.rs:499
0x3fc80ff8 - _ZN19embassy_hello_world3run4POOL17h14065b770df81ec3E
    at ??:??
0x00000000 - core::num::<impl u64>::wrapping_add
    at C:\Users\Bjoern\.cargo\registry\src\index.crates.io-6f17d22bba15001f\compiler_builtins-0.1.105\src\macros.rs:499
S4/x20=0x3fccffb0     S5/x21=0xffffffff     S6/x22=0x00000001     S7/x23=0x00000001     S8/x24=0x3fc81028
0x3fccffb0 - _ZN7esp_hal3rmt6asynch5WAKER17h7d00025adc6b0189E
    at ??:??
0xffffffff - memset
    at ??:??
0x00000001 - core::num::<impl u64>::wrapping_add
    at C:\Users\Bjoern\.cargo\registry\src\index.crates.io-6f17d22bba15001f\compiler_builtins-0.1.105\src\macros.rs:499
0x00000001 - core::num::<impl u64>::wrapping_add
    at C:\Users\Bjoern\.cargo\registry\src\index.crates.io-6f17d22bba15001f\compiler_builtins-0.1.105\src\macros.rs:499
0x3fc81028 - _ZN19embassy_hello_world14__embassy_main4POOL17h5f6bac714cbc00afE
    at ??:??
S9/x25=0x00000000     S10/x26=0x00000000    S11/x27=0x23450000    T3/x28=0x00000000     T4/x29=0x00000000
0x00000000 - core::num::<impl u64>::wrapping_add
    at C:\Users\Bjoern\.cargo\registry\src\index.crates.io-6f17d22bba15001f\compiler_builtins-0.1.105\src\macros.rs:499
0x00000000 - core::num::<impl u64>::wrapping_add
    at C:\Users\Bjoern\.cargo\registry\src\index.crates.io-6f17d22bba15001f\compiler_builtins-0.1.105\src\macros.rs:499
0x23450000 - ??
    at ??:??
0x00000000 - core::num::<impl u64>::wrapping_add
    at C:\Users\Bjoern\.cargo\registry\src\index.crates.io-6f17d22bba15001f\compiler_builtins-0.1.105\src\macros.rs:499
0x00000000 - core::num::<impl u64>::wrapping_add
    at C:\Users\Bjoern\.cargo\registry\src\index.crates.io-6f17d22bba15001f\compiler_builtins-0.1.105\src\macros.rs:499
T5/x30=0x00000000     T6/x31=0x00000000
0x00000000 - core::num::<impl u64>::wrapping_add
    at C:\Users\Bjoern\.cargo\registry\src\index.crates.io-6f17d22bba15001f\compiler_builtins-0.1.105\src\macros.rs:499
0x00000000 - core::num::<impl u64>::wrapping_add
    at C:\Users\Bjoern\.cargo\registry\src\index.crates.io-6f17d22bba15001f\compiler_builtins-0.1.105\src\macros.rs:499

MSTATUS=0x00001881
0x00001881 - ??
    at ??:??
MCAUSE=0x00000002
0x00000002 - core::num::<impl u64>::wrapping_add
    at C:\Users\Bjoern\.cargo\registry\src\index.crates.io-6f17d22bba15001f\compiler_builtins-0.1.105\src\macros.rs:499
MTVAL=0x0000a488
0x0000a488 - ??
    at ??:??

0x420040f6
0x420040f6 - embassy_executor::raw::util::SyncUnsafeCell<T>::get
    at C:\Users\Bjoern\.cargo\registry\src\index.crates.io-6f17d22bba15001f\embassy-executor-0.5.0\src\raw\util.rs:55
0x42000554
0x42000554 - esp_hal::embassy::executor::thread::Executor::run
    at C:\projects\esp\esp-hal\esp-hal\src\embassy\executor\thread.rs:105
0x420005ca
0x420005ca - <bool as core::fmt::Debug>::fmt
    at C:\Users\Bjoern\.rustup\toolchains\nightly-x86_64-pc-windows-msvc\lib\rustlib\src\rust\library\core\src\fmt\mod.rs:2325
0x420033e6
0x420033e6 - FROM_CPU_INTR0
    at C:\projects\esp\esp-hal\esp-hal\src\embassy\executor\thread.rs:21
0x42000104
0x42000104 - _start_rust
    at ??:??





```

into this

```
Exception 'Illegal instruction' mepc=0x420001ba, mtval=0x0000a488
0x420001ba - embassy_hello_world::__run_task::{{closure}}
    at C:\projects\esp\esp-hal\esp32c3-hal\examples\embassy_hello_world.rs:19
TrapFrame
PC=0x420001ba         RA/x1=0x420001b2      SP/x2=0x3fc81778      GP/x3=0x3fccfee0      TP/x4=0x00000000
0x420001ba - embassy_hello_world::__run_task::{{closure}}
    at C:\projects\esp\esp-hal\esp32c3-hal\examples\embassy_hello_world.rs:19
0x420001b2 - embassy_hello_world::__run_task::{{closure}}
    at C:\projects\esp\esp-hal\esp32c3-hal\examples\embassy_hello_world.rs:19
T0/x5=0x42003e1c      T1/x6=0x42003e1c      T2/x7=0x00000000      S0/FP/x8=0x3fccff30   S1/x9=0x3fc80fd8
0x42003e1c - embassy_executor::raw::waker::wake
    at C:\Users\Bjoern\.cargo\registry\src\index.crates.io-6f17d22bba15001f\embassy-executor-0.5.0\src\raw\waker.rs:12
0x42003e1c - embassy_executor::raw::waker::wake
    at C:\Users\Bjoern\.cargo\registry\src\index.crates.io-6f17d22bba15001f\embassy-executor-0.5.0\src\raw\waker.rs:12
0x3fc80fd8 - embassy_hello_world::run::POOL
    at ??:??
A0/x10=0x00000001     A1/x11=0x00000000     A2/x12=0x3fc80fd8     A3/x13=0x00000000     A4/x14=0x011af2eb
0x3fc80fd8 - embassy_hello_world::run::POOL
    at ??:??
A5/x15=0x00000000     A6/x16=0x42004000     A7/x17=0x00000000     S2/x18=0x3fc80ff8     S3/x19=0x00000000
0x42004000 - embassy_executor::raw::util::SyncUnsafeCell<T>::get
    at C:\Users\Bjoern\.cargo\registry\src\index.crates.io-6f17d22bba15001f\embassy-executor-0.5.0\src\raw\util.rs:55
0x3fc80ff8 - embassy_hello_world::run::POOL
    at ??:??
S4/x20=0x3fccffb0     S5/x21=0xffffffff     S6/x22=0x00000001     S7/x23=0x00000001     S8/x24=0x3fc81028
0x3fc81028 - embassy_hello_world::__embassy_main::POOL
    at ??:??
S9/x25=0x00000000     S10/x26=0x00000000    S11/x27=0x23450000    T3/x28=0x00000000     T4/x29=0x00000000
T5/x30=0x00000000     T6/x31=0x00000000

MSTATUS=0x00001881
MCAUSE=0x00000002
MTVAL=0x0000a488

0x420040f6
0x420040f6 - embassy_executor::raw::util::SyncUnsafeCell<T>::get
    at C:\Users\Bjoern\.cargo\registry\src\index.crates.io-6f17d22bba15001f\embassy-executor-0.5.0\src\raw\util.rs:55
0x42000554
0x42000554 - esp_hal::embassy::executor::thread::Executor::run
    at C:\projects\esp\esp-hal\esp-hal\src\embassy\executor\thread.rs:105
0x420005ca
0x420005ca - <bool as core::fmt::Debug>::fmt
    at C:\Users\Bjoern\.rustup\toolchains\nightly-x86_64-pc-windows-msvc\lib\rustlib\src\rust\library\core\src\fmt\mod.rs:2325
0x420033e6
0x420033e6 - FROM_CPU_INTR0
    at C:\projects\esp\esp-hal\esp-hal\src\embassy\executor\thread.rs:21
0x42000104
0x42000104 - _start_rust
    at ??:??




```

- don't try to resolve addresses not contained in the elf (into some garbage) (e.g. 0x00000000)
- demangle all symbols, not only functions (e.g. 0x3fc80fd8)
- don't print anything if we cannot resolve it

