### PR TITLE
Add a command to list available serial ports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add `non-interactive` flag to `flash` subcommand (#737)
 - Add `no-reset` flag to `monitor` subcommands (#737)
 - Add an environment variable to set monitoring baudrate (`MONITOR_BAUD`) (#737)
+Add list-ports command to list available serial ports.
+- Add list-ports command to list available serial ports.
 
 ### Changed
 - Split the baudrate for connecting and monitorinig in `flash` subcommand (#737)

--- a/cargo-espflash/README.md
+++ b/cargo-espflash/README.md
@@ -54,27 +54,29 @@ OPENSSL_NO_VENDOR=1 cargo install cargo-espflash
 ```text
 Cargo subcommand for flashing Espressif devices
 
-Usage: cargo espflash <COMMAND>
+Usage: cargo espflash [OPTIONS] <COMMAND>
 
 Commands:
   board-info       Print information about a connected target device
+  checksum-md5     Calculate the MD5 checksum of the given region
   completions      Generate completions for the given shell
   erase-flash      Erase Flash entirely
   erase-parts      Erase specified partitions
   erase-region     Erase specified region
   flash            Flash an application in ELF format to a target device
   hold-in-reset    Hold the target device in reset
+  list-ports       List serial ports available for flashing
   monitor          Open the serial monitor without flashing the connected target device
   partition-table  Convert partition tables between CSV and binary format
   read-flash       Read SPI flash content
   reset            Reset the target device
   save-image       Generate a binary application image and save it to a local disk
-  checksum-md5     Calculate the MD5 checksum of the given region
   help             Print this message or the help of the given subcommand(s)
 
 Options:
-  -h, --help     Print help
-  -V, --version  Print version
+  -S, --skip-update-check  Do not check for updates
+  -h, --help               Print help
+  -V, --version            Print version
 ```
 
 ### Permissions on Linux

--- a/cargo-espflash/src/main.rs
+++ b/cargo-espflash/src/main.rs
@@ -59,6 +59,8 @@ enum Commands {
     /// Automatically detects and prints the chip type, crystal frequency, flash
     /// size, chip features, and MAC address of a connected target device.
     BoardInfo(ConnectArgs),
+    /// Calculate the MD5 checksum of the given region
+    ChecksumMd5(ChecksumMd5Args),
     /// Generate completions for the given shell
     ///
     /// The completions are printed to stdout, and can be redirected as needed.
@@ -86,6 +88,11 @@ enum Commands {
     Flash(FlashArgs),
     /// Hold the target device in reset
     HoldInReset(ConnectArgs),
+    /// List serial ports available for flashing.
+    ///
+    /// The default behavior is to only list ports of devices known to be used
+    /// on development boards.
+    ListPorts(ListPortsArgs),
     /// Open the serial monitor without flashing the connected target device
     Monitor(MonitorArgs),
     /// Convert partition tables between CSV and binary format
@@ -110,8 +117,6 @@ enum Commands {
     /// Otherwise, each segment will be saved as individual binaries, prefixed
     /// with their intended addresses in flash.
     SaveImage(SaveImageArgs),
-    /// Calculate the MD5 checksum of the given region
-    ChecksumMd5(ChecksumMd5Args),
 }
 
 #[derive(Debug, Args)]
@@ -222,18 +227,19 @@ fn main() -> Result<()> {
     // associated arguments.
     match args {
         Commands::BoardInfo(args) => board_info(&args, &config),
+        Commands::ChecksumMd5(args) => checksum_md5(&args, &config),
         Commands::Completions(args) => completions(&args, &mut Cli::command(), "cargo"),
         Commands::EraseFlash(args) => erase_flash(args, &config),
         Commands::EraseParts(args) => erase_parts(args, &config),
         Commands::EraseRegion(args) => erase_region(args, &config),
         Commands::Flash(args) => flash(args, &config),
         Commands::HoldInReset(args) => hold_in_reset(args, &config),
+        Commands::ListPorts(args) => list_ports(&args, &config),
         Commands::Monitor(args) => serial_monitor(args, &config),
         Commands::PartitionTable(args) => partition_table(args),
         Commands::ReadFlash(args) => read_flash(args, &config),
         Commands::Reset(args) => reset(args, &config),
         Commands::SaveImage(args) => save_image(args, &config),
-        Commands::ChecksumMd5(args) => checksum_md5(&args, &config),
     }
 }
 

--- a/espflash/README.md
+++ b/espflash/README.md
@@ -49,28 +49,30 @@ cargo binstall espflash
 ```text
 A command-line tool for flashing Espressif devices
 
-Usage: espflash <COMMAND>
+Usage: espflash [OPTIONS] <COMMAND>
 
 Commands:
   board-info       Print information about a connected target device
+  checksum-md5     Calculate the MD5 checksum of the given region
   completions      Generate completions for the given shell
   erase-flash      Erase Flash entirely
   erase-parts      Erase specified partitions
   erase-region     Erase specified region
   flash            Flash an application in ELF format to a connected target device
   hold-in-reset    Hold the target device in reset
+  list-ports       List serial ports available for flashing
   monitor          Open the serial monitor without flashing the connected target device
   partition-table  Convert partition tables between CSV and binary format
   read-flash       Read SPI flash content
   reset            Reset the target device
   save-image       Generate a binary application image and save it to a local disk
   write-bin        Write a binary file to a specific address in a target device's flash
-  checksum-md5     Calculate the MD5 checksum of the given region
   help             Print this message or the help of the given subcommand(s)
 
 Options:
-  -h, --help     Print help
-  -V, --version  Print version
+  -S, --skip-update-check  Do not check for updates
+  -h, --help               Print help
+  -V, --version            Print version
 ```
 
 ### Permissions on Linux

--- a/espflash/src/bin/espflash.rs
+++ b/espflash/src/bin/espflash.rs
@@ -34,6 +34,8 @@ enum Commands {
     /// Automatically detects and prints the chip type, crystal frequency, flash
     /// size, chip features, and MAC address of a connected target device.
     BoardInfo(ConnectArgs),
+    /// Calculate the MD5 checksum of the given region
+    ChecksumMd5(ChecksumMd5Args),
     /// Generate completions for the given shell
     ///
     /// The completions are printed to stdout, and can be redirected as needed.
@@ -61,6 +63,11 @@ enum Commands {
     Flash(FlashArgs),
     /// Hold the target device in reset
     HoldInReset(ConnectArgs),
+    /// List serial ports available for flashing.
+    ///
+    /// The default behavior is to only list ports of devices known to be used
+    /// on development boards.
+    ListPorts(ListPortsArgs),
     /// Open the serial monitor without flashing the connected target device
     Monitor(MonitorArgs),
     /// Convert partition tables between CSV and binary format
@@ -87,8 +94,6 @@ enum Commands {
     SaveImage(SaveImageArgs),
     /// Write a binary file to a specific address in a target device's flash
     WriteBin(WriteBinArgs),
-    /// Calculate the MD5 checksum of the given region
-    ChecksumMd5(ChecksumMd5Args),
 }
 
 /// Erase named partitions based on provided partition table
@@ -173,19 +178,20 @@ fn main() -> Result<()> {
     // associated arguments.
     match args {
         Commands::BoardInfo(args) => board_info(&args, &config),
+        Commands::ChecksumMd5(args) => checksum_md5(&args, &config),
         Commands::Completions(args) => completions(&args, &mut Cli::command(), "espflash"),
         Commands::EraseFlash(args) => erase_flash(args, &config),
         Commands::EraseParts(args) => erase_parts(args, &config),
         Commands::EraseRegion(args) => erase_region(args, &config),
         Commands::Flash(args) => flash(args, &config),
         Commands::HoldInReset(args) => hold_in_reset(args, &config),
+        Commands::ListPorts(args) => list_ports(&args, &config),
         Commands::Monitor(args) => serial_monitor(args, &config),
         Commands::PartitionTable(args) => partition_table(args),
         Commands::ReadFlash(args) => read_flash(args, &config),
         Commands::Reset(args) => reset(args, &config),
         Commands::SaveImage(args) => save_image(args, &config),
         Commands::WriteBin(args) => write_bin(args, &config),
-        Commands::ChecksumMd5(args) => checksum_md5(&args, &config),
     }
 }
 


### PR DESCRIPTION
This pull request uses the existing logic for finding the serial ports to to create a new 'list-ports' command that just lists the ports that are available, with some additional information. This allows for some additional information when trying to resolve issues when flashing. It also opens some opportunities for scripting, e.g. to flash multiple connected devices from a single script.

By default only the ports that are 'known', that is ports that might be automatically selected are shown. The -a (or --all-ports) flag shows all serial ports available.

Tested on Ubuntu, Windows and OS-X.