### PR TITLE
Downgrade crossterm and fix compilation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-- Add `hold-in-reset` and `reset` subcommands
-- [cargo-espflash]: Add `--no-default-features` flag to mirror cargo features behavior 
+- Add `hold-in-reset` and `reset` subcommands (#644)
+- [cargo-espflash]: Add `--no-default-features` flag to mirror cargo features behavior (#647)
+
+### Fixed
+- Downgrade crossterm and update time crates (#659)
+
+### Changed
+
 
 ## [3.1.0] - 2024-05-24
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -620,7 +620,7 @@ version = "7.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b34115915337defe99b2aff5c2ce6771e5fbc4079f4b506301f5cf394c8452f7"
 dependencies = [
- "crossterm",
+ "crossterm 0.27.0",
  "strum",
  "strum_macros",
  "unicode-width",
@@ -738,6 +738,22 @@ checksum = "248e3bacc7dc6baa3b21e405ee045c3047101a49145e7e9eca583ab4c2ca5345"
 
 [[package]]
 name = "crossterm"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e64e6c0fbe2c17357405f7c758c1ef960fce08bdfb2c03d88d2a18d7e09c4b67"
+dependencies = [
+ "bitflags 1.3.2",
+ "crossterm_winapi",
+ "libc",
+ "mio",
+ "parking_lot",
+ "signal-hook",
+ "signal-hook-mio",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm"
 version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f476fe445d41c9e991fd07515a6f463074b782242ccf4a5b7b1d1012e70824df"
@@ -745,10 +761,7 @@ dependencies = [
  "bitflags 2.4.2",
  "crossterm_winapi",
  "libc",
- "mio",
  "parking_lot",
- "signal-hook",
- "signal-hook-mio",
  "winapi",
 ]
 
@@ -1181,7 +1194,7 @@ dependencies = [
  "clap",
  "clap_complete",
  "comfy-table",
- "crossterm",
+ "crossterm 0.25.0",
  "ctrlc",
  "defmt-decoder",
  "defmt-parser",
@@ -4082,9 +4095,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.34"
+version = "0.3.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8248b6521bb14bc45b4067159b9b6ad792e2d6d754d6c41fb50e29fefe38749"
+checksum = "5dfd88e563464686c916c7e46e623e520ddc6d79fa6641390f2e3fa86e83e885"
 dependencies = [
  "deranged",
  "itoa",
@@ -4105,9 +4118,9 @@ checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
 
 [[package]]
 name = "time-macros"
-version = "0.2.17"
+version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ba3a3ef41e6672a2f0f001392bb5dcd3ff0a9992d618ca761a11c3121547774"
+checksum = "3f252a68540fde3a3877aeea552b832b40ab9a69e318efd078774a01ddee1ccf"
 dependencies = [
  "num-conv",
  "time-core",

--- a/espflash/Cargo.toml
+++ b/espflash/Cargo.toml
@@ -33,7 +33,7 @@ clap = { version = "4.5.4", features = [
 ], optional = true }
 clap_complete = { version = "4.5.2", optional = true }
 comfy-table = { version = "7.1.1", optional = true }
-crossterm = { version = "0.27.0", optional = true } # 0.26.x and 0.27.x causes issues on Windows
+crossterm = { version = "0.25.0", optional = true } # 0.26.x and 0.27.x causes issues on Windows
 ctrlc = { version = "3.4.4", optional = true }
 # defmt dependencies are pinned since defmt does not guarantee MSRV even for patch releases
 defmt-decoder = { version = "0.3.11", features = [


### PR DESCRIPTION
- Downgrade crossterm to 0.25.0
- Update time to avoid build failure