### PR TITLE
Add new chip detect magic value, ability to read chip revision for ESP32-P4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Add new chip detect magic value, ability to read chip revision for ESP32-P4 (#686)
+
 ### Fixed
 - Fixed `partition-table-offset` argument to accept offsets in hexadecimal (#682)
 

--- a/espflash/src/targets/esp32p4.rs
+++ b/espflash/src/targets/esp32p4.rs
@@ -10,7 +10,7 @@ use crate::{
     targets::{Chip, Esp32Params, ReadEFuse, SpiRegisters, Target, XtalFrequency},
 };
 
-const CHIP_DETECT_MAGIC_VALUES: &[u32] = &[0x0];
+const CHIP_DETECT_MAGIC_VALUES: &[u32] = &[0x0, 0x0ADDBAD0];
 
 const FLASH_RANGES: &[Range<u32>] = &[
     0x4000_0000..0x4C00_0000, // IROM
@@ -20,7 +20,7 @@ const FLASH_RANGES: &[Range<u32>] = &[
 const PARAMS: Esp32Params = Esp32Params::new(
     0x2000,
     0x1_0000,
-    0x3f_0000, // TODO: Update
+    0x3f_0000,
     18,
     FlashFrequency::_40Mhz,
     include_bytes!("../../resources/bootloaders/esp32p4-bootloader.bin"),
@@ -52,15 +52,13 @@ impl Target for Esp32p4 {
     }
 
     #[cfg(feature = "serialport")]
-    fn major_chip_version(&self, _connection: &mut Connection) -> Result<u32, Error> {
-        // TODO: https://github.com/espressif/esptool/blob/master/esptool/targets/esp32p4.py#L96
-        Ok(0)
+    fn major_chip_version(&self, connection: &mut Connection) -> Result<u32, Error> {
+        Ok(self.read_efuse(connection, 19)? >> 4 & 0x03)
     }
 
     #[cfg(feature = "serialport")]
-    fn minor_chip_version(&self, _connection: &mut Connection) -> Result<u32, Error> {
-        // TODO: https://github.com/espressif/esptool/blob/master/esptool/targets/esp32p4.py#L92
-        Ok(0)
+    fn minor_chip_version(&self, connection: &mut Connection) -> Result<u32, Error> {
+        Ok(self.read_efuse(connection, 19)? & 0x0F)
     }
 
     #[cfg(feature = "serialport")]


### PR DESCRIPTION
Minor updates, nothing exciting.

Output:

```text
jesse@mbp ~/W/espflash git:feature/esp32p4 [ ✎ ⚑ ]
🦀 nightly@1.83.0 λ espflash board-info
[2024-10-07T10:36:33Z INFO ] Detected 2 serial ports
[2024-10-07T10:36:33Z INFO ] Ports which match a known common dev board are highlighted
[2024-10-07T10:36:33Z INFO ] Please select a port
[2024-10-07T10:36:34Z INFO ] Serial port: '/dev/cu.usbmodem14201'
[2024-10-07T10:36:34Z INFO ] Connecting...
[2024-10-07T10:36:34Z INFO ] Using flash stub
Chip type:         esp32p4 (revision v0.1)
Crystal frequency: 40 MHz
Flash size:        16MB
Features:          High-Performance MCU
MAC address:       60:55:f9:f9:04:5e
```

And when using `esptool.py get_security_info` (output has been truncated):

```text
jesse@mbp ~/W/espflash git:feature/esp32p4 [ ✎ ⚑ ]
🦀 nightly@1.83.0 λ esptool.py get_security_info
esptool.py v4.8.1
Found 2 serial ports
Serial port /dev/cu.usbmodem14201
Connecting...
Detecting chip type... ESP32-P4
Chip is unknown ESP32-P4 (revision v0.1)
Features: High-Performance MCU
Crystal is 40MHz
MAC: 60:55:f9:f9:04:5e

[...]
```