### PR TITLE
Add skip update check option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed `partition-table-offset` argument to accept offsets in hexadecimal (#682)
 - espflash defmt log didn't display timestamp, according to [defmt doc](https://defmt.ferrous-systems.com/timestamps). (#680)
 - Fixed pattern matching to detect download mode over multiple lines (#685)
+- Add an option to prevent update checks (#689)
 
 ### Changed
 

--- a/cargo-espflash/src/main.rs
+++ b/cargo-espflash/src/main.rs
@@ -51,6 +51,9 @@ enum CargoSubcommand {
     Espflash {
         #[clap(subcommand)]
         subcommand: Commands,
+
+        #[clap(short, long, global = true, action)]
+        skip_update_check: bool,
     },
 }
 
@@ -203,13 +206,19 @@ fn main() -> Result<()> {
 
     // Attempt to parse any provided comand-line arguments, or print the help
     // message and terminate if the invocation is not correct.
-    let CargoSubcommand::Espflash { subcommand: args } = Cli::parse().subcommand;
-    debug!("{:#?}", args);
+    let cli = Cli::parse();
+    let CargoSubcommand::Espflash {
+        subcommand: args,
+        skip_update_check,
+    } = cli.subcommand;
+    debug!("{:#?}, {:#?}", args, skip_update_check);
 
     // Only check for updates once the command-line arguments have been processed,
     // to avoid printing any update notifications when the help message is
     // displayed.
-    check_for_update(env!("CARGO_PKG_NAME"), env!("CARGO_PKG_VERSION"));
+    if !skip_update_check {
+        check_for_update(env!("CARGO_PKG_NAME"), env!("CARGO_PKG_VERSION"));
+    }
 
     // Load any user configuration, if present.
     let config = Config::load()?;

--- a/cargo-espflash/src/main.rs
+++ b/cargo-espflash/src/main.rs
@@ -52,6 +52,7 @@ enum CargoSubcommand {
         #[clap(subcommand)]
         subcommand: Commands,
 
+        /// Do not check for updates
         #[clap(short, long, global = true, action)]
         skip_update_check: bool,
     },

--- a/espflash/src/bin/espflash.rs
+++ b/espflash/src/bin/espflash.rs
@@ -29,6 +29,7 @@ pub struct Cli {
     #[command(subcommand)]
     subcommand: Commands,
 
+    /// Do not check for updates
     #[clap(short, long, global = true, action)]
     skip_update_check: bool,
 }

--- a/espflash/src/bin/espflash.rs
+++ b/espflash/src/bin/espflash.rs
@@ -28,6 +28,9 @@ use miette::{IntoDiagnostic, Result, WrapErr};
 pub struct Cli {
     #[command(subcommand)]
     subcommand: Commands,
+
+    #[clap(short, long, global = true, action)]
+    skip_update_check: bool,
 }
 
 #[derive(Debug, Subcommand)]
@@ -158,13 +161,16 @@ fn main() -> Result<()> {
 
     // Attempt to parse any provided comand-line arguments, or print the help
     // message and terminate if the invocation is not correct.
-    let args = Cli::parse().subcommand;
-    debug!("{:#?}", args);
+    let cli = Cli::parse();
+    let args = cli.subcommand;
+    debug!("{:#?}, {:#?}", args, cli.skip_update_check);
 
     // Only check for updates once the command-line arguments have been processed,
     // to avoid printing any update notifications when the help message is
     // displayed.
-    check_for_update(env!("CARGO_PKG_NAME"), env!("CARGO_PKG_VERSION"));
+    if !cli.skip_update_check {
+        check_for_update(env!("CARGO_PKG_NAME"), env!("CARGO_PKG_VERSION"));
+    }
 
     // Load any user configuration, if present.
     let config = Config::load()?;


### PR DESCRIPTION
Add a new global option to prevent espflash from checking updates.
It will make it work faster behind a proxy.

Closes #688 