### PR TITLE
If a port was specified via CLI or config, search *all* serial ports, not just the filtered list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Only filter the list of available serial ports if a port has not been specified via CLI option or configuration file (#693)
+
 ### Removed
 
 ## [3.2.0]

--- a/espflash/src/cli/serial.rs
+++ b/espflash/src/cli/serial.rs
@@ -33,13 +33,14 @@ pub fn get_serial_port_info(
     // doesn't work (on Windows) with "dummy" device paths like `COM4`. That's
     // the reason we need to handle Windows/Posix differently.
 
-    let ports = detect_usb_serial_ports(matches.list_all_ports).unwrap_or_default();
-
     if let Some(serial) = &matches.port {
+        let ports = detect_usb_serial_ports(true).unwrap_or_default();
         find_serial_port(&ports, serial)
     } else if let Some(serial) = &config.connection.serial {
+        let ports = detect_usb_serial_ports(true).unwrap_or_default();
         find_serial_port(&ports, serial)
     } else {
+        let ports = detect_usb_serial_ports(matches.list_all_ports).unwrap_or_default();
         let (port, matches) = select_serial_port(ports, config, matches.confirm_port)?;
 
         match &port.port_type {


### PR DESCRIPTION
Since the list of available ports were being filtered down by default, when specifying a port via CLI option or configuration file which had been filtered out, the port was reported as unavailable. This should resolve the issue by only filtering the list of ports if no port was specified.

@trombik are you able to test this branch out and confirm that it indeed resolves the issue for you, please?

Closes #692