### PR TITLE
Avoid running CI twice

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,11 @@ name: CI
 on:
   pull_request:
   push:
-  workflow_dispatch:
+    branches-ignore:
+      - "gh-readonly-queue/**"
+      - "main"
   merge_group:
+  workflow_dispatch:
 
 env:
   CARGO_TERM_COLOR: always


### PR DESCRIPTION
This causes the second workflow to cancel the first one.