### PR TITLE
Make clippy happy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
       fail-fast: false
       matrix:
         platform:
-          - os: "macos-12"
+          - os: "macos-13"
             target: "x86_64-apple-darwin"
             arch: "x86_64"
           - os: "ubuntu-22.04"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,11 +32,11 @@ jobs:
             target: "x86_64-pc-windows-msvc"
             arch: "x86_64"
           # macOs
-          - os: "macos-12"
+          - os: "macos-13"
             target: "aarch64-apple-darwin"
             # This is not true, but simplifies the logic of the action.
             arch: "x86_64"
-          - os: "macos-12"
+          - os: "macos-13"
             target: "x86_64-apple-darwin"
             arch: "x86_64"
     runs-on: ${{ matrix.platform.os }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Allow `partition_table_offset` to be specified in the config file. (for #699)
 - Support external log-processors (#705)
-- Address Clippy lints
+- Address Clippy lints (#710)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Allow `partition_table_offset` to be specified in the config file. (for #699)
 - Support external log-processors (#705)
+- Address Clippy lints
 
 ### Changed
 

--- a/espflash/src/command.rs
+++ b/espflash/src/command.rs
@@ -192,7 +192,7 @@ pub enum Command<'a> {
     FlashDetect,
 }
 
-impl<'a> Command<'a> {
+impl Command<'_> {
     /// Return the command type
     pub fn command_type(&self) -> CommandType {
         match self {

--- a/espflash/src/connection/mod.rs
+++ b/espflash/src/connection/mod.rs
@@ -515,7 +515,7 @@ mod encoder {
         }
     }
 
-    impl<'a, W: Write> Write for SlipEncoder<'a, W> {
+    impl<W: Write> Write for SlipEncoder<'_, W> {
         /// Writes the given buffer replacing the END and ESC bytes
         ///
         /// See https://docs.espressif.com/projects/esptool/en/latest/esp32c3/advanced-topics/serial-protocol.html#low-level-protocol

--- a/espflash/src/connection/reset.rs
+++ b/espflash/src/connection/reset.rs
@@ -253,7 +253,7 @@ pub fn soft_reset(
             connection.with_timeout(CommandType::FlashBegin.timeout(), |connection| {
                 let size: u32 = 0;
                 let offset: u32 = 0;
-                let blocks: u32 = (size + FLASH_WRITE_SIZE as u32 - 1) / FLASH_WRITE_SIZE as u32;
+                let blocks: u32 = size.div_ceil(FLASH_WRITE_SIZE as u32);
                 connection.command(Command::FlashBegin {
                     size,
                     blocks,
@@ -271,7 +271,7 @@ pub fn soft_reset(
         connection.with_timeout(CommandType::FlashBegin.timeout(), |connection| {
             let size: u32 = 0;
             let offset: u32 = 0;
-            let blocks: u32 = (size + FLASH_WRITE_SIZE as u32 - 1) / FLASH_WRITE_SIZE as u32;
+            let blocks: u32 = size.div_ceil(FLASH_WRITE_SIZE as u32);
             connection.command(Command::FlashBegin {
                 size,
                 blocks,

--- a/espflash/src/elf.rs
+++ b/espflash/src/elf.rs
@@ -184,7 +184,7 @@ impl<'a> CodeSegment<'a> {
     }
 }
 
-impl<'a> AddAssign<&'_ [u8]> for CodeSegment<'a> {
+impl AddAssign<&'_ [u8]> for CodeSegment<'_> {
     fn add_assign(&mut self, rhs: &'_ [u8]) {
         let mut data = take(&mut self.data).into_owned();
         data.extend_from_slice(rhs);
@@ -192,7 +192,7 @@ impl<'a> AddAssign<&'_ [u8]> for CodeSegment<'a> {
     }
 }
 
-impl<'a> AddAssign<&'_ CodeSegment<'_>> for CodeSegment<'a> {
+impl AddAssign<&'_ CodeSegment<'_>> for CodeSegment<'_> {
     fn add_assign(&mut self, rhs: &'_ CodeSegment<'_>) {
         let mut data = take(&mut self.data).into_owned();
         // pad or truncate

--- a/espflash/src/flasher/mod.rs
+++ b/espflash/src/flasher/mod.rs
@@ -302,7 +302,7 @@ pub struct FlashDataBuilder<'a> {
     min_chip_rev: u16,
 }
 
-impl<'a> Default for FlashDataBuilder<'a> {
+impl Default for FlashDataBuilder<'_> {
     fn default() -> Self {
         Self {
             bootloader_path: Default::default(),
@@ -567,6 +567,7 @@ pub struct Flasher {
 
 #[cfg(feature = "serialport")]
 impl Flasher {
+    #[allow(clippy::too_many_arguments)]
     pub fn connect(
         serial: Port,
         port_info: UsbPortInfo,

--- a/espflash/src/image_format.rs
+++ b/espflash/src/image_format.rs
@@ -113,6 +113,7 @@ pub struct IdfBootloaderFormat<'a> {
 }
 
 impl<'a> IdfBootloaderFormat<'a> {
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         image: &'a dyn FirmwareImage<'a>,
         chip: Chip,

--- a/espflash/src/targets/flash_target/esp32.rs
+++ b/espflash/src/targets/flash_target/esp32.rs
@@ -170,8 +170,8 @@ impl FlashTarget for Esp32Target {
 
         let target = self.chip.into_target();
         let flash_write_size = target.flash_write_size(connection)?;
-        let block_count = (compressed.len() + flash_write_size - 1) / flash_write_size;
-        let erase_count = (segment.data.len() + FLASH_SECTOR_SIZE - 1) / FLASH_SECTOR_SIZE;
+        let block_count = compressed.len().div_ceil(flash_write_size);
+        let erase_count = segment.data.len().div_ceil(FLASH_SECTOR_SIZE);
 
         // round up to sector size
         let erase_size = (erase_count * FLASH_SECTOR_SIZE) as u32;

--- a/espflash/src/targets/flash_target/ram.rs
+++ b/espflash/src/targets/flash_target/ram.rs
@@ -42,7 +42,7 @@ impl FlashTarget for RamTarget {
         let addr = segment.addr;
 
         let padding = 4 - segment.data.len() % 4;
-        let block_count = (segment.data.len() + padding + self.block_size - 1) / self.block_size;
+        let block_count = (segment.data.len() + padding).div_ceil(self.block_size);
 
         connection.command(Command::MemBegin {
             size: segment.data.len() as u32,


### PR DESCRIPTION
Subject says it all.

99% of the changes here are the result of 
```sh
rustup default nightly
cargo clippy --alllow-dirty --fix
```

... and then I added `#[allow(clippy::too_many_arguments)]` to two constructor functions as clippy complained (apparently they reduced the threshold down to 7 arguments before the complaints start)