### PR TITLE
feat: add --no-default-features flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
 - Add `hold-in-reset` and `reset` subcommands
+- Add `--no-default-features` flag to mirror cargo features behavior 
 
 ## [3.1.0] - 2024-05-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Add `hold-in-reset` and `reset` subcommands
-- Add `--no-default-features` flag to mirror cargo features behavior 
+- [cargo-espflash]: Add `--no-default-features` flag to mirror cargo features behavior 
 
 ## [3.1.0] - 2024-05-24
 

--- a/cargo-espflash/src/main.rs
+++ b/cargo-espflash/src/main.rs
@@ -128,6 +128,9 @@ struct BuildArgs {
     /// Comma delimited list of build features
     #[arg(long, use_value_delimiter = true)]
     pub features: Option<Vec<String>>,
+    /// Do not activate the `default` feature
+    #[arg(long)]
+    pub no_default_features: bool,
     /// Require Cargo.lock and cache are up to date
     #[arg(long)]
     pub frozen: bool,
@@ -373,6 +376,9 @@ fn build(
         .ok_or_else(|| NoTargetError::new(Some(chip)))?;
 
     let mut metadata_cmd = MetadataCommand::new();
+    if build_options.no_default_features {
+        metadata_cmd.features(cargo_metadata::CargoOpt::NoDefaultFeatures);
+    }
     if let Some(features) = &build_options.features {
         metadata_cmd.features(cargo_metadata::CargoOpt::SomeFeatures(features.clone()));
     }
@@ -433,6 +439,10 @@ fn build(
     if let Some(package) = &build_options.package {
         args.push("--package".to_string());
         args.push(package.to_string());
+    }
+
+    if build_options.no_default_features {
+        args.push("--no-default-features".to_string());
     }
 
     if let Some(features) = &build_options.features {


### PR DESCRIPTION
Default features are still included while using the following command:

```bash
cargo espflash flash --release --features one,two
```

This PR add the `--no-default-features` flag to mirror cargo features functionalities.

Close https://github.com/esp-rs/espflash/issues/645