### PR TITLE
Remove the dependency on `lazy_static` in favour of built-in `LazyLock`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1268,7 +1268,6 @@ dependencies = [
  "flate2",
  "hex",
  "indicatif",
- "lazy_static",
  "libc",
  "log",
  "md-5",

--- a/espflash/Cargo.toml
+++ b/espflash/Cargo.toml
@@ -40,7 +40,6 @@ esp-idf-part    = "0.5.0"
 flate2          = "1.0.35"
 hex             = { version = "0.4.3", features = ["serde"] }
 indicatif       = { version = "0.17.9", optional = true }
-lazy_static     = { version = "1.5.0", optional = true }
 log             = "0.4.22"
 md-5            = "0.10.6"
 miette          = "7.4.0"
@@ -74,7 +73,6 @@ cli = [
     "dep:directories",
     "dep:env_logger",
     "dep:indicatif",
-    "dep:lazy_static",
     "dep:parse_int",
     "dep:toml",
     "dep:update-informer",

--- a/espflash/src/cli/monitor/parser/mod.rs
+++ b/espflash/src/cli/monitor/parser/mod.rs
@@ -1,25 +1,22 @@
-pub mod esp_defmt;
-pub mod serial;
-
-use std::{borrow::Cow, io::Write};
+use std::{borrow::Cow, io::Write, sync::LazyLock};
 
 use crossterm::{
     style::{Color, Print, PrintStyledContent, Stylize},
     QueueableCommand,
 };
-use lazy_static::lazy_static;
 use regex::Regex;
 
 use crate::cli::monitor::{line_endings::normalized, symbols::Symbols};
+
+pub mod esp_defmt;
+pub mod serial;
 
 pub trait InputParser {
     fn feed(&mut self, bytes: &[u8], out: &mut dyn Write);
 }
 
 // Pattern to much a function address in serial output.
-lazy_static! {
-    static ref RE_FN_ADDR: Regex = Regex::new(r"0x[[:xdigit:]]{8}").unwrap();
-}
+static RE_FN_ADDR: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"0x[[:xdigit:]]{8}").unwrap());
 
 fn resolve_addresses(
     symbols: &Symbols<'_>,


### PR DESCRIPTION
There has been a built-in solution for this problem in Rust for quite some time now, so no reason to depend on this package anymore.