### PR TITLE
Prepare 3.0.0-rc.1 release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,7 +106,7 @@ jobs:
         with:
           arch: ${{ matrix.platform.arch }}
           target: ${{ matrix.platform.target }}
-          toolchain: "1.73"
+          toolchain: "1.74"
 
       - run: cargo check
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,9 +41,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Create `FlashData`, `FlashDataBuilder` and `FlashSettings` structs to reduce number of input arguments in some functions (#512, #566)
 - `espflash` will now exit with an error if `defmt` is selected but not usable (#524)
 - Unify configuration methods (#551)
-- MSRV bumped to `1.73.0` (#578)
 - Improved symbol resolving (#581)
 - Update ESP32-C2 stub (#584)
+- MSRV bumped to `1.74.0` (#586)
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,21 +5,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-[Unreleased]
+## [3.0.0-rc.1] - 2024-02-16
 
 ### Added
 
-- Added reset strategies (#487)
+- Add reset strategies (#487)
 - Read `esp-println` generated `defmt` messages (#466)
 - Add `--target-app-partition` argument to flash command (#461)
 - Add `--confirm-port` argument to flash command (#455)
 - Add `--chip argument` for flash and write-bin commands (#514)
 - Add `--partition-table-offset` argument for specifying the partition table offset (#516)
-- Add `Serialize` and `Deserialize` to `FlashFrequency`, `FlashMode` and `FlashSize`. (#528)
+- Add `Serialize` and `Deserialize` to `FlashFrequency`, `FlashMode` and `FlashSize` (#528)
 - Add `checksum-md5` command (#536)
 - Add verify and skipping of unchanged flash regions - add `--no-verify` and `--no-skip` (#538)
 - Add `--min-chip-rev` argument to specify minimum chip revision (#525)
-- Add `serialport` feature. (#535)
+- Add `serialport` feature (#535)
 - Add support for 26 MHz bootloader for ESP32 and ESP32-C2 (#553)
 - Add CI check to verify that CHANGELOG is updated (#560)
 - Add `--before` and `--after` reset arguments (#561)
@@ -32,13 +32,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Use partition table instead of hard-coded values for the location of partitions (#516)
 - Fix a missed `flush` call that may be causing communication errors (#521)
 - Fix "SHA-256 comparison failed: [...] attempting to boot anyway..." (#567)
-- Windows: Update RST/DTR order to avoid issues.
+- Windows: Update RST/DTR order to avoid issues (#562)
 - Tolerate non-utf8 data in boot detection (#573)
-- Fix flash/monitoring of 26mhz targets (#584)
+- Fix flash/monitoring of 26MHz targets (#584)
 
 ### Changed
 
-- Created `FlashData`, `FlashDataBuilder` and `FlashSettings` structs to reduce number of input arguments in some functions (#512, #566)
+- Create `FlashData`, `FlashDataBuilder` and `FlashSettings` structs to reduce number of input arguments in some functions (#512, #566)
 - `espflash` will now exit with an error if `defmt` is selected but not usable (#524)
 - Unify configuration methods (#551)
 - MSRV bumped to `1.73.0` (#578)
@@ -204,7 +204,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.0.0] - 2021-09-21
 
-[Unreleased]: https://github.com/esp-rs/espflash/compare/v2.1.0...HEAD
+[3.0.0-rc.1]: https://github.com/esp-rs/espflash/compare/v2.1.0...v3.0.0-rc.1
 [2.1.0]: https://github.com/esp-rs/espflash/compare/v2.0.1...v2.1.0
 [2.0.1]: https://github.com/esp-rs/espflash/compare/v2.0.0...v2.0.1
 [2.0.0]: https://github.com/esp-rs/espflash/compare/v2.0.0-rc.4...v2.0.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -213,15 +213,15 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.14.0"
+version = "3.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f30e7476521f6f8af1a1c4c0b8cc94f0bee37d91763d0ca2665f299b6cd8aec"
+checksum = "d32a994c2b3ca201d9b263612a374263f05e7adde37c4707f693dcd375076d1f"
 
 [[package]]
 name = "bytemuck"
-version = "1.14.1"
+version = "1.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed2490600f404f2b94c167e31d3ed1d5f3c225a0f3b80230053b3e0b7b962bd9"
+checksum = "a2ef034f05691a48569bd920a96c81b9d91bbad1ab5ac7c4616c1f6ef36cb79f"
 dependencies = [
  "bytemuck_derive",
 ]
@@ -234,7 +234,7 @@ checksum = "965ab7eb5f8f97d2a083c799f3a1b994fc397b2fe2da5d1da1626ce15a39f2b1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.49",
 ]
 
 [[package]]
@@ -324,7 +324,7 @@ dependencies = [
  "sha1",
  "shell-escape",
  "supports-hyperlinks 2.1.0",
- "syn 2.0.48",
+ "syn 2.0.49",
  "tar",
  "tempfile",
  "time",
@@ -342,9 +342,9 @@ dependencies = [
 
 [[package]]
 name = "cargo-credential"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1eb63e2bf69272d1d7236a7d3083a75a8437c9ce69465a1665caa7c3a213d757"
+checksum = "ec27ad011c37339b865c765fa28096cd63d5b25fab680c04d9e410cb586c327d"
 dependencies = [
  "anyhow",
  "libc",
@@ -352,14 +352,14 @@ dependencies = [
  "serde_json",
  "thiserror",
  "time",
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
 name = "cargo-credential-libsecret"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e66f527855fced262c773931afd15340dcb0b5094f009fcb97e51dde994bc09"
+checksum = "26b0ff7a44dd0af0fcd8d09bb1a6d7f7652847cba10aad017a6ea0a25ba7f00f"
 dependencies = [
  "anyhow",
  "cargo-credential",
@@ -368,9 +368,9 @@ dependencies = [
 
 [[package]]
 name = "cargo-credential-macos-keychain"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e07c6d49412548e3bbe9824c9259253bf0355e9f4bd22aa859ea22db154ac0b5"
+checksum = "4b7cf89a47dc2c20ae3a7c94335e151be32c20f85cc2790defdb1f5dac818de5"
 dependencies = [
  "cargo-credential",
  "security-framework",
@@ -378,23 +378,23 @@ dependencies = [
 
 [[package]]
 name = "cargo-credential-wincred"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba2353aca6dcb405fab527445d65bf35b64b56f47509bba516bb0be2800f70b4"
+checksum = "341df45dc893bdffa36e2f7cbe3da90b38c5c74e7f4c0088ac801fd055b6df5b"
 dependencies = [
  "cargo-credential",
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
 name = "cargo-espflash"
-version = "3.0.0-dev"
+version = "3.0.0-rc.1"
 dependencies = [
  "cargo",
  "cargo_metadata",
  "clap",
- "env_logger",
- "esp-idf-part",
+ "env_logger 0.10.2",
+ "esp-idf-part 0.4.1",
  "espflash",
  "log",
  "miette",
@@ -405,23 +405,24 @@ dependencies = [
 
 [[package]]
 name = "cargo-platform"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ceed8ef69d8518a5dda55c07425450b58a4e1946f4951eab6d7191ee86c2443d"
+checksum = "694c8807f2ae16faecc43dc17d74b3eb042482789fd0eb64b39a2e04e087053f"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "cargo-util"
-version = "0.2.8"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb2bdd1d8ab2353ddd763881eaba60cb53f1deee0ff9d271b9f0e4cdbcd063fb"
+checksum = "74862c3c6e53a1c1f8f0178f9d38ab41e49746cd3a7cafc239b3d0248fd4e342"
 dependencies = [
  "anyhow",
  "core-foundation",
  "filetime",
  "hex",
+ "ignore",
  "jobserver",
  "libc",
  "miow",
@@ -431,7 +432,7 @@ dependencies = [
  "tempfile",
  "tracing",
  "walkdir",
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -466,9 +467,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
-version = "4.4.18"
+version = "4.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e578d6ec4194633722ccf9544794b71b1385c3c027efe0c55db226fc880865c"
+checksum = "80c21025abd42669a92efc996ef13cfb2c5c627858421ea58d5c3b331a6c134f"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -476,43 +477,43 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.4.18"
+version = "4.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4df4df40ec50c46000231c914968278b1eb05098cf8f1b3a518a95030e71d1c7"
+checksum = "458bf1f341769dfcf849846f65dffdf9146daa56bcd2a47cb4e1de9915567c99"
 dependencies = [
  "anstream",
  "anstyle",
  "clap_lex",
- "strsim",
+ "strsim 0.11.0",
  "terminal_size",
 ]
 
 [[package]]
 name = "clap_complete"
-version = "4.4.10"
+version = "4.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abb745187d7f4d76267b37485a65e0149edd0e91a4cfcdd3f27524ad86cee9f3"
+checksum = "299353be8209bd133b049bf1c63582d184a8b39fd9c04f15fe65f50f88bdfe6c"
 dependencies = [
  "clap",
 ]
 
 [[package]]
 name = "clap_derive"
-version = "4.4.7"
+version = "4.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf9804afaaf59a91e75b022a30fb7229a7901f60c755489cc61c9b423b836442"
+checksum = "307bc0538d5f0f83b8248db3087aa92fe504e4691294d0c96c0eabc33f47ba47"
 dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.49",
 ]
 
 [[package]]
 name = "clap_lex"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "702fc72eb24e5a1e48ce58027a675bc24edd52096d5397d4aea7c6dd9eca0bd1"
+checksum = "98cc8fbded0c607b7ba9dd60cd98df59af97e84d24e49c8557331cfc26d301ce"
 
 [[package]]
 name = "clru"
@@ -624,9 +625,9 @@ dependencies = [
 
 [[package]]
 name = "crates-io"
-version = "0.39.1"
+version = "0.39.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4530c82103cc1a9c776970623b07b0f5ad097c477b1b0c69d114eb1132db1a8"
+checksum = "6622f902c3c338eced1f000091f034846ae36aadaf35d0acd1ab0469a2d8ef1f"
 dependencies = [
  "curl",
  "percent-encoding",
@@ -638,9 +639,9 @@ dependencies = [
 
 [[package]]
 name = "crc32fast"
-version = "1.3.2"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d"
+checksum = "b3855a8a784b474f333699ef2bbca9db2c4a1f6d9088a90a2d25b1eb53111eaa"
 dependencies = [
  "cfg-if",
 ]
@@ -784,24 +785,24 @@ dependencies = [
 
 [[package]]
 name = "curl"
-version = "0.4.44"
+version = "0.4.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "509bd11746c7ac09ebd19f0b17782eae80aadee26237658a6b4808afb5c11a22"
+checksum = "1e2161dd6eba090ff1594084e95fd67aeccf04382ffea77999ea94ed42ec67b6"
 dependencies = [
  "curl-sys",
  "libc",
  "openssl-probe",
  "openssl-sys",
  "schannel",
- "socket2 0.4.10",
- "winapi",
+ "socket2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
 name = "curl-sys"
-version = "0.4.71+curl-8.6.0"
+version = "0.4.72+curl-8.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7b12a7ab780395666cb576203dc3ed6e01513754939a600b85196ccf5356bc5"
+checksum = "29cbdc8314c447d11e8fd156dcdd031d9e02a7a976163e396b548c03153bc9ea"
 dependencies = [
  "cc",
  "libc",
@@ -810,7 +811,7 @@ dependencies = [
  "openssl-sys",
  "pkg-config",
  "vcpkg",
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -833,7 +834,7 @@ dependencies = [
  "ident_case",
  "proc-macro2",
  "quote",
- "strsim",
+ "strsim 0.10.0",
  "syn 1.0.109",
 ]
 
@@ -850,9 +851,9 @@ dependencies = [
 
 [[package]]
 name = "defmt-decoder"
-version = "0.3.9"
+version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cc8c950fcaefdfce609498332b92c9b235c431d85c6c71908142cbb55709140"
+checksum = "edfd9e4fb2a0ad57aac44194390825607592bee871dbee99188b8287e601dffa"
 dependencies = [
  "anyhow",
  "byteorder",
@@ -882,9 +883,9 @@ dependencies = [
 
 [[package]]
 name = "defmt-parser"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "269924c02afd7f94bc4cecbfa5c379f6ffcf9766b3408fe63d22c728654eccd0"
+checksum = "ff4a5fefe330e8d7f31b16a318f9ce81000d8e35e69b93eae154d16d2278f70f"
 dependencies = [
  "thiserror",
 ]
@@ -1027,9 +1028,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.9.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a26ae43d7bcc3b814de94796a5e736d4029efb0ee900c12e2d54c993ad1a1e07"
+checksum = "11157ac094ffbdde99aa67b23417ebdd801842852b500e395a45a9c0aac03e4a"
 
 [[package]]
 name = "elliptic-curve"
@@ -1068,6 +1069,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "env_filter"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a009aa4810eb158359dda09d0c87378e4bbb89b5a801f016885a4707ba24f7ea"
+dependencies = [
+ "log",
+ "regex",
+]
+
+[[package]]
 name = "env_logger"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1078,6 +1089,19 @@ dependencies = [
  "log",
  "regex",
  "termcolor",
+]
+
+[[package]]
+name = "env_logger"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c012a26a7f605efc424dd53697843a72be7dc86ad2d01f7814337794a12231d"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "env_filter",
+ "humantime",
+ "log",
 ]
 
 [[package]]
@@ -1113,7 +1137,7 @@ checksum = "28192549b6c3d0bfd3be8ff694802b8d92ff7e1b12a6fd0285ca96c66e97bed3"
 dependencies = [
  "csv",
  "deku",
- "heapless",
+ "heapless 0.7.17",
  "md5",
  "parse_int",
  "regex",
@@ -1124,8 +1148,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "esp-idf-part"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59f50b6c32370067087b46087cd5333f2dfe678f0b01223fa70fde6f15449844"
+dependencies = [
+ "csv",
+ "deku",
+ "heapless 0.8.0",
+ "md5",
+ "parse_int",
+ "regex",
+ "serde",
+ "serde_plain",
+ "strum 0.26.1",
+ "thiserror",
+]
+
+[[package]]
 name = "espflash"
-version = "3.0.0-dev"
+version = "3.0.0-rc.1"
 dependencies = [
  "addr2line",
  "base64",
@@ -1139,8 +1181,8 @@ dependencies = [
  "defmt-parser",
  "dialoguer",
  "directories",
- "env_logger",
- "esp-idf-part",
+ "env_logger 0.11.2",
+ "esp-idf-part 0.5.0",
  "flate2",
  "hex",
  "indicatif",
@@ -1351,9 +1393,9 @@ dependencies = [
 
 [[package]]
 name = "git2"
-version = "0.18.1"
+version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbf97ba92db08df386e10c8ede66a2a0369bd277090afd8710e19e38de9ec0cd"
+checksum = "1b3ba52851e73b46a4c3df1d89343741112003f0f6f13beb0dfac9e457c3fdcd"
 dependencies = [
  "bitflags 2.4.2",
  "libc",
@@ -1441,7 +1483,7 @@ dependencies = [
  "gix-date",
  "itoa",
  "thiserror",
- "winnow",
+ "winnow 0.5.40",
 ]
 
 [[package]]
@@ -1520,7 +1562,7 @@ dependencies = [
  "smallvec",
  "thiserror",
  "unicode-bom",
- "winnow",
+ "winnow 0.5.40",
 ]
 
 [[package]]
@@ -1738,7 +1780,7 @@ checksum = "d75e7ab728059f595f6ddc1ad8771b8d6a231971ae493d9d5948ecad366ee8bb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.49",
 ]
 
 [[package]]
@@ -1773,7 +1815,7 @@ dependencies = [
  "itoa",
  "smallvec",
  "thiserror",
- "winnow",
+ "winnow 0.5.40",
 ]
 
 [[package]]
@@ -1893,7 +1935,7 @@ dependencies = [
  "gix-transport",
  "maybe-async",
  "thiserror",
- "winnow",
+ "winnow 0.5.40",
 ]
 
 [[package]]
@@ -1925,7 +1967,7 @@ dependencies = [
  "gix-validate",
  "memmap2 0.7.1",
  "thiserror",
- "winnow",
+ "winnow 0.5.40",
 ]
 
 [[package]]
@@ -2165,6 +2207,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "hash32"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47d60b12902ba28e2730cd37e95b8c9223af2808df9e902d4df49588d1470606"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2177,10 +2228,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdc6457c0eb62c71aac4bc17216026d8410337c4126773b9c5daba343f17964f"
 dependencies = [
  "atomic-polyfill",
- "hash32",
+ "hash32 0.2.1",
  "rustc_version",
  "serde",
  "spin",
+ "stable_deref_trait",
+]
+
+[[package]]
+name = "heapless"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bfb9eb618601c89945a70e254898da93b13be0388091d42117462b265bb3fad"
+dependencies = [
+ "hash32 0.3.1",
+ "serde",
  "stable_deref_trait",
 ]
 
@@ -2192,9 +2254,9 @@ checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "hermit-abi"
-version = "0.3.5"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0c62115964e08cb8039170eb33c1d0e2388a256930279edca206fff675f82c3"
+checksum = "bd5256b483761cd23699d0da46cc6fd2ee3be420bbe6d020ae4a091e70b7e9fd"
 
 [[package]]
 name = "hex"
@@ -2298,7 +2360,7 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "socket2 0.5.5",
+ "socket2",
  "tokio",
  "tower-service",
  "tracing",
@@ -2314,7 +2376,7 @@ dependencies = [
  "futures-util",
  "http",
  "hyper",
- "rustls",
+ "rustls 0.21.10",
  "tokio",
  "tokio-rustls",
 ]
@@ -2367,9 +2429,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.2.2"
+version = "2.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "824b2ae422412366ba479e8111fd301f7b5faece8149317bb81925979a53f520"
+checksum = "233cf39063f058ea2caae4091bf4a3ef70a653afbc026f5c4a4135d114e3c177"
 dependencies = [
  "equivalent",
  "hashbrown",
@@ -2377,9 +2439,9 @@ dependencies = [
 
 [[package]]
 name = "indicatif"
-version = "0.17.7"
+version = "0.17.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb28741c9db9a713d93deb3bb9515c20788cef5815265bee4980e87bde7e0f25"
+checksum = "763a5a8f45087d6bcea4222e7b72c291a054edf80e4ef6efd2a4979878c7bea3"
 dependencies = [
  "console",
  "instant",
@@ -2415,12 +2477,12 @@ checksum = "8f518f335dce6725a761382244631d86cf0ccb2863413590b31338feb467f9c3"
 
 [[package]]
 name = "is-terminal"
-version = "0.4.10"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bad00257d07be169d870ab665980b06cdb366d792ad690bf2e76876dc503455"
+checksum = "f23ff5ef2b80d608d61efee834934d862cd92461afc0560dedf493e4c033738b"
 dependencies = [
  "hermit-abi",
- "rustix",
+ "libc",
  "windows-sys 0.52.0",
 ]
 
@@ -2447,18 +2509,18 @@ checksum = "b1a46d1a171d865aa5f83f92695765caa047a9b4cbae2cbf37dbd613a793fd4c"
 
 [[package]]
 name = "jobserver"
-version = "0.1.27"
+version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c37f63953c4c63420ed5fd3d6d398c719489b9f872b9fa683262f8edd363c7d"
+checksum = "ab46a6e9526ddef3ae7f787c06f0f2600639ba80ea3eade3d8e670a2230f51d6"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "js-sys"
-version = "0.3.67"
+version = "0.3.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a1d36f1235bc969acba30b7f5990b864423a6068a10f7c90ae8f0112e3a59d1"
+checksum = "406cda4b368d531c842222cf9d2600a9a4acce8d29423695379c6868a143a9ee"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -2492,9 +2554,9 @@ checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
 
 [[package]]
 name = "libgit2-sys"
-version = "0.16.1+1.7.1"
+version = "0.16.2+1.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2a2bb3680b094add03bb3732ec520ece34da31a8cd2d633d1389d0f0fb60d0c"
+checksum = "ee4126d8b4ee5c9d9ea891dd875cfdc1e9d0950437179104b183d7d8a74d24e8"
 dependencies = [
  "cc",
  "libc",
@@ -2632,7 +2694,7 @@ checksum = "afc95a651c82daf7004c824405aa1019723644950d488571bd718e3ed84646ed"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.49",
 ]
 
 [[package]]
@@ -2686,9 +2748,9 @@ dependencies = [
 
 [[package]]
 name = "miette"
-version = "7.0.0"
+version = "7.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98a72adfa0c7ae88ba0abcbd00047a476616c66b831d628b8ac7f1e9de0cfd67"
+checksum = "baed61d13cc3723ee6dbed730a82bfacedc60a85d81da2d77e9c3e8ebc0b504a"
 dependencies = [
  "backtrace",
  "backtrace-ext",
@@ -2705,13 +2767,13 @@ dependencies = [
 
 [[package]]
 name = "miette-derive"
-version = "7.0.0"
+version = "7.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "279def6bf114a34b3cf887489eb440d4dfcf709ab3ce9955e4a6f957ce5cce77"
+checksum = "f301c3f54f98abc6c212ee722f5e5c62e472a334415840669e356f04850051ec"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.49",
 ]
 
 [[package]]
@@ -2815,9 +2877,9 @@ checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
 
 [[package]]
 name = "num-traits"
-version = "0.2.17"
+version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39e3200413f237f41ab11ad6d161bc7239c84dcb631773ccd7de3dfe4b5c267c"
+checksum = "da0df0e5185db44f69b44f26786fe401b6c293d1907744beaa7fa62b2e5a517a"
 dependencies = [
  "autocfg",
 ]
@@ -2834,9 +2896,9 @@ dependencies = [
 
 [[package]]
 name = "num_threads"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2819ce041d2ee131036f4fc9d6ae7ae125a3a40e97ba64d04fe799ad9dabbb44"
+checksum = "5c7398b9c8b70908f6371f47ed36737907c87c52af34c268fed0bf0ceb92ead9"
 dependencies = [
  "libc",
 ]
@@ -2898,7 +2960,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.49",
 ]
 
 [[package]]
@@ -2909,9 +2971,9 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-src"
-version = "300.2.2+3.2.1"
+version = "300.2.3+3.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bbfad0063610ac26ee79f7484739e2b07555a75c42453b89263830b5c8103bc"
+checksum = "5cff92b6f71555b61bb9315f7c64da3ca43d87531622120fea0195fc761b4843"
 dependencies = [
  "cc",
 ]
@@ -3088,9 +3150,9 @@ dependencies = [
 
 [[package]]
 name = "pkg-config"
-version = "0.3.29"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2900ede94e305130c13ddd391e0ab7cbaeb783945ae07a279c268cb05109c6cb"
+checksum = "d231b230927b5e4ad203db57bbcbee2802f6bce620b1e4a9024a07d94e2907ec"
 
 [[package]]
 name = "portable-atomic"
@@ -3299,7 +3361,7 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
- "rustls",
+ "rustls 0.21.10",
  "rustls-pemfile",
  "serde",
  "serde_json",
@@ -3313,7 +3375,7 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "webpki-roots",
+ "webpki-roots 0.25.4",
  "winreg",
 ]
 
@@ -3389,8 +3451,22 @@ checksum = "f9d5a6813c0759e4609cd494e8e725babae6a2ca7b62a5536a13daaec6fcb7ba"
 dependencies = [
  "log",
  "ring",
- "rustls-webpki",
+ "rustls-webpki 0.101.7",
  "sct",
+]
+
+[[package]]
+name = "rustls"
+version = "0.22.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e87c9956bd9807afa1f77e0f7594af32566e830e088a5576d27c5b6f30f49d41"
+dependencies = [
+ "log",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki 0.102.2",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -3403,12 +3479,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-pki-types"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "048a63e5b3ac996d78d402940b5fa47973d2d080c6c6fffa1d0f19c4445310b7"
+
+[[package]]
 name = "rustls-webpki"
 version = "0.101.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
 dependencies = [
  "ring",
+ "untrusted",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.102.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "faaa0a62740bedb9b2ef5afa303da42764c012f743917351dc9a237ea1663610"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
  "untrusted",
 ]
 
@@ -3552,7 +3645,7 @@ checksum = "33c85360c95e7d137454dc81d9a4ed2b8efd8fbe19cee57357b32b9771fccb67"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.49",
 ]
 
 [[package]]
@@ -3752,16 +3845,6 @@ checksum = "b7c388c1b5e93756d0c740965c41e8822f866621d41acbdf6336a6a168f8840c"
 
 [[package]]
 name = "socket2"
-version = "0.4.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f7916fc008ca5542385b89a3d3ce689953c143e9304a9bf8beec1de48994c0d"
-dependencies = [
- "libc",
- "winapi",
-]
-
-[[package]]
-name = "socket2"
 version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b5fac59a5cb5dd637972e5fca70daf0523c9067fcdc4842f053dae04a18f8e9"
@@ -3806,6 +3889,12 @@ name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+
+[[package]]
+name = "strsim"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ee073c9e4cd00e28217186dbe12796d692868f432bf2e97ee73bed0c56dfa01"
 
 [[package]]
 name = "strum"
@@ -3854,7 +3943,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.48",
+ "syn 2.0.49",
 ]
 
 [[package]]
@@ -3867,7 +3956,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.48",
+ "syn 2.0.49",
 ]
 
 [[package]]
@@ -3919,9 +4008,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.48"
+version = "2.0.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f3531638e407dfc0814761abb7c00a5b54992b849452a0646b7f65c9f770f3f"
+checksum = "915aea9e586f80826ee59f8453c1101f9d1c4b3964cd2460185ee8e299ada496"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4015,22 +4104,22 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.56"
+version = "1.0.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d54378c645627613241d077a3a79db965db602882668f9136ac42af9ecb730ad"
+checksum = "1e45bcbe8ed29775f228095caf2cd67af7a4ccf756ebff23a306bf3e8b47b24b"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.56"
+version = "1.0.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa0faa943b50f3db30a20aa7e265dbc66076993efed8463e8de414e5d06d3471"
+checksum = "a953cb265bef375dae3de6663da4d3804eee9682ea80d8e2542529b73c531c81"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.49",
 ]
 
 [[package]]
@@ -4103,7 +4192,7 @@ dependencies = [
  "mio",
  "num_cpus",
  "pin-project-lite",
- "socket2 0.5.5",
+ "socket2",
  "windows-sys 0.48.0",
 ]
 
@@ -4113,7 +4202,7 @@ version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
 dependencies = [
- "rustls",
+ "rustls 0.21.10",
  "tokio",
 ]
 
@@ -4140,7 +4229,7 @@ dependencies = [
  "serde",
  "serde_spanned",
  "toml_datetime",
- "toml_edit 0.22.4",
+ "toml_edit 0.22.6",
 ]
 
 [[package]]
@@ -4160,7 +4249,7 @@ checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
 dependencies = [
  "indexmap",
  "toml_datetime",
- "winnow",
+ "winnow 0.5.40",
 ]
 
 [[package]]
@@ -4173,20 +4262,20 @@ dependencies = [
  "serde",
  "serde_spanned",
  "toml_datetime",
- "winnow",
+ "winnow 0.5.40",
 ]
 
 [[package]]
 name = "toml_edit"
-version = "0.22.4"
+version = "0.22.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c9ffdf896f8daaabf9b66ba8e77ea1ed5ed0f72821b398aba62352e95062951"
+checksum = "2c1b5fd4128cc8d3e0cb74d4ed9a9cc7c7284becd4df68f5f940e1ad123606f6"
 dependencies = [
  "indexmap",
  "serde",
  "serde_spanned",
  "toml_datetime",
- "winnow",
+ "winnow 0.6.1",
 ]
 
 [[package]]
@@ -4214,7 +4303,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.49",
 ]
 
 [[package]]
@@ -4363,20 +4452,21 @@ dependencies = [
 
 [[package]]
 name = "ureq"
-version = "2.9.1"
+version = "2.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8cdd25c339e200129fe4de81451814e5228c9b771d57378817d6117cc2b3f97"
+checksum = "11f214ce18d8b2cbe84ed3aa6486ed3f5b285cf8d8fbdbce9f3f767a724adc35"
 dependencies = [
  "base64",
  "flate2",
  "log",
  "once_cell",
- "rustls",
- "rustls-webpki",
+ "rustls 0.22.2",
+ "rustls-pki-types",
+ "rustls-webpki 0.102.2",
  "serde",
  "serde_json",
  "url",
- "webpki-roots",
+ "webpki-roots 0.26.1",
 ]
 
 [[package]]
@@ -4441,9 +4531,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.90"
+version = "0.2.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1223296a201415c7fad14792dbefaace9bd52b62d33453ade1c5b5f07555406"
+checksum = "c1e124130aee3fb58c5bdd6b639a0509486b0338acaaae0c84a5124b0f588b7f"
 dependencies = [
  "cfg-if",
  "wasm-bindgen-macro",
@@ -4451,24 +4541,24 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.90"
+version = "0.2.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcdc935b63408d58a32f8cc9738a0bffd8f05cc7c002086c6ef20b7312ad9dcd"
+checksum = "c9e7e1900c352b609c8488ad12639a311045f40a35491fb69ba8c12f758af70b"
 dependencies = [
  "bumpalo",
  "log",
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.49",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.40"
+version = "0.4.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bde2032aeb86bdfaecc8b261eef3cba735cc426c1f3a3416d1e0791be95fc461"
+checksum = "877b9c3f61ceea0e56331985743b13f3d25c406a7098d45180fb5f09bc19ed97"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -4478,9 +4568,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.90"
+version = "0.2.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e4c238561b2d428924c49815533a8b9121c664599558a5d9ec51f8a1740a999"
+checksum = "b30af9e2d358182b5c7449424f017eba305ed32a7010509ede96cdc4696c46ed"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -4488,28 +4578,28 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.90"
+version = "0.2.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bae1abb6806dc1ad9e560ed242107c0f6c84335f1749dd4e8ddb012ebd5e25a7"
+checksum = "642f325be6301eb8107a83d12a8ac6c1e1c54345a7ef1a9261962dfefda09e66"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.49",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.90"
+version = "0.2.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d91413b1c31d7539ba5ef2451af3f0b833a005eb27a631cec32bc0635a8602b"
+checksum = "4f186bd2dcf04330886ce82d6f33dd75a7bfcf69ecf5763b89fcde53b6ac9838"
 
 [[package]]
 name = "web-sys"
-version = "0.3.67"
+version = "0.3.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58cd2333b6e0be7a39605f0e255892fd7418a682d8da8fe042fe25128794d2ed"
+checksum = "96565907687f7aceb35bc5fc03770a8a0471d82e479f25832f54a0e3f4b28446"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -4520,6 +4610,15 @@ name = "webpki-roots"
 version = "0.25.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
+
+[[package]]
+name = "webpki-roots"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3de34ae270483955a94f4b21bdaaeb83d508bb84a01435f393818edb0012009"
+dependencies = [
+ "rustls-pki-types",
+]
 
 [[package]]
 name = "winapi"
@@ -4686,9 +4785,18 @@ checksum = "dff9641d1cd4be8d1a070daf9e3773c5f67e78b4d9d42263020c057706765c04"
 
 [[package]]
 name = "winnow"
-version = "0.5.37"
+version = "0.5.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7cad8365489051ae9f054164e459304af2e7e9bb407c958076c8bf4aef52da5"
+checksum = "f593a95398737aeed53e489c785df13f3618e41dbcd6718c6addbf1395aa6876"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "winnow"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d90f4e0f530c4c69f62b80d839e9ef3855edc9cba471a160c4d692deed62b401"
 dependencies = [
  "memchr",
 ]

--- a/cargo-espflash/Cargo.toml
+++ b/cargo-espflash/Cargo.toml
@@ -2,7 +2,7 @@
 name = "cargo-espflash"
 version = "3.0.0-rc.1"
 edition = "2021"
-rust-version = "1.73"
+rust-version = "1.74"
 description  = "Cargo subcommand for flashing Espressif devices"
 repository   = "https://github.com/esp-rs/espflash"
 license      = "MIT OR Apache-2.0"

--- a/cargo-espflash/Cargo.toml
+++ b/cargo-espflash/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-espflash"
-version = "3.0.0-dev"
+version = "3.0.0-rc.1"
 edition = "2021"
 rust-version = "1.73"
 description  = "Cargo subcommand for flashing Espressif devices"
@@ -19,7 +19,7 @@ cargo_metadata = "0.18.1"
 clap = { version = "4.4.18", features = ["derive", "wrap_help"] }
 env_logger = "0.10.2"
 esp-idf-part = "0.4.1"
-espflash = { version = "3.0.0-dev", path = "../espflash" }
+espflash = { version = "3.0.0-rc.1", path = "../espflash" }
 log = "0.4.20"
 miette = { version = "7.0.0", features = ["fancy"] }
 serde = { version = "1.0.196", features = ["derive"] }

--- a/cargo-espflash/README.md
+++ b/cargo-espflash/README.md
@@ -2,7 +2,7 @@
 # cargo-espflash
 
 [![Crates.io](https://img.shields.io/crates/v/cargo-espflash?labelColor=1C2C2E&color=C96329&logo=Rust&style=flat-square)](https://crates.io/crates/cargo-espflash)
-![MSRV](https://img.shields.io/badge/MSRV-1.73-blue?labelColor=1C2C2E&logo=Rust&style=flat-square)
+![MSRV](https://img.shields.io/badge/MSRV-1.74-blue?labelColor=1C2C2E&logo=Rust&style=flat-square)
 ![Crates.io](https://img.shields.io/crates/l/cargo-espflash?labelColor=1C2C2E&style=flat-square)
 
 Cross-compiler and Cargo extension for flashing Espressif devices.
@@ -25,7 +25,7 @@ Supports the **ESP32**, **ESP32-C2/C3/C6**, **ESP32-H2**, **ESP32-P4**, and **ES
 
 ## Installation
 
-If you are installing `cargo-espflash` from source (ie. using `cargo install`) then you must have `rustc>=1.73.0` installed on your system.
+If you are installing `cargo-espflash` from source (ie. using `cargo install`) then you must have `rustc>=1.74.0` installed on your system.
 
 If you are running **macOS** or **Linux** then [libuv] must also be installed; this is available via most popular package managers. If you are running **Windows** you can ignore this step.
 

--- a/espflash/Cargo.toml
+++ b/espflash/Cargo.toml
@@ -2,7 +2,7 @@
 name = "espflash"
 version = "3.0.0-rc.1"
 edition = "2021"
-rust-version = "1.73"
+rust-version = "1.74"
 description  = "A command-line tool for flashing Espressif devices"
 repository   = "https://github.com/esp-rs/espflash"
 license      = "MIT OR Apache-2.0"

--- a/espflash/Cargo.toml
+++ b/espflash/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "espflash"
-version = "3.0.0-dev"
+version = "3.0.0-rc.1"
 edition = "2021"
 rust-version = "1.73"
 description  = "A command-line tool for flashing Espressif devices"
@@ -29,15 +29,15 @@ bytemuck = { version = "1.14.1", features = ["derive"] }
 clap = { version = "4.4.18", features = ["derive", "env", "wrap_help"], optional = true }
 clap_complete = { version = "4.4.10", optional = true }
 comfy-table = { version = "7.1.0", optional = true }
-crossterm = { version = "0.25.0", optional = true } # 0.26.x causes issues on Windows
+crossterm = { version = "0.25.0", optional = true } # 0.26.x and 0.27.x causes issues on Windows
 ctrlc = { version = "3.4.2", optional = true }
 # defmt dependencies are pinned since defmt does not guarantee MSRV even for patch releases
-defmt-decoder = { version = "=0.3.9", features = ["unstable"], optional = true }
-defmt-parser = { version = "=0.3.3", features = ["unstable"], optional = true }
+defmt-decoder = { version = "=0.3.10", features = ["unstable"], optional = true }
+defmt-parser = { version = "=0.3.4", features = ["unstable"], optional = true }
 dialoguer = { version = "0.11.0", optional = true }
 directories = { version = "5.0.1", optional = true }
-env_logger = { version = "0.10.2", optional = true }
-esp-idf-part = "0.4.1"
+env_logger = { version = "0.11.2", optional = true }
+esp-idf-part = "0.5.0"
 flate2 = "1.0.28"
 hex = { version = "0.4.3", features = ["serde"], optional = true }
 indicatif = { version = "0.17.7", optional = true }

--- a/espflash/README.md
+++ b/espflash/README.md
@@ -3,7 +3,7 @@
 
 [![Crates.io](https://img.shields.io/crates/v/espflash?labelColor=1C2C2E&color=C96329&logo=Rust&style=flat-square)](https://crates.io/crates/espflash)
 [![docs.rs](https://img.shields.io/docsrs/espflash?labelColor=1C2C2E&color=C96329&logo=rust&style=flat-square)](https://docs.rs/espflash)
-![MSRV](https://img.shields.io/badge/MSRV-1.73-blue?labelColor=1C2C2E&logo=Rust&style=flat-square)
+![MSRV](https://img.shields.io/badge/MSRV-1.74-blue?labelColor=1C2C2E&logo=Rust&style=flat-square)
 ![Crates.io](https://img.shields.io/crates/l/espflash?labelColor=1C2C2E&style=flat-square)
 
 A library and command-line tool for flashing Espressif devices.
@@ -27,7 +27,7 @@ Supports the **ESP32**, **ESP32-C2/C3/C6**, **ESP32-H2**, **ESP32-P4**, and **ES
 
 ## Installation
 
-If you are installing `espflash` from source (ie. using `cargo install`) then you must have `rustc>=1.73.0` installed on your system.
+If you are installing `espflash` from source (ie. using `cargo install`) then you must have `rustc>=1.74.0` installed on your system.
 
 If you are running **macOS** or **Linux** then [libuv] must also be installed; this is available via most popular package managers. If you are running **Windows** you can ignore this step.
 

--- a/espflash/src/error.rs
+++ b/espflash/src/error.rs
@@ -125,7 +125,7 @@ pub enum Error {
 
     #[error("This command requires using the RAM stub")]
     #[diagnostic(
-        code(espflash::stub_required_to_erase_flash),
+        code(espflash::stub_required),
         help("Don't use the `--no-stub` option with the command")
     )]
     StubRequired,


### PR DESCRIPTION
- Bump dependencies
- Updated and formated changelog for the rc
- Bump espflash and cargo-espflash version to `3.0.0-rc.1`
- Bump MSRV to 1.74

## Tests
I've successfully finished a round of testing, where I tested:
- Flashing and monitoring
- Erasing and reading flash
- Save-image and write-bin
- Configuration file (locally and globally)
See details test and results bellow.

### Flash/Monitoring
Used a basic `esp-template` for all targets and also an `esp-idf-tempalte` in C3 and S3
- ESP32
    - `cargo espflash flash -M`
    - `espflash flash -M`
    - `espflash monitor`
- ESP32-S2 (UART port)
    - `cargo espflash flash -M`
    - `espflash flash -M`
- ESP32-S3 (UART, USB ports) - std and no_std app
    - `cargo espflash flash -M`
    - `espflash flash -M`
- ESP32-C2 (26MHz and 40MHz)
    - `cargo espflash flash -M`
    - `espflash flash -M` 
- ESP32-C3 (UART, USB ports) ) - std and no_std app
    - `cargo espflash flash -M`
    - `espflash flash -M` 
- ESP32-C6 (UART, USB ports)
    - `cargo espflash flash -M`
    - `espflash flash -M` 
-  ESP32-H2 (UART, USB ports)
    - `cargo espflash flash -M`
    - `espflash flash -M`
      
### Erase/Read flash (On S3)
- `espflash read-flash  0 0x200 flash_content.bin && hexdump -C flash_content.bin`
```
00000000  e9 04 02 20 08 99 3c 40  ee 00 00 00 09 00 00 00  |... ..<@........|
00000010  00 63 00 00 00 00 00 01  18 38 ce 3f 50 17 00 00  |.c.......8.?P...|
00000020  ff ff ff ff 1b 00 00 00  1b 00 00 00 1c 00 00 00  |................|
00000030  1c 00 00 00 28 50 04 00  f8 27 03 00 01 00 00 00  |....(P...'......|
00000040  00 f0 01 60 00 00 00 00  04 00 00 00 05 00 00 00  |...`............|
00000050  06 00 00 00 07 00 00 00  41 73 73 65 72 74 20 66  |........Assert f|
00000060  61 69 6c 65 64 20 69 6e  20 25 73 2c 20 25 73 3a  |ailed in %s, %s:|
00000070  25 64 20 28 25 73 29 0d  0a 00 61 62 6f 72 74 28  |%d (%s)...abort(|
00000080  29 20 77 61 73 20 63 61  6c 6c 65 64 20 61 74 20  |) was called at |
00000090  50 43 20 30 78 25 30 38  78 0d 0a 00 62 6f 6f 74  |PC 0x%08x...boot|
000000a0  00 1b 5b 30 3b 33 31 6d  45 20 28 25 6c 75 29 20  |..[0;31mE (%lu) |
000000b0  25 73 3a 20 6c 6f 61 64  20 70 61 72 74 69 74 69  |%s: load partiti|
000000c0  6f 6e 20 74 61 62 6c 65  20 65 72 72 6f 72 21 1b  |on table error!.|
000000d0  5b 30 6d 0a 00 20 69 73  20 6e 6f 74 20 62 6f 6f  |[0m.. is not boo|
000000e0  74 61 62 6c 65 00 1b 5b  30 3b 33 31 6d 45 20 28  |table..[0;31mE (|
000000f0  25 6c 75 29 20 25 73 3a  20 46 61 63 74 6f 72 79  |%lu) %s: Factory|
00000100  20 61 70 70 20 70 61 72  74 69 74 69 6f 6e 25 73  | app partition%s|
00000110  1b 5b 30 6d 0a 00 1b 5b  30 3b 33 31 6d 45 20 28  |.[0m...[0;31mE (|
00000120  25 6c 75 29 20 25 73 3a  20 46 61 63 74 6f 72 79  |%lu) %s: Factory|
00000130  20 74 65 73 74 20 61 70  70 20 70 61 72 74 69 74  | test app partit|
00000140  69 6f 6e 25 73 1b 5b 30  6d 0a 00 1b 5b 30 3b 33  |ion%s.[0m...[0;3|
00000150  31 6d 45 20 28 25 6c 75  29 20 25 73 3a 20 4f 54  |1mE (%lu) %s: OT|
00000160  41 20 61 70 70 20 70 61  72 74 69 74 69 6f 6e 20  |A app partition |
00000170  73 6c 6f 74 20 25 64 25  73 1b 5b 30 6d 0a 00 1b  |slot %d%s.[0m...|
00000180  5b 30 3b 33 32 6d 49 20  28 25 6c 75 29 20 25 73  |[0;32mI (%lu) %s|
00000190  3a 20 44 69 73 61 62 6c  69 6e 67 20 52 4e 47 20  |: Disabling RNG |
000001a0  65 61 72 6c 79 20 65 6e  74 72 6f 70 79 20 73 6f  |early entropy so|
000001b0  75 72 63 65 2e 2e 2e 1b  5b 30 6d 0a 00 44 52 4f  |urce....[0m..DRO|
000001c0  4d 00 1b 5b 30 3b 33 31  6d 45 20 28 25 6c 75 29  |M..[0;31mE (%lu)|
000001d0  20 25 73 3a 20 49 6d 61  67 65 20 63 6f 6e 74 61  | %s: Image conta|
000001e0  69 6e 73 20 6d 75 6c 74  69 70 6c 65 20 25 73 20  |ins multiple %s |
000001f0  73 65 67 6d 65 6e 74 73  2e 20 4f 6e 6c 79 20 74  |segments. Only t|
00000200
```
- `espflash erase-flash`, then `espflash  read-flash  0 0x200 flash_content.bin && hexdump -C flash_content.bin`:
```
❯ hexdump -C flash_content.bin
00000000  ff ff ff ff ff ff ff ff  ff ff ff ff ff ff ff ff  |................|
*
00000200
```

### Save-image/write-bin (ESP32)
- `espflash save-image --merge --chip esp32 app.bin`
- `espflash write-bin 0x0 app.bin`
- `espflash monitor`

### Configuration file (C3)

#### Local config file
- Using the following `<cwd>/espflash.toml`:
```toml
baudrate = 460800
bootloader = "/home/sergio/Documents/Espressif/tests/confgi6/bootloader.bin"
partition_table = "/home/sergio/Documents/Espressif/tests/confgi6/partition-table.bin"

[connection]

[[usb_device]]
vid = "303a"
pid = "1001"
```
And using `RUST_LOG=debug cargo r`, we can spot the following:
```
...
[2024-02-16T12:28:04Z DEBUG] Config: Config {
        baudrate: Some(
            460800,
        ),
        bootloader: Some(
            "/home/sergio/Documents/Espressif/tests/confgi6/bootloader.bin",
        ),
        connection: Connection {
            serial: None,
        },
        partition_table: Some(
            "/home/sergio/Documents/Espressif/tests/confgi6/partition-table.bin",
        ),
        usb_device: [
            UsbDevice {
                vid: 12346,
                pid: 4097,
            },
        ],
        save_path: "/home/sergio/Documents/Espressif/tests/config/espflash.toml",
    }
...
Bootloader:        /home/sergio/Documents/Espressif/tests/confgi6/bootloader.bin
Partition table:   /home/sergio/Documents/Espressif/tests/confgi6/partition-table.bin
App/part. siz
...
[2024-02-16T12:28:05Z DEBUG] Change baud to: 460800
...
```

#### Global config file
- Using the following `$HOME/.config/espflash/espflash.toml`:
```toml
baudrate = 921600
bootloader = "/home/sergio/Documents/Espressif/tests/templates/std/esp32c3/target/riscv32imc-esp-espidf/debug/bootloader.bin"
partition_table = "/home/sergio/Documents/Espressif/tests/templates/std/esp32c3/target/riscv32imc-esp-espidf/debug/partition-table.bin"
[[usb_device]]
vid = "303a"
pid = "1001"
```
And using `RUST_LOG=debug cargo r`, we can spot the following:
```
...
[2024-02-16T12:33:36Z DEBUG] Config: Config {
        baudrate: Some(
            921600,
        ),
        bootloader: Some(
            "/home/sergio/Documents/Espressif/tests/templates/std/esp32c3/target/riscv32imc-esp-espidf/debug/bootloader.bin",
        ),
        connection: Connection {
            serial: None,
        },
        partition_table: Some(
            "/home/sergio/Documents/Espressif/tests/templates/std/esp32c3/target/riscv32imc-esp-espidf/debug/partition-table.bin",
        ),
        usb_device: [
            UsbDevice {
                vid: 12346,
                pid: 4097,
            },
        ],
        save_path: "/home/sergio/.config/espflash/espflash.toml",
    }
...
Bootloader:        /home/sergio/Documents/Espressif/tests/templates/std/esp32c3/target/riscv32imc-esp-espidf/debug/bootloader.bin
Partition table:   /home/sergio/Documents/Espressif/tests/templates/std/esp32c3/target/riscv32imc-esp-espidf/debug/partition-table.bin 
...
[2024-02-16T12:33:36Z DEBUG] Change baud to: 921600
...
```