### PR TITLE
Allow `partition_table_offset` to be specified in the config file. (for #699)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Allow `partition_table_offset` to be specified in the config file. (for #699)
+
 ### Changed
 
 ### Fixed

--- a/espflash/src/cli/config.rs
+++ b/espflash/src/cli/config.rs
@@ -87,6 +87,9 @@ pub struct Config {
     /// Partition table path
     #[serde(default)]
     pub partition_table: Option<PathBuf>,
+    /// Partition table offset
+    #[serde(default)]
+    pub partition_table_offset: Option<u32>,
     /// Preferred USB devices
     #[serde(default)]
     pub usb_device: Vec<UsbDevice>,

--- a/espflash/src/cli/mod.rs
+++ b/espflash/src/cli/mod.rs
@@ -826,6 +826,10 @@ pub fn make_flash_data(
         .or(config.partition_table.as_deref())
         .or(default_partition_table);
 
+    let partition_table_offset = image_args
+        .partition_table_offset
+        .or(config.partition_table_offset);
+
     if let Some(path) = &bootloader {
         println!("Bootloader:        {}", path.display());
     }
@@ -837,7 +841,7 @@ pub fn make_flash_data(
     FlashData::new(
         bootloader,
         partition_table,
-        image_args.partition_table_offset,
+        partition_table_offset,
         image_args.target_app_partition,
         flash_settings,
         image_args.min_chip_rev,


### PR DESCRIPTION
Change to implement #699 

I tested this with `espflash.toml` in the local directory:
```
partition_table_offset = 0xA000

[flash]
size = "8MB"
```

It works as expected, I can see that when I change the partition_table_offset address in the config file that the tool's behavior honors that change.