### PR TITLE
Fix test failure with `no-run` vs `no_run`

### DIFF
--- a/espflash/src/cli/monitor/external_processors.rs
+++ b/espflash/src/cli/monitor/external_processors.rs
@@ -14,7 +14,7 @@
 //! The executable will get the path of the ELF file as the first argument if available.
 //!
 //! Example processor which turns some letters into uppercase
-//! ```rust,no-run
+//! ```rust,no_run
 //! use std::io::{stdin, stdout, Read, Write};
 //!
 //! fn main() {


### PR DESCRIPTION
Fixes the following currently present in 3.3.0:
```
   Doc-tests espflash
warning: unknown attribute `no-run`
  --> espflash/src/cli/monitor/external_processors.rs:2:1
   |
2  | / //! External processor support
3  | | //!
4  | | //! Via the command line argument `--processors` you can instruct espflash to run external executables to p...
5  | | //! the logs received from the target. Multiple processors are supported by separating them via `,`. Proces...
...  |
41 | | //! }
42 | | //! ```
   | |_______^
   |
   = help: use `no_run` to compile, but not run, the code sample during testing
   = help: this code block may be skipped during testing, because unknown attributes are treated as markers for code samples written in other programming languages, unless it is also explicitly marked as `rust`
   = note: `#[warn(rustdoc::invalid_codeblock_attributes)]` on by default

warning: 1 warning emitted


running 1 test
test espflash/src/cli/monitor/external_processors.rs - cli::monitor::external_processors (line 17) ... FAILED

failures:

---- espflash/src/cli/monitor/external_processors.rs - cli::monitor::external_processors (line 17) stdout ----
Test executable failed (exit status: 101).

stderr:
thread 'main' panicked at espflash/src/cli/monitor/external_processors.rs:6:36:
index out of bounds: the len is 1 but the index is 1
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```