### PR TITLE
Deny missing debug implementation and Rust 2018 idioms

### DIFF
--- a/espflash/src/cli/mod.rs
+++ b/espflash/src/cli/mod.rs
@@ -553,7 +553,7 @@ pub(crate) fn display_image_size(app_size: u32, part_size: Option<u32>) {
 }
 
 /// Progress callback implementations for use in `cargo-espflash` and `espflash`
-#[derive(Default)]
+#[derive(Debug, Default)]
 pub struct EspflashProgress {
     pb: Option<ProgressBar>,
 }

--- a/espflash/src/cli/monitor/external_processors.rs
+++ b/espflash/src/cli/monitor/external_processors.rs
@@ -72,6 +72,7 @@ impl std::error::Error for Error {}
 
 impl Diagnostic for Error {}
 
+#[derive(Debug)]
 struct Processor {
     rx: mpsc::Receiver<u8>,
     stdin: ChildStdin,
@@ -121,6 +122,7 @@ impl Drop for Processor {
     }
 }
 
+#[derive(Debug)]
 pub struct ExternalProcessors {
     processors: Vec<Processor>,
 }

--- a/espflash/src/cli/monitor/parser/esp_defmt.rs
+++ b/espflash/src/cli/monitor/parser/esp_defmt.rs
@@ -33,6 +33,7 @@ enum FrameKind<'a> {
     Raw(&'a [u8]),
 }
 
+#[derive(Debug)]
 struct FrameDelimiter {
     buffer: Vec<u8>,
     in_frame: bool,
@@ -97,6 +98,7 @@ impl FrameDelimiter {
     }
 }
 
+#[derive(Debug)]
 pub struct EspDefmt {
     delimiter: FrameDelimiter,
     table: Table,

--- a/espflash/src/cli/monitor/parser/mod.rs
+++ b/espflash/src/cli/monitor/parser/mod.rs
@@ -58,6 +58,7 @@ fn resolve_addresses(
     Ok(())
 }
 
+#[derive(Debug)]
 struct Utf8Merger {
     incomplete_utf8_buffer: Vec<u8>,
 }
@@ -104,6 +105,7 @@ impl Utf8Merger {
     }
 }
 
+#[allow(missing_debug_implementations)]
 pub struct ResolvingPrinter<'ctx, W: Write> {
     writer: W,
     symbols: Option<Symbols<'ctx>>,

--- a/espflash/src/cli/monitor/parser/serial.rs
+++ b/espflash/src/cli/monitor/parser/serial.rs
@@ -2,6 +2,7 @@ use std::io::Write;
 
 use crate::cli::monitor::parser::InputParser;
 
