### PR TITLE
Calculate end of bootloader to update SHA256

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Update the app image SHA in the correct location for padded images (#715)
+
 ### Removed
 
 ## [3.3.0] - 2025-01-13

--- a/espflash/Cargo.toml
+++ b/espflash/Cargo.toml
@@ -43,7 +43,7 @@ directories = { version = "5.0.1", optional = true }
 env_logger = { version = "0.11.6", optional = true }
 esp-idf-part = "0.5.0"
 flate2 = "1.0.35"
-hex = { version = "0.4.3", features = ["serde"], optional = true }
+hex = { version = "0.4.3", features = ["serde"]}
 indicatif = { version = "0.17.9", optional = true }
 lazy_static = { version = "1.5.0", optional = true }
 log = "0.4.22"
@@ -79,7 +79,6 @@ cli = [
     "dep:dialoguer",
     "dep:directories",
     "dep:env_logger",
-    "dep:hex",
     "dep:indicatif",
     "dep:lazy_static",
     "dep:parse_int",


### PR DESCRIPTION
The current implementation uses the last 32 bytes of the bootloader file. When Secure Boot V2 is enabled, the bootloader is padded. The new implementation walks through the segments to find the end and adds the 16-byte aligned 1-byte checksum to update the SHA256 instead of incorrectly updating the padding.

Closes #715