### PR TITLE
Always resolve package_id from metadata when finding bootloader and partition table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Fixed help text for size parameter of read-flash subcommand
+- [cargo-espflash]: Always resolve package_id from metadata when finding bootloader and partition table (#632)
 
 ### Changed
 


### PR DESCRIPTION
The package ID format was officially documented as an opaque identifier and the only thing we were allowed to do with them is look them up in the cargo metadata.  Rust 1.77 switched the package ID field to use the publicly documented "Package ID Specification" format instead, which means that the old logic no longer works.