### PR TITLE
Write the image to the correct target app partition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed help text for size parameter of read-flash subcommand
 - Fixed port detection on `musl` when detection returns paths starting with `/dev/`
 - [cargo-espflash]: Always resolve package_id from metadata when finding bootloader and partition table (#632)
+- Fixed behavior of the --target-app-partition flag (#634)
 
 ### Changed
 

--- a/espflash/src/image_format.rs
+++ b/espflash/src/image_format.rs
@@ -259,7 +259,7 @@ impl<'a> IdfBootloaderFormat<'a> {
         let app_size = data.len() as u32;
         let part_size = target_app_partition.size();
 
-        // The size of the application must not exceed the size of the factory
+        // The size of the application must not exceed the size of the target app
         // partition.
         if app_size as f32 / part_size as f32 > 1.0 {
             return Err(Error::ElfTooBig(app_size, part_size));
@@ -307,22 +307,8 @@ impl<'a> IdfBootloaderFormat<'a> {
             data: Cow::Owned(self.partition_table.to_bin().unwrap()),
         };
 
-        let app_partition = self
-            .partition_table
-            .find("factory")
-            .or_else(|| self.partition_table.find_by_type(Type::App))
-            .expect("no application partition found");
-
-        if self.flash_segment.data.len() > app_partition.size() as usize {
-            panic!(
-                "image size ({} bytes) is larger partition size ({} bytes)",
-                self.flash_segment.data.len(),
-                app_partition.size()
-            );
-        }
-
         let app_segment = RomSegment {
-            addr: app_partition.offset(),
+            addr: self.flash_segment.addr,
             data: Cow::Borrowed(&self.flash_segment.data),
         };
 


### PR DESCRIPTION
Perhaps I am misunderstanding what the --target-app-partition flag is supposed to do, but the code previously always wrote the image to the "factory" app partition if one was present, regardless of the partition specified with the `--target-app-partition` flag.

This change updates the code to write the image to the partition specified with the `--target-app-partition` flag.

I confirmed that using `espflash flash --target-app-partition ota_0` now causes espflash to write the image to the `ota_0` partition.  Note that this leaves the `factory` partition and any `ota_data` partition unchanged, so the bootloader will still boot from the factory partition by default, but this makes it possible to write new app images to the OTA partitions for testing purposes.