### PR TITLE
Fixed docs for read-flash size parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 ### Fixed
+- Fixed help text for size parameter of read-flash subcommand
 
 ### Changed
 

--- a/espflash/src/cli/mod.rs
+++ b/espflash/src/cli/mod.rs
@@ -198,7 +198,7 @@ pub struct ReadFlashArgs {
     /// Connection configuration
     #[clap(flatten)]
     connect_args: ConnectArgs,
-    /// Size of the region to erase
+    /// Size of the region to read
     #[arg(value_name = "SIZE", value_parser = parse_uint32)]
     pub size: u32,
     /// Name of binary dump


### PR DESCRIPTION
The size parameter of the read-flash subcommand indicated it was erasing flash.