### PR TITLE
fix: musl list ports handle /dev/* from available_ports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Fixed help text for size parameter of read-flash subcommand
+- Fixed port detection on `musl` when detection returns paths starting with `/dev/`
 
 ### Changed
 

--- a/espflash/src/cli/serial.rs
+++ b/espflash/src/cli/serial.rs
@@ -124,7 +124,7 @@ fn detect_usb_serial_ports(_list_all_ports: bool) -> Result<Vec<SerialPortInfo>>
             // In case of `/dev/*` we transform them into `/sys/class/tty/*`
             let path = match AsRef::<Path>::as_ref(&port_info.port_name).strip_prefix("/dev/") {
                 Ok(rem) => PathBuf::from("/sys/class/tty/").join(rem),
-                Err(_) => PathBuf::from(&port_info.port_name)
+                Err(_) => PathBuf::from(&port_info.port_name),
             };
 
             // This will give something like:


### PR DESCRIPTION
Hi, I've been trying to use espflash from Alpine linux and on my system `serialport::available_ports()` returns something like `[SerialPortInfo { port_name: "/dev/ttyS0", port_type: Unknown }, SerialPortInfo { port_name: "/dev/ttyUSB0", port_type: Unknown }]`. The function that handles this expects `port_name` to be in the form of `/sys/class/tty/*` and this makes espflash not work on my system due to being unable to detect any serial ports.

In this PR I've added a branch which checks if the path returned from `available_ports` starts with `/dev/` and if it does it replaces it with `/sys/class/tty/` and proceeds as before. I can confirm this works for flashing esp32c3 board I'm working with.

I'm not sure this is the best approach but at least it works now. Let me know if you think this can be improved in an obvious way.