+#[derive(Debug)]
 pub struct Serial;
 
 impl InputParser for Serial {

--- a/espflash/src/connection/mod.rs
+++ b/espflash/src/connection/mod.rs
@@ -103,6 +103,7 @@ pub struct CommandResponse {
 }
 
 /// An established connection with a target device
+#[derive(Debug)]
 pub struct Connection {
     serial: Port,
     port_info: UsbPortInfo,

--- a/espflash/src/connection/mod.rs
+++ b/espflash/src/connection/mod.rs
@@ -412,7 +412,7 @@ impl Connection {
     }
 
     /// Write a command to the serial port
-    pub fn write_command(&mut self, command: Command) -> Result<(), Error> {
+    pub fn write_command(&mut self, command: Command<'_>) -> Result<(), Error> {
         debug!("Writing command: {:02x?}", command);
         let mut binding = Box::new(&mut self.serial);
         let serial = binding.as_mut();
@@ -427,7 +427,7 @@ impl Connection {
     }
 
     ///  Write a command and reads the response
-    pub fn command(&mut self, command: Command) -> Result<CommandResponseValue, Error> {
+    pub fn command(&mut self, command: Command<'_>) -> Result<CommandResponseValue, Error> {
         let ty = command.command_type();
         self.write_command(command).for_command(ty)?;
 

--- a/espflash/src/elf.rs
+++ b/espflash/src/elf.rs
@@ -48,6 +48,7 @@ pub trait FirmwareImage<'a> {
 }
 
 /// A firmware image built from an ELF file
+#[derive(Debug)]
 pub struct ElfFirmwareImage<'a> {
     elf: ElfFile<'a>,
 }
@@ -230,8 +231,8 @@ impl Ord for CodeSegment<'_> {
     }
 }
 
-#[derive(Clone)]
 /// A segment of data to write to the flash
+#[derive(Debug, Clone)]
 pub struct RomSegment<'a> {
     /// ROM address at which the segment begins
     pub addr: u32,

--- a/espflash/src/error.rs
+++ b/espflash/src/error.rs
@@ -337,7 +337,7 @@ pub struct TimedOutCommand {
 
 #[cfg(feature = "serialport")]
 impl Display for TimedOutCommand {
-    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match &self.command {
             Some(command) => write!(f, "{} ", command),
             None => Ok(()),

--- a/espflash/src/flasher/mod.rs
+++ b/espflash/src/flasher/mod.rs
@@ -1010,7 +1010,7 @@ impl Flasher {
     /// Load multiple bin images to flash at specific addresses
     pub fn write_bins_to_flash(
         &mut self,
-        segments: &[RomSegment],
+        segments: &[RomSegment<'_>],
         mut progress: Option<&mut dyn ProgressCallbacks>,
     ) -> Result<(), Error> {
         let mut target = self

--- a/espflash/src/flasher/mod.rs
+++ b/espflash/src/flasher/mod.rs
@@ -291,6 +291,7 @@ impl FlashSettings {
 }
 
 /// Builder interface to create [`FlashData`] objects.
+#[derive(Debug)]
 pub struct FlashDataBuilder<'a> {
     bootloader_path: Option<&'a Path>,
     partition_table_path: Option<&'a Path>,
@@ -539,13 +540,14 @@ pub fn parse_partition_table(path: &Path) -> Result<PartitionTable, Error> {
     Ok(PartitionTable::try_from(data)?)
 }
 
-#[cfg(feature = "serialport")]
 /// List of SPI parameters to try while detecting flash size
+#[cfg(feature = "serialport")]
 pub(crate) const TRY_SPI_PARAMS: [SpiAttachParams; 2] =
     [SpiAttachParams::default(), SpiAttachParams::esp32_pico_d4()];
 
-#[cfg(feature = "serialport")]
 /// Connect to and flash a target device
+#[cfg(feature = "serialport")]
+#[derive(Debug)]
 pub struct Flasher {
     /// Connection for flash operations
     connection: Connection,

--- a/espflash/src/image_format.rs
+++ b/espflash/src/image_format.rs
@@ -369,7 +369,7 @@ impl<'a> IdfBootloaderFormat<'a> {
 ///
 /// (this is because the segment's vaddr may not be IROM_ALIGNed, more likely is
 /// aligned IROM_ALIGN+0x18 to account for the binary file header)
-fn get_segment_padding(offset: usize, segment: &CodeSegment) -> u32 {
+fn get_segment_padding(offset: usize, segment: &CodeSegment<'_>) -> u32 {
     let align_past = (segment.addr - SEG_HEADER_LEN) % IROM_ALIGN;
     let pad_len = ((IROM_ALIGN - ((offset as u32) % IROM_ALIGN)) + align_past) % IROM_ALIGN;
 
@@ -383,10 +383,10 @@ fn get_segment_padding(offset: usize, segment: &CodeSegment) -> u32 {
 }
 
 /// Merge adjacent segments into one.
-fn merge_adjacent_segments(mut segments: Vec<CodeSegment>) -> Vec<CodeSegment> {
+fn merge_adjacent_segments(mut segments: Vec<CodeSegment<'_>>) -> Vec<CodeSegment<'_>> {
     segments.sort();
 
-    let mut merged: Vec<CodeSegment> = Vec::with_capacity(segments.len());
+    let mut merged: Vec<CodeSegment<'_>> = Vec::with_capacity(segments.len());
     for segment in segments {
         match merged.last_mut() {
             Some(last) if last.addr + last.size() == segment.addr => {
@@ -404,7 +404,7 @@ fn merge_adjacent_segments(mut segments: Vec<CodeSegment>) -> Vec<CodeSegment> {
 /// Save a segment to the data buffer.
 fn save_flash_segment(
     data: &mut Vec<u8>,
-    mut segment: CodeSegment,
+    mut segment: CodeSegment<'_>,
     checksum: u8,
 ) -> Result<u8, Error> {
     let end_pos = (data.len() + segment.data().len()) as u32 + SEG_HEADER_LEN;
@@ -425,7 +425,7 @@ fn save_flash_segment(
 }
 
 /// Stores a segment header and the segment data in the data buffer.
-fn save_segment(data: &mut Vec<u8>, segment: &CodeSegment, checksum: u8) -> Result<u8, Error> {
+fn save_segment(data: &mut Vec<u8>, segment: &CodeSegment<'_>, checksum: u8) -> Result<u8, Error> {
     let padding = (4 - segment.size() % 4) % 4;
     let header = SegmentHeader {
         addr: segment.addr,

--- a/espflash/src/image_format.rs
+++ b/espflash/src/image_format.rs
@@ -103,6 +103,7 @@ struct SegmentHeader {
 
 /// Image format for ESP32 family chips using the second-stage bootloader from
 /// ESP-IDF
+#[derive(Debug)]
 pub struct IdfBootloaderFormat<'a> {
     params: Esp32Params,
     bootloader: Cow<'a, [u8]>,

--- a/espflash/src/lib.rs
+++ b/espflash/src/lib.rs
@@ -27,7 +27,7 @@
 //! [cargo-binstall]: https://github.com/cargo-bins/cargo-binstall
 
 #![cfg_attr(docsrs, feature(doc_cfg))]
-#![deny(missing_debug_implementations)]
+#![deny(missing_debug_implementations, rust_2018_idioms)]
 
 #[cfg(feature = "cli")]
 #[cfg_attr(docsrs, doc(cfg(feature = "cli")))]

--- a/espflash/src/lib.rs
+++ b/espflash/src/lib.rs
@@ -27,6 +27,7 @@
 //! [cargo-binstall]: https://github.com/cargo-bins/cargo-binstall
 
 #![cfg_attr(docsrs, feature(doc_cfg))]
+#![deny(missing_debug_implementations)]
 
 #[cfg(feature = "cli")]
 #[cfg_attr(docsrs, doc(cfg(feature = "cli")))]

--- a/espflash/src/targets/flash_target/esp32.rs
+++ b/espflash/src/targets/flash_target/esp32.rs
@@ -22,6 +22,7 @@ use crate::{
 };
 
 /// Applications running from an ESP32's (or variant's) flash
+#[derive(Debug)]
 pub struct Esp32Target {
     chip: Chip,
     spi_attach_params: SpiAttachParams,

--- a/espflash/src/targets/flash_target/esp32.rs
+++ b/espflash/src/targets/flash_target/esp32.rs
@@ -136,7 +136,7 @@ impl FlashTarget for Esp32Target {
     fn write_segment(
         &mut self,
         connection: &mut Connection,
-        segment: RomSegment,
+        segment: RomSegment<'_>,
         progress: &mut Option<&mut dyn ProgressCallbacks>,
     ) -> Result<(), Error> {
         let addr = segment.addr;

--- a/espflash/src/targets/flash_target/mod.rs
+++ b/espflash/src/targets/flash_target/mod.rs
@@ -24,7 +24,7 @@ pub trait FlashTarget {
     fn write_segment(
         &mut self,
         connection: &mut Connection,
-        segment: RomSegment,
+        segment: RomSegment<'_>,
         progress: &mut Option<&mut dyn ProgressCallbacks>,
     ) -> Result<(), Error>;
 

--- a/espflash/src/targets/flash_target/ram.rs
+++ b/espflash/src/targets/flash_target/ram.rs
@@ -37,7 +37,7 @@ impl FlashTarget for RamTarget {
     fn write_segment(
         &mut self,
         connection: &mut Connection,
-        segment: RomSegment,
+        segment: RomSegment<'_>,
         progress: &mut Option<&mut dyn ProgressCallbacks>,
     ) -> Result<(), Error> {
         let addr = segment.addr;

--- a/espflash/src/targets/flash_target/ram.rs
+++ b/espflash/src/targets/flash_target/ram.rs
@@ -10,6 +10,7 @@ use crate::{elf::RomSegment, error::Error};
 pub const MAX_RAM_BLOCK_SIZE: usize = 0x1800;
 
 /// Applications running in the target device's RAM
+#[derive(Debug)]
 pub struct RamTarget {
     entry: Option<u32>,
     block_size: usize,

--- a/espflash/src/targets/mod.rs
+++ b/espflash/src/targets/mod.rs
@@ -246,6 +246,7 @@ impl Esp32Params {
 }
 
 /// SPI register addresses
+#[derive(Debug)]
 pub struct SpiRegisters {
     base: u32,
     usr_offset: u32,


### PR DESCRIPTION
These are mostly just stylistic changes, but IMO good to have in many cases. Would also like to add `#![deny(missing_docs)]`, but this will be a non-trivial amount of work to document everything so will handle that in a separate PR 😅 

Maybe additionally it would be good to apply some of the Rust Style Guide guidelines to our code base like we did in `esp-hal`, however no rush there. Can be done at a later date for sure.