### PR TITLE
Fix USB JTAG Serial HardReset sequence in Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,10 +10,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 ### Fixed
+- Change the `hard_reset` sequence to fix Windows issues (#594)
 
 ### Changed
-
 - `FlashData::new` now returns `crate::Error` (#591)
+- Moved `reset_after_flash` method to `reset` module (#594)
 
 ### Removed
 

--- a/espflash/src/cli/mod.rs
+++ b/espflash/src/cli/mod.rs
@@ -568,12 +568,13 @@ pub fn erase_flash(args: EraseFlashArgs, config: &Config) -> Result<()> {
         return Err(Error::StubRequired.into());
     }
 
-    let mut flash = connect(&args.connect_args, config, true, true)?;
-
+    let mut flasher = connect(&args.connect_args, config, true, true)?;
     info!("Erasing Flash...");
 
-    flash.erase_flash()?;
-    flash.connection().reset_after(!args.connect_args.no_stub)?;
+    flasher.erase_flash()?;
+    flasher
+        .connection()
+        .reset_after(!args.connect_args.no_stub)?;
 
     Ok(())
 }

--- a/espflash/src/cli/monitor/mod.rs
+++ b/espflash/src/cli/monitor/mod.rs
@@ -27,7 +27,7 @@ use strum::{Display, EnumIter, EnumString, VariantNames};
 
 use crate::{
     cli::monitor::parser::{InputParser, ResolvingPrinter},
-    connection::{reset_after_flash, Port},
+    connection::{reset::reset_after_flash, Port},
 };
 
 pub mod parser;

--- a/espflash/src/connection/mod.rs
+++ b/espflash/src/connection/mod.rs
@@ -21,8 +21,8 @@ use self::reset::UnixTightReset;
 use self::{
     encoder::SlipEncoder,
     reset::{
-        construct_reset_strategy_sequence, hard_reset, ClassicReset, ResetAfterOperation,
-        ResetBeforeOperation, ResetStrategy, UsbJtagSerialReset,
+        construct_reset_strategy_sequence, hard_reset, reset_after_flash, ClassicReset,
+        ResetAfterOperation, ResetBeforeOperation, ResetStrategy, UsbJtagSerialReset,
     },
 };
 use crate::{
@@ -486,33 +486,6 @@ impl Connection {
     pub fn get_usb_pid(&self) -> Result<u16, Error> {
         Ok(self.port_info.pid)
     }
-}
-
-/// Reset the target device when flashing has completed
-pub fn reset_after_flash(serial: &mut Port, pid: u16) -> Result<(), serialport::Error> {
-    sleep(Duration::from_millis(100));
-
-    if pid == USB_SERIAL_JTAG_PID {
-        serial.write_data_terminal_ready(false)?;
-
-        sleep(Duration::from_millis(100));
-
-        serial.write_request_to_send(true)?;
-        serial.write_data_terminal_ready(false)?;
-        serial.write_request_to_send(true)?;
-
-        sleep(Duration::from_millis(100));
-
-        serial.write_request_to_send(false)?;
-    } else {
-        serial.write_request_to_send(true)?;
-
-        sleep(Duration::from_millis(100));
-
-        serial.write_request_to_send(false)?;
-    }
-
-    Ok(())
 }
 
 mod encoder {

--- a/espflash/src/connection/mod.rs
+++ b/espflash/src/connection/mod.rs
@@ -21,7 +21,7 @@ use self::reset::UnixTightReset;
 use self::{
     encoder::SlipEncoder,
     reset::{
-        construct_reset_strategy_sequence, ClassicReset, HardReset, ResetAfterOperation,
+        construct_reset_strategy_sequence, hard_reset, ClassicReset, ResetAfterOperation,
         ResetBeforeOperation, ResetStrategy, UsbJtagSerialReset,
     },
 };
@@ -158,7 +158,7 @@ impl Connection {
         let mut buff: Vec<u8>;
         if self.before_operation != ResetBeforeOperation::NoReset {
             // Reset the chip to bootloader (download mode)
-            reset_strategy.reset(&mut self.serial, None)?;
+            reset_strategy.reset(&mut self.serial)?;
 
             let available_bytes = self.serial.bytes_to_read()?;
             buff = vec![0; available_bytes as usize];
@@ -259,7 +259,7 @@ impl Connection {
         let pid = self.get_usb_pid()?;
 
         match self.after_operation {
-            ResetAfterOperation::HardReset => HardReset.reset(&mut self.serial, Some(pid)),
+            ResetAfterOperation::HardReset => hard_reset(&mut self.serial, pid),
             ResetAfterOperation::NoReset => {
                 info!("Staying in bootloader");
                 soft_reset(self, true, is_stub)?;
@@ -276,17 +276,17 @@ impl Connection {
     // Reset the device to flash mode
     pub fn reset_to_flash(&mut self, extra_delay: bool) -> Result<(), Error> {
         if self.port_info.pid == USB_SERIAL_JTAG_PID {
-            UsbJtagSerialReset.reset(&mut self.serial, None)
+            UsbJtagSerialReset.reset(&mut self.serial)
         } else {
             #[cfg(unix)]
             if UnixTightReset::new(extra_delay)
-                .reset(&mut self.serial, None)
+                .reset(&mut self.serial)
                 .is_ok()
             {
                 return Ok(());
             }
 
-            ClassicReset::new(extra_delay).reset(&mut self.serial, None)
+            ClassicReset::new(extra_delay).reset(&mut self.serial)
         }
     }
 


### PR DESCRIPTION
- Reuse `reset_after_flash` sequence in `hard_reset`
  - We dont know where this sequence came from, but it seems to work fine in all platforms. See #157 and #153
  - Using [`esptool` HardReset sequence](https://github.com/espressif/esptool/blob/3301d0ff4638d4db1760a22540dbd9d07c55ec37/esptool/reset.py#L132-L153) does not work in Windows.
- Move `reset_after_flash` method to `reset` module  

Thanks @bjoernQ for the help debugging and testing this