### PR TITLE
Add list-all-ports flag and filter the default list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Add `--list-all-ports` connection argument to avoid serial port filtering (#590)
 
 ### Fixed
 
 ### Changed
+- Non-linux-musl: Only list the available USB Ports by default (#590)
+
 
 ### Removed
 

--- a/espflash/src/cli/mod.rs
+++ b/espflash/src/cli/mod.rs
@@ -61,6 +61,9 @@ pub struct ConnectArgs {
     /// Require confirmation before auto-connecting to a recognized device.
     #[arg(short = 'C', long)]
     pub confirm_port: bool,
+    /// List all available ports.
+    #[arg(long)]
+    pub list_all_ports: bool,
     /// Do not use the RAM stub for loading
     #[arg(long)]
     pub no_stub: bool,

--- a/espflash/src/error.rs
+++ b/espflash/src/error.rs
@@ -115,7 +115,7 @@ pub enum Error {
     #[error("No serial ports could be detected")]
     #[diagnostic(
         code(espflash::no_serial),
-        help("Make sure you have connected a device to the host system")
+        help("Make sure you have connected a device to the host system. If the device is connected but not listed, try using the `--list-all-ports` flag.")
     )]
     NoSerial,
 


### PR DESCRIPTION
- Add `--list-all-ports` connection argument to avoid serial port filtering
- In all the targets, except for linux-musl, only list the available USB Ports by default (#590)

~~Draft PR until it can be properly tested and we verify that it closes #575~~
@jessebraham verified that it resolves #575, thanks for testing it!