### PR TITLE
Additional improvements to CI workflow

### DIFF
--- a/.github/actions/setup-target/action.yml
+++ b/.github/actions/setup-target/action.yml
@@ -3,9 +3,11 @@ description: Setup an ARM or x86_64 build environment
 
 inputs:
   arch:
-    required: true
+    default: x86_64
+    required: false
   target:
-    required: true
+    default: x86_64-unknown-linux-gnu
+    required: false
   toolchain:
     default: stable
     required: false
@@ -15,10 +17,10 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: Replace target string
-      if: inputs.arch != 'x86_64'
-      uses: mad9000/actions-find-and-replace-string@5
+    - if: inputs.arch != 'x86_64'
+      name: Replace target string
       id: findandreplace
+      uses: mad9000/actions-find-and-replace-string@5
       with:
         source: ${{ inputs.target }}
         find: "unknown-"
@@ -33,14 +35,14 @@ runs:
 
     - uses: Swatinem/rust-cache@v2
 
-    - name: Install Cross-Compile Support
-      if: inputs.arch != 'x86_64'
+    - if: inputs.arch != 'x86_64'
+      name: Install Cross-Compile Support
       uses: junelife/gha-ubuntu-cross@v6
       with:
         arch: ${{ inputs.arch }}
 
-    - name: Install dependencies (Raspberry Pi)
-      if: inputs.arch != 'x86_64'
+    - if: inputs.arch != 'x86_64'
+      name: Install dependencies (Raspberry Pi)
       shell: bash
       run: |
         sudo apt-get update && sudo apt-get install -y \
@@ -53,14 +55,14 @@ runs:
           musl-tools \
           pkg-config
 
-    - name: Install dependencies (x86_64 linux)
-      if: inputs.target == 'x86_64-unknown-linux-gnu' || inputs.target == 'x86_64-unknown-linux-musl'
+    - if: inputs.target == 'x86_64-unknown-linux-gnu' || inputs.target == 'x86_64-unknown-linux-musl'
+      name: Install dependencies (x86_64 linux)
       shell: bash
       run: |
         sudo apt-get update && sudo apt-get -y install musl-tools pkg-config
 
-    - name: Set environment variables
-      if: inputs.arch != 'x86_64'
+    - if: inputs.arch != 'x86_64'
+      name: Set environment variables
       shell: bash
       run: |
         echo "PKG_CONFIG_ALLOW_SYSTEM_LIBS=0" >> $GITHUB_ENV

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,7 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
+  MSRV: "1.82"
 
 # Cancel any currently running workflows from the same PR, branch, or
 # tag when a new workflow is triggered.
@@ -59,10 +60,8 @@ jobs:
           arch: ${{ matrix.platform.arch }}
           target: ${{ matrix.platform.target }}
 
-      - run: cargo check
-
-      - run: cargo run --package=cargo-espflash -- espflash completions bash
-      - run: cargo run --package=espflash -- completions bash
+      - run: cargo run -p cargo-espflash -- espflash completions bash
+      - run: cargo run -p espflash -- completions bash
 
   check-lib:
     name: Check lib (${{ matrix.platform.target }})
@@ -112,7 +111,7 @@ jobs:
         with:
           arch: ${{ matrix.platform.arch }}
           target: ${{ matrix.platform.target }}
-          toolchain: "1.82"
+          toolchain: ${{ env.MSRV }}
 
       - run: cargo check -p espflash --lib
 
@@ -120,26 +119,12 @@ jobs:
   # Test
 
   test:
-    name: Unit Tests (${{ matrix.platform.target }})
-    strategy:
-      fail-fast: false
-      matrix:
-        platform:
-          - target: "x86_64-unknown-linux-gnu"
-            arch: "x86_64"
-          - target: "aarch64-unknown-linux-gnu"
-            arch: "arm64"
-          - target: "armv7-unknown-linux-gnueabihf"
-            arch: "armhf"
+    name: Unit Tests
     runs-on: ubuntu-22.04
 
     steps:
       - uses: actions/checkout@v4
-
       - uses: ./.github/actions/setup-target
-        with:
-          arch: ${{ matrix.platform.arch }}
-          target: ${{ matrix.platform.target }}
 
       - run: cargo test --lib
 
@@ -147,29 +132,17 @@ jobs:
   # Lint
 
   clippy:
-    name: Clippy (${{ matrix.platform.target }})
-    strategy:
-      fail-fast: false
-      matrix:
-        platform:
-          - target: "x86_64-unknown-linux-gnu"
-            arch: "x86_64"
-          - target: "aarch64-unknown-linux-gnu"
-            arch: "arm64"
-          - target: "armv7-unknown-linux-gnueabihf"
-            arch: "armhf"
+    name: Clippy
     runs-on: ubuntu-22.04
 
     steps:
       - uses: actions/checkout@v4
-
-      - uses: ./.github/actions/setup-target
+      - uses: dtolnay/rust-toolchain@stable
         with:
-          arch: ${{ matrix.platform.arch }}
-          target: ${{ matrix.platform.target }}
           components: clippy
+      - uses: Swatinem/rust-cache@v2
 
-      - run: cargo clippy -- -D warnings -A clippy::too_many_arguments
+      - run: cargo clippy -- -D warnings
 
   rustfmt:
     name: Rustfmt


### PR DESCRIPTION
This has pretty drastically reduced the runtime on my fork at least. Some additional re-org in here too, sorry for the noise.

Additional considerations:

- The matrices in the `check`, `check-lib`, and `msrv` jobs are different
  - Should we check all platforms/archs for each of these jobs, or is a limited subset adequate?
  - If the latter, which platforms should be checked? Is x86_64 macOS/Linux/Windows enough for the `check-lib` and `msrv` jobs? Something else?