### PR TITLE
Make the libudev dependency optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Allow `partition_table_offset` to be specified in the config file. (for #699)
 - Support external log-processors (#705)
+- Make the `libudev` dependency optional with a new - enabled by default - feature: `libudev`
 
 ### Changed
 

--- a/espflash/Cargo.toml
+++ b/espflash/Cargo.toml
@@ -54,7 +54,7 @@ miette = "7.2.0"
 parse_int = { version = "0.6.0", optional = true }
 regex = { version = "1.11.0", optional = true }
 serde = { version = "1.0.210", features = ["derive"] }
-serialport = { version = "4.6.0", optional = true }
+serialport = { version = "4.6.0", default-features = false, optional = true }
 sha2 = "0.10.8"
 slip-codec = { version = "0.4.0", optional = true }
 strum = { version = "0.26.3", features = ["derive"] }
@@ -67,7 +67,8 @@ xmas-elf = "0.9.1"
 libc = "0.2.159"
 
 [features]
-default = ["cli"]
+default = ["cli", "libudev"]
+libudev = ["serialport?/libudev"]
 cli = [
     "dep:addr2line",
     "dep:clap",


### PR DESCRIPTION
Subject says it all. 

The main driver for this is to be able to cross-compile `espflash` for other Linux targets (e.g. Raspberry Pi) with either:
```sh
cross build --release --target=arm-unknown-linux-gnueabihf
```

or
```sh
cargo zigbuild --target aarch64-unknown-linux-gnu.2.17
```

Neither of these can do it when the dependency to `libudev` is present, and both do succeed when the dependency to `libudev` is not there.

I'm yet to test this on a RPI (real soon), but on a regular Ubuntu 22.04, disabling the `libudev` dependency actually does not lead to a visible loss in functionality. At least not when `espflash` is driven programmatically via its API as I did.
`/dev/ttyUSB0` is still detected as _the_ serial port where the esp32(s3) device is answering.
