### PR TITLE
Update download mode detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Fixed `partition-table-offset` argument to accept offsets in hexadecimal (#682)
+- Fixed pattern matching to detect download mode over multiple lines (#685)
 
 ### Changed
 

--- a/espflash/src/connection/mod.rs
+++ b/espflash/src/connection/mod.rs
@@ -173,8 +173,8 @@ impl Connection {
 
             let read_slice = String::from_utf8_lossy(&buff[..read_bytes as usize]).into_owned();
 
-            let pattern = 
-                Regex::new(r"boot:(0x[0-9a-fA-F]+)([\s\S]*waiting for download)?").unwrap();
+            let pattern =
+                 Regex::new(r"boot:(0x[0-9a-fA-F]+)([\s\S]*waiting for download)?").unwrap();
 
             // Search for the pattern in the read data
             if let Some(data) = pattern.captures(&read_slice) {

--- a/espflash/src/connection/mod.rs
+++ b/espflash/src/connection/mod.rs
@@ -173,7 +173,7 @@ impl Connection {
 
             let read_slice = String::from_utf8_lossy(&buff[..read_bytes as usize]).into_owned();
 
-            let pattern = Regex::new(r"boot:(0x[0-9a-fA-F]+)(.*waiting for download)?").unwrap();
+            let pattern = Regex::new(r"boot:(0x[0-9a-fA-F]+)([\s\S]*waiting for download)?").unwrap();
 
             // Search for the pattern in the read data
             if let Some(data) = pattern.captures(&read_slice) {

--- a/espflash/src/connection/mod.rs
+++ b/espflash/src/connection/mod.rs
@@ -174,7 +174,7 @@ impl Connection {
             let read_slice = String::from_utf8_lossy(&buff[..read_bytes as usize]).into_owned();
 
             let pattern =
-                 Regex::new(r"boot:(0x[0-9a-fA-F]+)([\s\S]*waiting for download)?").unwrap();
+                Regex::new(r"boot:(0x[0-9a-fA-F]+)([\s\S]*waiting for download)?").unwrap();
 
             // Search for the pattern in the read data
             if let Some(data) = pattern.captures(&read_slice) {

--- a/espflash/src/connection/mod.rs
+++ b/espflash/src/connection/mod.rs
@@ -173,7 +173,8 @@ impl Connection {
 
             let read_slice = String::from_utf8_lossy(&buff[..read_bytes as usize]).into_owned();
 
-            let pattern = Regex::new(r"boot:(0x[0-9a-fA-F]+)([\s\S]*waiting for download)?").unwrap();
+            let pattern = 
+                Regex::new(r"boot:(0x[0-9a-fA-F]+)([\s\S]*waiting for download)?").unwrap();
 
             // Search for the pattern in the read data
             if let Some(data) = pattern.captures(&read_slice) {


### PR DESCRIPTION
Previously, this failed to detect download mode during this regex match in the following message.

```
ESP-ROM:esp32s3-20210327
    Build:Mar 27 2021
    rst:0x1 (POWERON),boot:0x0 (DOWNLOAD(USB/UART0))
    waiting for download

```

`.*` only matches on any character EXCEPT line breaks,  where as `[\s\S]` will match on anything.