### PR TITLE
Fix: bump cargo version to latest and adjusted dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+## 3.1.2 - 2024-08-24
+
+### Added
+
+### Fixed
+
+- Update cargo version to v0.81.0 to fix (#671)
+### Changed
 ## [3.1.1] - 2024-08-15
 
 ### Added

--- a/cargo-espflash/Cargo.toml
+++ b/cargo-espflash/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-espflash"
-version = "3.1.1"
+version = "3.1.2"
 edition = "2021"
 rust-version = "1.74"
 description = "Cargo subcommand for flashing Espressif devices"

--- a/cargo-espflash/Cargo.toml
+++ b/cargo-espflash/Cargo.toml
@@ -8,10 +8,10 @@ repository = "https://github.com/esp-rs/espflash"
 license = "MIT OR Apache-2.0"
 keywords = ["cargo", "cli", "embedded", "esp"]
 categories = [
-    "command-line-utilities",
-    "development-tools",
-    "development-tools::cargo-plugins",
-    "embedded",
+  "command-line-utilities",
+  "development-tools",
+  "development-tools::cargo-plugins",
+  "embedded",
 ]
 
 [package.metadata.binstall]
@@ -21,18 +21,18 @@ pkg-fmt = "zip"
 
 [dependencies]
 cargo_metadata = "0.18.1"
-clap           = { version = "4.5.4", features = ["derive", "wrap_help"] }
-env_logger     = "0.11.3"
-esp-idf-part   = "0.5.0"
-espflash       = { version = "3.1.0", path = "../espflash" }
-log            = "0.4.21"
-miette         = { version = "7.2.0", features = ["fancy"] }
-serde          = { version = "1.0.202", features = ["derive"] }
-thiserror      = "1.0.61"
-toml           = "0.8.13"
+clap = { version = "4.5.4", features = ["derive", "wrap_help"] }
+env_logger = "0.11.3"
+esp-idf-part = "0.5.0"
+espflash = { version = "3.1.0", path = "../espflash" }
+log = "0.4.21"
+miette = { version = "7.2.0", features = ["fancy"] }
+serde = { version = "1.0.202", features = ["derive"] }
+thiserror = "1.0.61"
+toml = "0.8.13"
 
 [target.'cfg(unix)'.dependencies]
-cargo = { version = "0.78.1", features = ["vendored-openssl"] }
+cargo = { version = "0.81.0", features = ["vendored-openssl"] }
 
 [target.'cfg(windows)'.dependencies]
-cargo = "0.78.1"
+cargo = "0.81.0"

--- a/cargo-espflash/src/package_metadata.rs
+++ b/cargo-espflash/src/package_metadata.rs
@@ -2,7 +2,7 @@ use std::path::PathBuf;
 
 use cargo::{
     core::{Package, Workspace},
-    util::Config,
+    util::GlobalContext,
 };
 use miette::{IntoDiagnostic, Result};
 use serde::Deserialize;
@@ -25,7 +25,7 @@ impl PackageMetadata {
         }
 
         let manifest_path = manifest_path.canonicalize().into_diagnostic()?;
-        let config = Config::default().map_err(|_| Error::InvalidWorkspace)?;
+        let config = GlobalContext::default().map_err(|_| Error::InvalidWorkspace)?;
 
         let workspace =
             Workspace::new(&manifest_path, &config).map_err(|_| Error::InvalidWorkspace)?;


### PR DESCRIPTION
Bump cargo version to "0.81.0", and updated cargo::util::Config to cargo::util::GlobalContext, which was changed in v0.79.0

Tested on Mac, Linux, and Windows machines using `cargo install --git https://github.com/andreybuchinskiy/espflash/ --branch bugfix/Installing-cargo-espflash-with-cargo-fails cargo-espflash`

Fixes #671