### PR TITLE
Address minor feedback things of rc.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+### Fixed
+
+### Changed
+
+### Removed
+
 ## [3.0.0-rc.1] - 2024-02-16
 
 ### Added
@@ -47,6 +57,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
+- Remove support for Cargo metadata configuration (#551)
 - Remove support for the ESP8266 (#576)
 - Remove the direct boot image format (#577)
 - Remove support for Raspberry Pi's internal UART peripherals (#585)
@@ -204,6 +215,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.0.0] - 2021-09-21
 
+[Unreleased]: https://github.com/esp-rs/espflash/compare/v3.0.0-rc.1...HEAD
 [3.0.0-rc.1]: https://github.com/esp-rs/espflash/compare/v2.1.0...v3.0.0-rc.1
 [2.1.0]: https://github.com/esp-rs/espflash/compare/v2.0.1...v2.1.0
 [2.0.1]: https://github.com/esp-rs/espflash/compare/v2.0.0...v2.0.1

--- a/espflash/src/targets/flash_target/esp32.rs
+++ b/espflash/src/targets/flash_target/esp32.rs
@@ -4,7 +4,7 @@ use flate2::{
     write::{ZlibDecoder, ZlibEncoder},
     Compression,
 };
-use log::debug;
+use log::info;
 use md5::{Digest, Md5};
 
 #[cfg(feature = "serialport")]
@@ -155,7 +155,10 @@ impl FlashTarget for Esp32Target {
                 })?;
 
             if checksum_md5.as_slice() == flash_checksum_md5.to_be_bytes() {
-                debug!("Skipping segment at address {:x}", addr);
+                info!(
+                    "Segment at address '0x{:x}' has not changed, skipping write",
+                    addr
+                );
                 return Ok(());
             }
         }


### PR DESCRIPTION
- Prepare CHANGELOG for next dev-cycle
- Update log message when we skip writing a segment. Here is how it looks, reflashing an app where only the app changed:
  ```
  ...
  App/part. size:    223,776/4,128,768 bytes, 5.42%
  [2024-02-19T09:16:12Z INFO ] Segment at address '0x0' did not change, skipping it
  [2024-02-19T09:16:12Z INFO ] Segment at address '0x8000' did not change, skipping it
  [00:00:01] [========================================]      74/74      0x10000                                                                                                                                                                                    [2024-02-19T09:16:14Z INFO ] Flashing has completed!
  ```
- Include the removal of Cargo package metadata configuration in changelog.


cc: @jessebraham @Vollbrecht