### PR TITLE
Update runner for arch64 and armv7 linux jobs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,10 +21,10 @@ jobs:
           - os: "ubuntu-22.04"
             target: "x86_64-unknown-linux-musl"
             arch: "x86_64"
-          - os: "ubuntu-20.04"
+          - os: "ubuntu-22.04"
             target: "aarch64-unknown-linux-gnu"
             arch: "arm64"
-          - os: "ubuntu-20.04"
+          - os: "ubuntu-22.04"
             target: "armv7-unknown-linux-gnueabihf"
             arch: "armhf"
           # Windows


### PR DESCRIPTION
- Use Ubuntu 22.04 as 20.04 leads to: https://github.com/esp-rs/espflash/actions/runs/8264223261/job/22607923609.

Successful CI run with ubuntu22.04: https://github.com/SergioGasquez/espflash/actions/runs/8264491562/job/22608213573