### PR TITLE
[cargo-espflash]: Fix `-s` collision

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 ### Fixed
-
 - Update the app image SHA in the correct location for padded images (#715)
+- Fix `-s` argument collision (#731)
 
 ### Removed
 

--- a/cargo-espflash/src/main.rs
+++ b/cargo-espflash/src/main.rs
@@ -53,7 +53,7 @@ enum CargoSubcommand {
         subcommand: Commands,
 
         /// Do not check for updates
-        #[clap(short, long, global = true, action)]
+        #[clap(short = 'S', long, global = true, action)]
         skip_update_check: bool,
     },
 }


### PR DESCRIPTION
https://github.com/esp-rs/espflash/pull/705#discussion_r1858239611 fixed the collision for `espflash` but not for `cargo-espflash`