### PR TITLE
Allow Cargo workspace config file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Allow config file to live in parent folder (#595)
 
 ### Fixed
 

--- a/cargo-espflash/README.md
+++ b/cargo-espflash/README.md
@@ -140,7 +140,7 @@ The configuration file allows you to define various parameters for your applicat
 
 You can have a local and/or a global configuration file:
 
-- For local configurations, store the file under the current working directory with the name `espflash.toml`
+- For local configurations, store the file under the current working directory or in the parent directory (to support Cargo workspaces) with the name `espflash.toml`
 - Global file location differs based on your operating system:
   - Linux: `$HOME/.config/espflash/espflash.toml`
   - macOS: `$HOME/Library/Application Support/rs.esp.espflash/espflash.toml`

--- a/espflash/README.md
+++ b/espflash/README.md
@@ -154,7 +154,7 @@ The configuration file allows you to define various parameters for your applicat
 
 You can have a local and/or a global configuration file:
 
-- For local configurations, store the file under the current working directory with the name `espflash.toml`
+- For local configurations, store the file under the current working directory or in the parent directory (to support Cargo workspaces) with the name `espflash.toml`
 - Global file location differs based on your operating system:
   - Linux: `$HOME/.config/espflash/espflash.toml`
   - macOS: `$HOME/Library/Application Support/rs.esp.espflash/espflash.toml`

--- a/espflash/src/cli/config.rs
+++ b/espflash/src/cli/config.rs
@@ -101,6 +101,12 @@ impl Config {
         if local_config.exists() {
             return Ok(local_config);
         }
+        if let Some(parent_folder) = std::env::current_dir()?.parent() {
+            let workspace_config = parent_folder.join("espflash.toml");
+            if workspace_config.exists() {
+                return Ok(workspace_config);
+            }
+        }
 
         let project_dirs = ProjectDirs::from("rs", "esp", "espflash").unwrap();
         let global_config = project_dirs.config_dir().join("espflash.toml");


### PR DESCRIPTION
- Local `espflash.toml` config file can also be stored in parent folder to simplify Cargo workspaces