### PR TITLE
Add timeout to HIL tests

### DIFF
--- a/.github/workflows/hil.yml
+++ b/.github/workflows/hil.yml
@@ -85,33 +85,33 @@ jobs:
           echo "$PWD/espflash_app" >> "$GITHUB_PATH"
 
       - name: board-info test
-        run: bash espflash/tests/scripts/board-info.sh
+        run: timeout 10 bash espflash/tests/scripts/board-info.sh
 
       - name: flash test
-        run: bash espflash/tests/scripts/flash.sh ${{ matrix.board.mcu }}
+        run: timeout 25 bash espflash/tests/scripts/flash.sh ${{ matrix.board.mcu }}
 
       - name: monitor test
-        run: bash espflash/tests/scripts/monitor.sh
+        run: timeout 10 bash espflash/tests/scripts/monitor.sh
 
       - name: erase-flash test
-        run: bash espflash/tests/scripts/erase-flash.sh
+        run: timeout 60 bash espflash/tests/scripts/erase-flash.sh
 
       - name: save-image/write-bin test
         run: |
-          bash espflash/tests/scripts/save-image_write-bin.sh ${{ matrix.board.mcu }}
-          bash espflash/tests/scripts/monitor.sh
+          timeout 40 bash espflash/tests/scripts/save-image_write-bin.sh ${{ matrix.board.mcu }}
+          timeout 10 bash espflash/tests/scripts/monitor.sh
 
       - name: erase-region test
-        run: bash espflash/tests/scripts/erase-region.sh
+        run: timeout 10 bash espflash/tests/scripts/erase-region.sh
 
       - name: hold-in-reset test
-        run: bash espflash/tests/scripts/hold-in-reset.sh
+        run: timeout 5 bash espflash/tests/scripts/hold-in-reset.sh
 
-      - name: reset test
+      - name: timeout 5 reset test
         run: bash espflash/tests/scripts/reset.sh
 
-      - name: checksum-md5 test
+      - name: timeout 40 checksum-md5 test
         run: bash espflash/tests/scripts/checksum-md5.sh
 
-      - name: list-ports test
+      - name: timeout 10 list-ports test
         run: bash espflash/tests/scripts/list-ports.sh

--- a/.github/workflows/hil.yml
+++ b/.github/workflows/hil.yml
@@ -98,7 +98,7 @@ jobs:
 
       - name: save-image/write-bin test
         run: |
-          timeout 40 bash espflash/tests/scripts/save-image_write-bin.sh ${{ matrix.board.mcu }}
+          timeout 60 bash espflash/tests/scripts/save-image_write-bin.sh ${{ matrix.board.mcu }}
           timeout 10 bash espflash/tests/scripts/monitor.sh
 
       - name: erase-region test


### PR DESCRIPTION
Not sure this is the best way but I like it more compared to editing all scripts and wrapping them in a timeout helpers. Maybe I'm missing other simpler option. 

closes https://github.com/esp-rs/espflash/issues/774