### PR TITLE
Prepare 3.0.0-rc.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,23 +5,24 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [3.0.0-rc.2] - 2024-03-04
 
 ### Added
+
 - Add `--list-all-ports` connection argument to avoid serial port filtering (#590)
 - Allow config file to live in parent folder (#595)
 
 ### Fixed
+
 - Change the `hard_reset` sequence to fix Windows issues (#594)
 - Improve resolving non-code addresses (#603)
 
 ### Changed
+
 - Non-linux-musl: Only list the available USB Ports by default (#590)
 - `FlashData::new` now returns `crate::Error` (#591)
 - Moved `reset_after_flash` method to `reset` module (#594)
 - The `command` module now requires `serialport`. (#599)
-
-### Removed
 
 ## [3.0.0-rc.1] - 2024-02-16
 
@@ -224,7 +225,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.0.0] - 2021-09-21
 
-[Unreleased]: https://github.com/esp-rs/espflash/compare/v3.0.0-rc.1...HEAD
+[3.0.0-rc.2]: https://github.com/esp-rs/espflash/compare/v3.0.0-rc.1...v3.0.0-rc.2
 [3.0.0-rc.1]: https://github.com/esp-rs/espflash/compare/v2.1.0...v3.0.0-rc.1
 [2.1.0]: https://github.com/esp-rs/espflash/compare/v2.0.1...v2.1.0
 [2.0.1]: https://github.com/esp-rs/espflash/compare/v2.0.0...v2.0.1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -405,7 +405,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-espflash"
-version = "3.0.0-rc.1"
+version = "3.0.0-rc.2"
 dependencies = [
  "cargo",
  "cargo_metadata",
@@ -1147,7 +1147,7 @@ dependencies = [
 
 [[package]]
 name = "espflash"
-version = "3.0.0-rc.1"
+version = "3.0.0-rc.2"
 dependencies = [
  "addr2line",
  "base64 0.22.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -153,6 +153,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
 
 [[package]]
+name = "base64"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9475866fec1451be56a3c2400fd081ff546538961565ccb5b7142cbd22bc7a51"
+
+[[package]]
 name = "base64ct"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -207,7 +213,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05efc5cfd9110c8416e471df0e96702d58690178e206e61b7173706673c93706"
 dependencies = [
  "memchr",
- "regex-automata 0.4.5",
+ "regex-automata 0.4.6",
  "serde",
 ]
 
@@ -282,7 +288,7 @@ dependencies = [
  "anstream",
  "anstyle",
  "anyhow",
- "base64",
+ "base64 0.21.7",
  "bytesize",
  "cargo-credential",
  "cargo-credential-libsecret",
@@ -1144,7 +1150,7 @@ name = "espflash"
 version = "3.0.0-rc.1"
 dependencies = [
  "addr2line",
- "base64",
+ "base64 0.22.0",
  "bytemuck",
  "clap",
  "clap_complete",
@@ -2049,7 +2055,7 @@ version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f731cfefc4d62468c6dd2053f5c6707828256a6d2f5488c1811e3f42c178b144"
 dependencies = [
- "base64",
+ "base64 0.21.7",
  "bstr",
  "curl",
  "gix-command",
@@ -2145,7 +2151,7 @@ dependencies = [
  "aho-corasick",
  "bstr",
  "log",
- "regex-automata 0.4.5",
+ "regex-automata 0.4.6",
  "regex-syntax 0.8.2",
 ]
 
@@ -2379,7 +2385,7 @@ dependencies = [
  "globset",
  "log",
  "memchr",
- "regex-automata 0.4.5",
+ "regex-automata 0.4.6",
  "same-file",
  "walkdir",
  "winapi-util",
@@ -3276,7 +3282,7 @@ checksum = "b62dbe01f0b06f9d8dc7d49e05a0785f153b00b2c227856282f671e0318c9b15"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata 0.4.5",
+ "regex-automata 0.4.6",
  "regex-syntax 0.8.2",
 ]
 
@@ -3291,9 +3297,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.5"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bb987efffd3c6d0d8f5f89510bb458559eab11e4f869acb20bf845e016259cd"
+checksum = "86b83b8b9847f9bf95ef68afb0b8e6cdb80f498442f5179a29fad448fcc1eaea"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -3318,7 +3324,7 @@ version = "0.11.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6920094eb85afde5e4a138be3f2de8bbdf28000f0029e72c45025a56b042251"
 dependencies = [
- "base64",
+ "base64 0.21.7",
  "bytes",
  "encoding_rs",
  "futures-core",
@@ -3455,7 +3461,7 @@ version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
 dependencies = [
- "base64",
+ "base64 0.21.7",
 ]
 
 [[package]]
@@ -4402,7 +4408,7 @@ version = "2.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "11f214ce18d8b2cbe84ed3aa6486ed3f5b285cf8d8fbdbce9f3f767a724adc35"
 dependencies = [
- "base64",
+ "base64 0.21.7",
  "flate2",
  "log",
  "once_cell",

--- a/cargo-espflash/Cargo.toml
+++ b/cargo-espflash/Cargo.toml
@@ -16,14 +16,14 @@ pkg-fmt = "zip"
 
 [dependencies]
 cargo_metadata = "0.18.1"
-clap = { version = "4.4.18", features = ["derive", "wrap_help"] }
+clap = { version = "4.5.1", features = ["derive", "wrap_help"] }
 env_logger = "0.11.2"
 esp-idf-part = "0.5.0"
 espflash = { version = "3.0.0-rc.1", path = "../espflash" }
-log = "0.4.20"
-miette = { version = "7.0.0", features = ["fancy"] }
-serde = { version = "1.0.196", features = ["derive"] }
-thiserror = "1.0.56"
+log = "0.4.21"
+miette = { version = "7.1.0", features = ["fancy"] }
+serde = { version = "1.0.197", features = ["derive"] }
+thiserror = "1.0.57"
 toml = "0.8.10"
 
 [target.'cfg(unix)'.dependencies]

--- a/cargo-espflash/Cargo.toml
+++ b/cargo-espflash/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-espflash"
-version = "3.0.0-rc.1"
+version = "3.0.0-rc.2"
 edition = "2021"
 rust-version = "1.74"
 description  = "Cargo subcommand for flashing Espressif devices"
@@ -19,7 +19,7 @@ cargo_metadata = "0.18.1"
 clap = { version = "4.5.1", features = ["derive", "wrap_help"] }
 env_logger = "0.11.2"
 esp-idf-part = "0.5.0"
-espflash = { version = "3.0.0-rc.1", path = "../espflash" }
+espflash = { version = "3.0.0-rc.2", path = "../espflash" }
 log = "0.4.21"
 miette = { version = "7.1.0", features = ["fancy"] }
 serde = { version = "1.0.197", features = ["derive"] }

--- a/espflash/Cargo.toml
+++ b/espflash/Cargo.toml
@@ -24,10 +24,10 @@ required-features = ["cli", "serialport"]
 
 [dependencies]
 addr2line = { version = "0.21.0", optional = true }
-base64 = "0.21.7"
-bytemuck = { version = "1.14.1", features = ["derive"] }
-clap = { version = "4.4.18", features = ["derive", "env", "wrap_help"], optional = true }
-clap_complete = { version = "4.4.10", optional = true }
+base64 = "0.22.0"
+bytemuck = { version = "1.14.3", features = ["derive"] }
+clap = { version = "4.5.1", features = ["derive", "env", "wrap_help"], optional = true }
+clap_complete = { version = "4.5.1", optional = true }
 comfy-table = { version = "7.1.0", optional = true }
 crossterm = { version = "0.25.0", optional = true } # 0.26.x and 0.27.x causes issues on Windows
 ctrlc = { version = "3.4.2", optional = true }
@@ -40,19 +40,19 @@ env_logger = { version = "0.11.2", optional = true }
 esp-idf-part = "0.5.0"
 flate2 = "1.0.28"
 hex = { version = "0.4.3", features = ["serde"], optional = true }
-indicatif = { version = "0.17.7", optional = true }
+indicatif = { version = "0.17.8", optional = true }
 lazy_static = { version = "1.4.0", optional = true }
-log = "0.4.20"
+log = "0.4.21"
 md-5 = "0.10.6"
-miette = { version = "7.0.0" }
+miette = { version = "7.1.0" }
 parse_int = { version = "0.6.0", optional = true }
 regex = { version = "1.10.3", optional = true }
-serde = { version = "1.0.196", features = ["derive"] }
+serde = { version = "1.0.197", features = ["derive"] }
 serialport = { version = "4.3.0", optional = true }
 sha2 = "0.10.8"
 slip-codec = { version = "0.4.0", optional = true }
 strum = { version = "0.26.1", features = ["derive"] }
-thiserror = "1.0.56"
+thiserror = "1.0.57"
 toml = { version = "0.8.10", optional = true }
 update-informer = { version = "1.1.0", optional = true }
 xmas-elf        = { version = "0.9.1" }

--- a/espflash/Cargo.toml
+++ b/espflash/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "espflash"
-version = "3.0.0-rc.1"
+version = "3.0.0-rc.2"
 edition = "2021"
 rust-version = "1.74"
 description  = "A command-line tool for flashing Espressif devices"


### PR DESCRIPTION
- Update dependencies
- Bump `espflash` and `cargo-espflash` version
- Update changelog