### PR TITLE
Return `crate::Error` instead of a miette Report

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- `FlashData::new` now returns `crate::Error` (#591)
+
 ### Removed
 
 ## [3.0.0-rc.1] - 2024-02-16

--- a/espflash/src/error.rs
+++ b/espflash/src/error.rs
@@ -202,6 +202,12 @@ pub enum Error {
 
     #[error("Internal Error")]
     InternalError,
+
+    #[error("Failed to open file: {0}")]
+    FileOpenError(String, #[source] std::io::Error),
+
+    #[error("Failed to parse partition table")]
+    Partition(#[from] esp_idf_part::Error),
 }
 
 #[cfg(feature = "serialport")]


### PR DESCRIPTION
cc #587