### PR TITLE
Update workflows to use newer Ubuntu release

### DIFF
--- a/.github/actions/setup-target/action.yml
+++ b/.github/actions/setup-target/action.yml
@@ -26,21 +26,6 @@ runs:
         find: "unknown-"
         replace: ""
 
-    - name: Install toolchain
-      uses: dtolnay/rust-toolchain@v1
-      with:
-        toolchain: ${{ inputs.toolchain }}
-        target: ${{ inputs.target }}
-        components: ${{ inputs.components }}
-
-    - uses: Swatinem/rust-cache@v2
-
-    - if: inputs.arch != 'x86_64'
-      name: Install Cross-Compile Support
-      uses: junelife/gha-ubuntu-cross@v6
-      with:
-        arch: ${{ inputs.arch }}
-
     - if: inputs.arch != 'x86_64'
       name: Install dependencies (Raspberry Pi)
       shell: bash
@@ -59,7 +44,22 @@ runs:
       name: Install dependencies (x86_64 linux)
       shell: bash
       run: |
-        sudo apt-get update && sudo apt-get -y install musl-tools pkg-config
+        sudo apt-get update && sudo apt-get -y install curl musl-tools pkg-config
+
+    - name: Install toolchain
+      uses: dtolnay/rust-toolchain@v1
+      with:
+        toolchain: ${{ inputs.toolchain }}
+        target: ${{ inputs.target }}
+        components: ${{ inputs.components }}
+
+    - uses: Swatinem/rust-cache@v2
+
+    - if: inputs.arch != 'x86_64'
+      name: Install Cross-Compile Support
+      uses: junelife/gha-ubuntu-cross@v6
+      with:
+        arch: ${{ inputs.arch }}
 
     - if: inputs.arch != 'x86_64'
       name: Set environment variables

--- a/.github/workflows/hil.yml
+++ b/.github/workflows/hil.yml
@@ -29,7 +29,10 @@ concurrency:
 jobs:
   build-espflash:
     name: Build espflash
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
+    container:
+      image: ubuntu:20.04
+
     steps:
       - uses: actions/checkout@v4
         with:
@@ -55,7 +58,13 @@ jobs:
     name: ${{ matrix.board.mcu }}${{ matrix.board.freq }}
     if: github.repository_owner == 'esp-rs'
     needs: build-espflash
-    runs-on: [self-hosted, linux, x64, "${{ matrix.board.mcu }}${{ matrix.board.freq }}"]
+    runs-on:
+      [
+        self-hosted,
+        linux,
+        x64,
+        "${{ matrix.board.mcu }}${{ matrix.board.freq }}",
+      ]
     strategy:
       matrix:
         board:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,7 +52,7 @@ jobs:
 
   publish-cratesio:
     name: Publish to Crates.io
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
As of April 1st the `ubuntu-20.04` image will no longer be supported. We are already using `ubuntu-22.04` in the CI workflow, so I have updated the `hil` and `release` workflows to match.