### PR TITLE
Improve resolving non-code addresses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Change the `hard_reset` sequence to fix Windows issues (#594)
+- Improve resolving non-code addresses (#603)
 
 ### Changed
 - Non-linux-musl: Only list the available USB Ports by default (#590)


### PR DESCRIPTION
This improves how we resolve non-code addresses.

Before
```
load:0x40080400,len:4
0x40080400 - _DoubleExceptionVector
    at ??:??
ho 8 tail 4 room 4
load:0x40080404,len:3876
0x40080404 - _DoubleExceptionVector
    at ??:??
entry 0x4008064c
0x4008064c - __user_exception
    at C:\Users\Bjoern\.cargo\registry\src\index.crates.io-6f17d22bba15001f\esp-backtrace-0.11.0\src\lib.rs:130
```

After
```
load:0x40080400,len:4
ho 8 tail 4 room 4
load:0x40080404,len:3876
entry 0x4008064c
0x4008064c - __user_exception
    at C:\Users\Bjoern\.cargo\registry\src\index.crates.io-6f17d22bba15001f\esp-backtrace-0.11.0\src\lib.rs:130
```

`__user_exception` is still confusing but at least it's the same result as `xtensa-esp32-elf-addr2line`
