### PR TITLE
Implement new USB Serial JTAG reset strategy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add list-ports command to list available serial ports. (#761)
 - [cargo-espflash]: Add `write-bin` subcommand (#789)
 - Add `--monitor` option to `write-bin`. (#783)
+- Add `watchdog-reset` strategy to `--after` subcommand (#779)
 
 ### Changed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -201,9 +201,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.7.0"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1be3f42a67d6d345ecd59f675f3f012d6974981560836e938c22b424b85ce1be"
+checksum = "5c8214115b7bf84099f1309324e63141d4c5d7cc26862f97a0a857dbefe165bd"
 
 [[package]]
 name = "bitmaps"
@@ -782,7 +782,7 @@ version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
 dependencies = [
- "bitflags 2.7.0",
+ "bitflags 2.9.0",
  "crossterm_winapi",
  "mio",
  "parking_lot",
@@ -1231,7 +1231,7 @@ version = "4.0.0-dev"
 dependencies = [
  "addr2line",
  "base64",
- "bitflags 2.7.0",
+ "bitflags 2.9.0",
  "bytemuck",
  "clap",
  "clap_complete",
@@ -1478,7 +1478,7 @@ version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b903b73e45dc0c6c596f2d37eccece7c1c8bb6e4407b001096387c63d0d93724"
 dependencies = [
- "bitflags 2.7.0",
+ "bitflags 2.9.0",
  "libc",
  "libgit2-sys",
  "log",
@@ -1655,7 +1655,7 @@ version = "0.14.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "11365144ef93082f3403471dbaa94cfe4b5e72743bdb9560719a251d439f4cee"
 dependencies = [
- "bitflags 2.7.0",
+ "bitflags 2.9.0",
  "bstr",
  "gix-path",
  "libc",
@@ -1799,7 +1799,7 @@ version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aaf69a6bec0a3581567484bf99a4003afcaf6c469fd4214352517ea355cf3435"
 dependencies = [
- "bitflags 2.7.0",
+ "bitflags 2.9.0",
  "bstr",
  "gix-features",
  "gix-path",
@@ -1845,7 +1845,7 @@ version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "270645fd20556b64c8ffa1540d921b281e6994413a0ca068596f97e9367a257a"
 dependencies = [
- "bitflags 2.7.0",
+ "bitflags 2.9.0",
  "bstr",
  "filetime",
  "fnv",
@@ -1884,7 +1884,7 @@ version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d27f830a16405386e9c83b9d5be8261fe32bbd6b3caf15bd1b284c6b2b7ef1a8"
 dependencies = [
- "bitflags 2.7.0",
+ "bitflags 2.9.0",
  "gix-commitgraph",
  "gix-date",
  "gix-hash",
@@ -1999,7 +1999,7 @@ version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c472dfbe4a4e96fcf7efddcd4771c9037bb4fdea2faaabf2f4888210c75b81e"
 dependencies = [
- "bitflags 2.7.0",
+ "bitflags 2.9.0",
  "bstr",
  "gix-attributes",
  "gix-config-value",
@@ -2129,7 +2129,7 @@ version = "0.10.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8b876ef997a955397809a2ec398d6a45b7a55b4918f2446344330f778d14fd6"
 dependencies = [
- "bitflags 2.7.0",
+ "bitflags 2.9.0",
  "gix-path",
  "libc",
  "windows-sys 0.52.0",
@@ -2206,7 +2206,7 @@ version = "0.43.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ed47d648619e23e93f971d2bba0d10c1100e54ef95d2981d609907a8cabac89"
 dependencies = [
- "bitflags 2.7.0",
+ "bitflags 2.9.0",
  "gix-commitgraph",
  "gix-date",
  "gix-hash",
@@ -2874,7 +2874,7 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
 dependencies = [
- "bitflags 2.7.0",
+ "bitflags 2.9.0",
  "libc",
  "redox_syscall",
 ]
@@ -3097,7 +3097,7 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
 dependencies = [
- "bitflags 2.7.0",
+ "bitflags 2.9.0",
  "cfg-if",
  "cfg_aliases",
  "libc",
@@ -3197,7 +3197,7 @@ version = "0.10.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bac25ee399abb46215765b1cb35bc0212377e58a061560d8b29b024fd0430e7c"
 dependencies = [
- "bitflags 2.7.0",
+ "bitflags 2.9.0",
  "cfg-if",
  "foreign-types",
  "libc",
@@ -3587,7 +3587,7 @@ version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03a862b389f93e68874fbf580b9de08dd02facb9a788ebadaf4a3fd33cf58834"
 dependencies = [
- "bitflags 2.7.0",
+ "bitflags 2.9.0",
 ]
 
 [[package]]
@@ -3720,7 +3720,7 @@ version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7753b721174eb8ff87a9a0e799e2d7bc3749323e773db92e0984debb00019d6e"
 dependencies = [
- "bitflags 2.7.0",
+ "bitflags 2.9.0",
  "fallible-iterator",
  "fallible-streaming-iterator",
  "hashlink",
@@ -3764,7 +3764,7 @@ version = "0.38.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a78891ee6bf2340288408954ac787aa063d8e8817e9f53abb37c695c6d834ef6"
 dependencies = [
- "bitflags 2.7.0",
+ "bitflags 2.9.0",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -3880,7 +3880,7 @@ version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "271720403f46ca04f7ba6f55d438f8bd878d6b8ca0a1046e8228c4145bcbb316"
 dependencies = [
- "bitflags 2.7.0",
+ "bitflags 2.9.0",
  "core-foundation",
  "core-foundation-sys",
  "libc",
@@ -4004,7 +4004,7 @@ version = "4.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ecfc4858c2266c7695d8b8460bbd612fa81bd2e250f5f0dd16195e4b4f8b3d8"
 dependencies = [
- "bitflags 2.7.0",
+ "bitflags 2.9.0",
  "cfg-if",
  "core-foundation",
  "core-foundation-sys",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1231,6 +1231,7 @@ version = "4.0.0-dev"
 dependencies = [
  "addr2line",
  "base64",
+ "bitflags 2.7.0",
  "bytemuck",
  "clap",
  "clap_complete",

--- a/cargo-espflash/src/main.rs
+++ b/cargo-espflash/src/main.rs
@@ -264,6 +264,7 @@ pub fn erase_parts(args: ErasePartsArgs, config: &Config) -> Result<()> {
         .or(config.partition_table.as_deref());
 
     let mut flasher = connect(&args.connect_args, config, false, false)?;
+    let chip = flasher.chip();
     let partition_table = match partition_table {
         Some(path) => Some(parse_partition_table(path)?),
         None => None,
@@ -274,7 +275,7 @@ pub fn erase_parts(args: ErasePartsArgs, config: &Config) -> Result<()> {
     erase_partitions(&mut flasher, partition_table, Some(args.erase_parts), None)?;
     flasher
         .connection()
-        .reset_after(!args.connect_args.no_stub)?;
+        .reset_after(!args.connect_args.no_stub, chip)?;
 
     Ok(())
 }

--- a/espflash/Cargo.toml
+++ b/espflash/Cargo.toml
@@ -27,6 +27,7 @@ required-features = ["cli", "serialport"]
 [dependencies]
 addr2line       = { version = "0.24.2", optional = true }
 base64          = "0.22.1"
+bitflags        = "2.4"
 bytemuck        = { version = "1.21.0", features = ["derive"] }
 clap            = { version = "4.5.24", features = ["derive", "env", "wrap_help"], optional = true }
 clap_complete   = { version = "4.5.41", optional = true }

--- a/espflash/Cargo.toml
+++ b/espflash/Cargo.toml
@@ -27,7 +27,7 @@ required-features = ["cli", "serialport"]
 [dependencies]
 addr2line       = { version = "0.24.2", optional = true }
 base64          = "0.22.1"
-bitflags        = "2.4"
+bitflags        = "2.9.0"
 bytemuck        = { version = "1.21.0", features = ["derive"] }
 clap            = { version = "4.5.24", features = ["derive", "env", "wrap_help"], optional = true }
 clap_complete   = { version = "4.5.41", optional = true }

--- a/espflash/src/bin/espflash.rs
+++ b/espflash/src/bin/espflash.rs
@@ -183,6 +183,7 @@ pub fn erase_parts(args: ErasePartsArgs, config: &Config) -> Result<()> {
     }
 
     let mut flasher = connect(&args.connect_args, config, false, false)?;
+    let chip = flasher.chip();
     let partition_table = match args.partition_table {
         Some(path) => Some(parse_partition_table(&path)?),
         None => None,
@@ -193,7 +194,7 @@ pub fn erase_parts(args: ErasePartsArgs, config: &Config) -> Result<()> {
     erase_partitions(&mut flasher, partition_table, Some(args.erase_parts), None)?;
     flasher
         .connection()
-        .reset_after(!args.connect_args.no_stub)?;
+        .reset_after(!args.connect_args.no_stub, chip)?;
 
     info!("Specified partitions successfully erased!");
 

--- a/espflash/src/cli/mod.rs
+++ b/espflash/src/cli/mod.rs
@@ -723,10 +723,12 @@ pub fn erase_flash(args: EraseFlashArgs, config: &Config) -> Result<()> {
     let mut flasher = connect(&args.connect_args, config, true, true)?;
     info!("Erasing Flash...");
 
+    let chip = flasher.chip();
+
     flasher.erase_flash()?;
     flasher
         .connection()
-        .reset_after(!args.connect_args.no_stub)?;
+        .reset_after(!args.connect_args.no_stub, chip)?;
 
     info!("Flash has been erased!");
 
@@ -747,6 +749,7 @@ pub fn erase_region(args: EraseRegionArgs, config: &Config) -> Result<()> {
     }
 
     let mut flasher = connect(&args.connect_args, config, true, true)?;
+    let chip = flasher.chip();
 
     info!(
         "Erasing region at 0x{:08x} ({} bytes)",
@@ -756,7 +759,7 @@ pub fn erase_region(args: EraseRegionArgs, config: &Config) -> Result<()> {
     flasher.erase_region(args.address, args.size)?;
     flasher
         .connection()
-        .reset_after(!args.connect_args.no_stub)?;
+        .reset_after(!args.connect_args.no_stub, chip)?;
 
     Ok(())
 }

--- a/espflash/src/connection/mod.rs
+++ b/espflash/src/connection/mod.rs
@@ -298,7 +298,9 @@ impl Connection {
 
                 match chip {
                     Chip::Esp32c3 => {
-                        wdt_reset(chip, self)?;
+                        if pid == USB_SERIAL_JTAG_PID {
+                            wdt_reset(chip, self)?;
+                        }
                     }
                     Chip::Esp32s2 => {
                         let esp32s2 = esp32s2::Esp32s2;

--- a/espflash/src/connection/mod.rs
+++ b/espflash/src/connection/mod.rs
@@ -330,7 +330,12 @@ impl Connection {
                             }
                         }
                     }
-                    _ => println!("Unsupported chip for watchdog reset {:?}", chip),
+                    _ => {
+                        return Err(Error::UnsupportedFeature {
+                            chip,
+                            feature: "watchdog reset".into(),
+                        })
+                    }
                 }
 
                 Ok(())

--- a/espflash/src/connection/mod.rs
+++ b/espflash/src/connection/mod.rs
@@ -303,13 +303,13 @@ impl Connection {
                     }
                     Chip::Esp32p4 => {
                         // Check if the connection is USB OTG
-                        if self.is_using_usb_otg(chip)? {
+                        if chip.into_usb_otg()?.is_using_usb_otg(self)? {
                             chip.into_rtc_wdt_reset()?.rtc_wdt_reset(self)?;
                         }
                     }
                     Chip::Esp32s2 => {
                         // Check if the connection is USB OTG
-                        if self.is_using_usb_otg(chip)? {
+                        if chip.into_usb_otg()?.is_using_usb_otg(self)? {
                             let target = chip.into_rtc_wdt_reset()?;
 
                             // Check the strapping register to see if we can perform RTC WDT
@@ -320,7 +320,9 @@ impl Connection {
                         }
                     }
                     Chip::Esp32s3 => {
-                        if pid == USB_SERIAL_JTAG_PID || self.is_using_usb_otg(chip)? {
+                        if pid == USB_SERIAL_JTAG_PID
+                            || chip.into_usb_otg()?.is_using_usb_otg(self)?
+                        {
                             let target = chip.into_rtc_wdt_reset()?;
 
                             // Check the strapping register to see if we can perform RTC WDT
@@ -595,19 +597,6 @@ impl Connection {
 
     pub(crate) fn is_using_usb_serial_jtag(&self) -> bool {
         self.port_info.pid == USB_SERIAL_JTAG_PID
-    }
-
-    #[cfg(feature = "serialport")]
-    /// Check if the connection is USB OTG
-    pub(crate) fn is_using_usb_otg(&mut self, chip: Chip) -> Result<bool, Error> {
-        let (buf_no, no_usb_otg) = match chip {
-            Chip::Esp32p4 => (esp32p4::UARTDEV_BUF_NO, esp32p4::UARTDEV_BUF_NO_USB_OTG),
-            Chip::Esp32s2 => (esp32s2::UARTDEV_BUF_NO, esp32s2::UARTDEV_BUF_NO_USB_OTG),
-            Chip::Esp32s3 => (esp32s3::UARTDEV_BUF_NO, esp32s3::UARTDEV_BUF_NO_USB_OTG),
-            _ => unreachable!(),
-        };
-
-        Ok(self.read_reg(buf_no)? == no_usb_otg)
     }
 }
 

--- a/espflash/src/connection/mod.rs
+++ b/espflash/src/connection/mod.rs
@@ -36,7 +36,7 @@ use self::{
 };
 use crate::{
     error::{ConnectionError, Error, ResultExt, RomError, RomErrorKind},
-    targets::{esp32s2, esp32s3, Chip},
+    targets::{esp32p4, esp32s2, esp32s3, Chip},
 };
 
 pub(crate) mod command;
@@ -299,6 +299,13 @@ impl Connection {
                 match chip {
                     Chip::Esp32c3 => {
                         if pid == USB_SERIAL_JTAG_PID {
+                            wdt_reset(chip, self)?;
+                        }
+                    }
+                    Chip::Esp32p4 => {
+                        let esp32p4 = esp32p4::Esp32p4;
+                        // Check if the connection is USB OTG
+                        if esp32p4.connection_is_usb_otg(self)? {
                             wdt_reset(chip, self)?;
                         }
                     }

--- a/espflash/src/connection/mod.rs
+++ b/espflash/src/connection/mod.rs
@@ -297,7 +297,7 @@ impl Connection {
 
                 match chip {
                     Chip::Esp32c3 => {
-                        if pid == USB_SERIAL_JTAG_PID {
+                        if self.is_using_usb_serial_jtag() {
                             chip.into_rtc_wdt_reset()?.rtc_wdt_reset(self)?;
                         }
                     }
@@ -320,7 +320,7 @@ impl Connection {
                         }
                     }
                     Chip::Esp32s3 => {
-                        if pid == USB_SERIAL_JTAG_PID
+                        if self.is_using_usb_serial_jtag()
                             || chip.into_usb_otg()?.is_using_usb_otg(self)?
                         {
                             let target = chip.into_rtc_wdt_reset()?;
@@ -347,7 +347,7 @@ impl Connection {
 
     // Reset the device to flash mode
     pub fn reset_to_flash(&mut self, extra_delay: bool) -> Result<(), Error> {
-        if self.port_info.pid == USB_SERIAL_JTAG_PID {
+        if self.is_using_usb_serial_jtag() {
             UsbJtagSerialReset.reset(&mut self.serial)
         } else {
             #[cfg(unix)]

--- a/espflash/src/connection/reset.rs
+++ b/espflash/src/connection/reset.rs
@@ -200,6 +200,7 @@ impl ResetStrategy for UsbJtagSerialReset {
     }
 }
 
+#[cfg(feature = "serialport")]
 pub(crate) trait RtcWdtReset {
     fn wdt_wprotect(&self) -> u32;
     fn wdt_wkey(&self) -> u32;

--- a/espflash/src/connection/reset.rs
+++ b/espflash/src/connection/reset.rs
@@ -222,6 +222,21 @@ impl RtcWdtReset for crate::targets::esp32c3::Esp32c3 {
     }
 }
 
+impl RtcWdtReset for crate::targets::esp32p4::Esp32p4 {
+    fn wdt_wprotect(&self) -> u32 {
+        0x5011_6000 + 0x0018
+    }
+    fn wdt_wkey(&self) -> u32 {
+        0x50D8_3AA1
+    }
+    fn wdt_config0(&self) -> u32 {
+        0x5011_6000 // no offset here
+    }
+    fn wdt_config1(&self) -> u32 {
+        0x5011_6000 + 0x0004
+    }
+}
+
 impl RtcWdtReset for crate::targets::esp32s2::Esp32s2 {
     fn wdt_wprotect(&self) -> u32 {
         0x3F40_8000 + 0x00AC

--- a/espflash/src/connection/reset.rs
+++ b/espflash/src/connection/reset.rs
@@ -200,71 +200,11 @@ impl ResetStrategy for UsbJtagSerialReset {
     }
 }
 
-trait RtcWdtReset {
+pub(crate) trait RtcWdtReset {
     fn wdt_wprotect(&self) -> u32;
     fn wdt_wkey(&self) -> u32;
     fn wdt_config0(&self) -> u32;
     fn wdt_config1(&self) -> u32;
-}
-
-impl RtcWdtReset for crate::targets::esp32c3::Esp32c3 {
-    fn wdt_wprotect(&self) -> u32 {
-        0x6000_8000 + 0x00A8
-    }
-    fn wdt_wkey(&self) -> u32 {
-        0x50D8_3AA1
-    }
-    fn wdt_config0(&self) -> u32 {
-        0x6000_8000 + 0x0090
-    }
-    fn wdt_config1(&self) -> u32 {
-        0x6000_8000 + 0x0094
-    }
-}
-
-impl RtcWdtReset for crate::targets::esp32p4::Esp32p4 {
-    fn wdt_wprotect(&self) -> u32 {
-        0x5011_6000 + 0x0018
-    }
-    fn wdt_wkey(&self) -> u32 {
-        0x50D8_3AA1
-    }
-    fn wdt_config0(&self) -> u32 {
-        0x5011_6000 // no offset here
-    }
-    fn wdt_config1(&self) -> u32 {
-        0x5011_6000 + 0x0004
-    }
-}
-
-impl RtcWdtReset for crate::targets::esp32s2::Esp32s2 {
-    fn wdt_wprotect(&self) -> u32 {
-        0x3F40_8000 + 0x00AC
-    }
-    fn wdt_wkey(&self) -> u32 {
-        0x50D8_3AA1
-    }
-    fn wdt_config0(&self) -> u32 {
-        0x3F40_8000 + 0x0094
-    }
-    fn wdt_config1(&self) -> u32 {
-        0x3F40_8000 + 0x0098
-    }
-}
-
-impl RtcWdtReset for crate::targets::esp32s3::Esp32s3 {
-    fn wdt_wprotect(&self) -> u32 {
-        0x6000_8000 + 0x00B0
-    }
-    fn wdt_wkey(&self) -> u32 {
-        0x50D8_3AA1
-    }
-    fn wdt_config0(&self) -> u32 {
-        0x6000_8000 + 0x0098
-    }
-    fn wdt_config1(&self) -> u32 {
-        0x6000_8000 + 0x009C
-    }
 }
 
 /// Reset the target device

--- a/espflash/src/connection/reset.rs
+++ b/espflash/src/connection/reset.rs
@@ -209,7 +209,7 @@ trait RtcWdtReset {
 
 impl RtcWdtReset for crate::targets::esp32c3::Esp32c3 {
     fn wdt_wprotect(&self) -> u32 {
-        0x6000_8000 + 0x00A0
+        0x6000_8000 + 0x00A8
     }
     fn wdt_wkey(&self) -> u32 {
         0x50D8_3AA1
@@ -239,16 +239,16 @@ impl RtcWdtReset for crate::targets::esp32s2::Esp32s2 {
 
 impl RtcWdtReset for crate::targets::esp32s3::Esp32s3 {
     fn wdt_wprotect(&self) -> u32 {
-        0x6000_E000 + 0x00B0
+        0x6000_8000 + 0x00B0
     }
     fn wdt_wkey(&self) -> u32 {
         0x50D8_3AA1
     }
     fn wdt_config0(&self) -> u32 {
-        0x6000_E000 + 0x0098
+        0x6000_8000 + 0x0098
     }
     fn wdt_config1(&self) -> u32 {
-        0x6000_E000 + 0x009C
+        0x6000_8000 + 0x009C
     }
 }
 

--- a/espflash/src/flasher/mod.rs
+++ b/espflash/src/flasher/mod.rs
@@ -17,6 +17,7 @@ use serde::{Deserialize, Serialize};
 #[cfg(feature = "serialport")]
 use serialport::UsbPortInfo;
 use strum::{Display, EnumIter, IntoEnumIterator, VariantNames};
+#[cfg(feature = "serialport")]
 use xmas_elf::ElfFile;
 
 #[cfg(feature = "serialport")]
@@ -31,7 +32,7 @@ use crate::{
         Connection,
         Port,
     },
-    error::{ConnectionError, ResultExt},
+    error::{ConnectionError, ElfError, ResultExt as _},
     flasher::stubs::{
         FlashStub,
         CHIP_DETECT_MAGIC_REG_ADDR,
@@ -41,8 +42,8 @@ use crate::{
     image_format::{ram_segments, rom_segments, Segment},
 };
 use crate::{
-    error::{ElfError, Error},
     targets::{Chip, XtalFrequency},
+    Error,
 };
 
 #[cfg(feature = "serialport")]

--- a/espflash/src/targets/esp32c3.rs
+++ b/espflash/src/targets/esp32c3.rs
@@ -5,6 +5,7 @@ use xmas_elf::ElfFile;
 #[cfg(feature = "serialport")]
 use crate::connection::Connection;
 use crate::{
+    connection::reset::RtcWdtReset,
     flasher::{FlashData, FlashFrequency},
     image_format::IdfBootloaderFormat,
     targets::{Chip, Esp32Params, ReadEFuse, SpiRegisters, Target, XtalFrequency},
@@ -112,5 +113,20 @@ impl Target for Esp32c3 {
             "riscv32imc-esp-espidf",
             "riscv32imc-unknown-none-elf",
         ]
+    }
+}
+
+impl RtcWdtReset for Esp32c3 {
+    fn wdt_wprotect(&self) -> u32 {
+        0x6000_8000 + 0x00A8
+    }
+    fn wdt_wkey(&self) -> u32 {
+        0x50D8_3AA1
+    }
+    fn wdt_config0(&self) -> u32 {
+        0x6000_8000 + 0x0090
+    }
+    fn wdt_config1(&self) -> u32 {
+        0x6000_8000 + 0x0094
     }
 }

--- a/espflash/src/targets/esp32c3.rs
+++ b/espflash/src/targets/esp32c3.rs
@@ -3,9 +3,8 @@ use std::ops::Range;
 use xmas_elf::ElfFile;
 
 #[cfg(feature = "serialport")]
-use crate::connection::Connection;
+use crate::connection::{reset::RtcWdtReset, Connection};
 use crate::{
-    connection::reset::RtcWdtReset,
     flasher::{FlashData, FlashFrequency},
     image_format::IdfBootloaderFormat,
     targets::{Chip, Esp32Params, ReadEFuse, SpiRegisters, Target, XtalFrequency},
@@ -116,6 +115,7 @@ impl Target for Esp32c3 {
     }
 }
 
+#[cfg(feature = "serialport")]
 impl RtcWdtReset for Esp32c3 {
     fn wdt_wprotect(&self) -> u32 {
         0x6000_8000 + 0x00A8

--- a/espflash/src/targets/esp32c3.rs
+++ b/espflash/src/targets/esp32c3.rs
@@ -3,7 +3,7 @@ use std::ops::Range;
 use xmas_elf::ElfFile;
 
 #[cfg(feature = "serialport")]
-use crate::connection::{reset::RtcWdtReset, Connection};
+use crate::connection::Connection;
 use crate::{
     flasher::{FlashData, FlashFrequency},
     image_format::IdfBootloaderFormat,
@@ -116,17 +116,20 @@ impl Target for Esp32c3 {
 }
 
 #[cfg(feature = "serialport")]
-impl RtcWdtReset for Esp32c3 {
+impl super::RtcWdtReset for Esp32c3 {
     fn wdt_wprotect(&self) -> u32 {
-        0x6000_8000 + 0x00A8
+        0x6000_80A8
     }
-    fn wdt_wkey(&self) -> u32 {
-        0x50D8_3AA1
-    }
+
     fn wdt_config0(&self) -> u32 {
-        0x6000_8000 + 0x0090
+        0x6000_8090
     }
+
     fn wdt_config1(&self) -> u32 {
-        0x6000_8000 + 0x0094
+        0x6000_8094
+    }
+
+    fn can_rtc_wdt_reset(&self, _connection: &mut Connection) -> Result<bool, Error> {
+        Ok(true)
     }
 }

--- a/espflash/src/targets/esp32p4.rs
+++ b/espflash/src/targets/esp32p4.rs
@@ -31,8 +31,18 @@ const PARAMS: Esp32Params = Esp32Params::new(
 pub struct Esp32p4;
 
 impl Esp32p4 {
+    /// Check if the magic value contains the specified value
     pub fn has_magic_value(value: u32) -> bool {
         CHIP_DETECT_MAGIC_VALUES.contains(&value)
+    }
+
+    #[cfg(feature = "serialport")]
+    /// Check if the connection is USB OTG
+    pub(crate) fn connection_is_usb_otg(&self, connection: &mut Connection) -> Result<bool, Error> {
+        const UARTDEV_BUF_NO: u32 = 0x4FF3_FEC8; // Address which indicates OTG in use
+        const UARTDEV_BUF_NO_USB_OTG: u32 = 5; // Value of UARTDEV_BUF_NO when OTG is in use
+
+        Ok(connection.read_reg(UARTDEV_BUF_NO)? == UARTDEV_BUF_NO_USB_OTG)
     }
 }
 

--- a/espflash/src/targets/esp32p4.rs
+++ b/espflash/src/targets/esp32p4.rs
@@ -3,7 +3,7 @@ use std::ops::Range;
 use xmas_elf::ElfFile;
 
 #[cfg(feature = "serialport")]
-use crate::connection::{reset::RtcWdtReset, Connection};
+use crate::connection::Connection;
 use crate::{
     flasher::{FlashData, FlashFrequency},
     image_format::IdfBootloaderFormat,
@@ -109,17 +109,20 @@ impl Target for Esp32p4 {
 }
 
 #[cfg(feature = "serialport")]
-impl RtcWdtReset for crate::targets::esp32p4::Esp32p4 {
+impl super::RtcWdtReset for Esp32p4 {
     fn wdt_wprotect(&self) -> u32 {
-        0x5011_6000 + 0x0018
+        0x5011_6018
     }
-    fn wdt_wkey(&self) -> u32 {
-        0x50D8_3AA1
-    }
+
     fn wdt_config0(&self) -> u32 {
-        0x5011_6000 // no offset here
+        0x5011_6000
     }
+
     fn wdt_config1(&self) -> u32 {
-        0x5011_6000 + 0x0004
+        0x5011_6004
+    }
+
+    fn can_rtc_wdt_reset(&self, _connection: &mut Connection) -> Result<bool, Error> {
+        Ok(true)
     }
 }

--- a/espflash/src/targets/esp32p4.rs
+++ b/espflash/src/targets/esp32p4.rs
@@ -27,11 +27,6 @@ const PARAMS: Esp32Params = Esp32Params::new(
     include_bytes!("../../resources/bootloaders/esp32p4-bootloader.bin"),
 );
 
-#[cfg(feature = "serialport")]
-pub(crate) const UARTDEV_BUF_NO: u32 = 0x4FF3_FEC8; // Address which indicates OTG in use
-#[cfg(feature = "serialport")]
-pub(crate) const UARTDEV_BUF_NO_USB_OTG: u32 = 5; // Value of UARTDEV_BUF_NO when OTG is in use
-
 /// ESP32-P4 Target
 pub struct Esp32p4;
 
@@ -124,5 +119,16 @@ impl super::RtcWdtReset for Esp32p4 {
 
     fn can_rtc_wdt_reset(&self, _connection: &mut Connection) -> Result<bool, Error> {
         Ok(true)
+    }
+}
+
+#[cfg(feature = "serialport")]
+impl super::UsbOtg for Esp32p4 {
+    fn uartdev_buf_no(&self) -> u32 {
+        0x4FF3_FEC8
+    }
+
+    fn uartdev_buf_no_usb_otg(&self) -> u32 {
+        5
     }
 }

--- a/espflash/src/targets/esp32p4.rs
+++ b/espflash/src/targets/esp32p4.rs
@@ -3,9 +3,8 @@ use std::ops::Range;
 use xmas_elf::ElfFile;
 
 #[cfg(feature = "serialport")]
-use crate::connection::Connection;
+use crate::connection::{reset::RtcWdtReset, Connection};
 use crate::{
-    connection::reset::RtcWdtReset,
     flasher::{FlashData, FlashFrequency},
     image_format::IdfBootloaderFormat,
     targets::{Chip, Esp32Params, ReadEFuse, SpiRegisters, Target, XtalFrequency},
@@ -28,7 +27,9 @@ const PARAMS: Esp32Params = Esp32Params::new(
     include_bytes!("../../resources/bootloaders/esp32p4-bootloader.bin"),
 );
 
+#[cfg(feature = "serialport")]
 pub(crate) const UARTDEV_BUF_NO: u32 = 0x4FF3_FEC8; // Address which indicates OTG in use
+#[cfg(feature = "serialport")]
 pub(crate) const UARTDEV_BUF_NO_USB_OTG: u32 = 5; // Value of UARTDEV_BUF_NO when OTG is in use
 
 /// ESP32-P4 Target
@@ -107,6 +108,7 @@ impl Target for Esp32p4 {
     }
 }
 
+#[cfg(feature = "serialport")]
 impl RtcWdtReset for crate::targets::esp32p4::Esp32p4 {
     fn wdt_wprotect(&self) -> u32 {
         0x5011_6000 + 0x0018

--- a/espflash/src/targets/esp32s2.rs
+++ b/espflash/src/targets/esp32s2.rs
@@ -3,16 +3,15 @@ use std::ops::Range;
 use xmas_elf::ElfFile;
 
 #[cfg(feature = "serialport")]
-use crate::{connection::Connection, flasher::FLASH_WRITE_SIZE, targets::MAX_RAM_BLOCK_SIZE};
+use super::flash_target::MAX_RAM_BLOCK_SIZE;
+#[cfg(feature = "serialport")]
+use crate::connection::{reset::RtcWdtReset, Connection};
 use crate::{
-    connection::reset::RtcWdtReset,
-    flasher::{FlashData, FlashFrequency},
+    flasher::{FlashData, FlashFrequency, FLASH_WRITE_SIZE},
     image_format::IdfBootloaderFormat,
     targets::{Chip, Esp32Params, ReadEFuse, SpiRegisters, Target, XtalFrequency},
     Error,
 };
-#[cfg(feature = "serialport")]
-use crate::{connection::Connection, flasher::FLASH_WRITE_SIZE, targets::MAX_RAM_BLOCK_SIZE};
 
 const CHIP_DETECT_MAGIC_VALUES: &[u32] = &[0x0000_07c6];
 
@@ -33,7 +32,9 @@ const PARAMS: Esp32Params = Esp32Params::new(
     include_bytes!("../../resources/bootloaders/esp32s2-bootloader.bin"),
 );
 
+#[cfg(feature = "serialport")]
 pub(crate) const UARTDEV_BUF_NO: u32 = 0x3FFF_FD14; // Address which indicates OTG in use
+#[cfg(feature = "serialport")]
 pub(crate) const UARTDEV_BUF_NO_USB_OTG: u32 = 2; // Value of UARTDEV_BUF_NO when OTG is in use
 
 /// ESP32-S2 Target
@@ -200,6 +201,7 @@ impl Target for Esp32s2 {
     }
 }
 
+#[cfg(feature = "serialport")]
 impl RtcWdtReset for Esp32s2 {
     fn wdt_wprotect(&self) -> u32 {
         0x3F40_8000 + 0x00AC

--- a/espflash/src/targets/esp32s2.rs
+++ b/espflash/src/targets/esp32s2.rs
@@ -5,9 +5,9 @@ use xmas_elf::ElfFile;
 #[cfg(feature = "serialport")]
 use super::flash_target::MAX_RAM_BLOCK_SIZE;
 #[cfg(feature = "serialport")]
-use crate::connection::Connection;
+use crate::{connection::Connection, flasher::FLASH_WRITE_SIZE};
 use crate::{
-    flasher::{FlashData, FlashFrequency, FLASH_WRITE_SIZE},
+    flasher::{FlashData, FlashFrequency},
     image_format::IdfBootloaderFormat,
     targets::{Chip, Esp32Params, ReadEFuse, SpiRegisters, Target, XtalFrequency},
     Error,

--- a/espflash/src/targets/esp32s2.rs
+++ b/espflash/src/targets/esp32s2.rs
@@ -5,7 +5,7 @@ use xmas_elf::ElfFile;
 #[cfg(feature = "serialport")]
 use super::flash_target::MAX_RAM_BLOCK_SIZE;
 #[cfg(feature = "serialport")]
-use crate::connection::{reset::RtcWdtReset, Connection};
+use crate::connection::Connection;
 use crate::{
     flasher::{FlashData, FlashFrequency, FLASH_WRITE_SIZE},
     image_format::IdfBootloaderFormat,
@@ -66,20 +66,6 @@ impl Esp32s2 {
         let psram_version = (blk1_word3 >> 28) & 0xf;
 
         Ok(psram_version)
-    }
-
-    #[cfg(feature = "serialport")]
-    /// Check the strapping register to see if we can perform RTC WDT reset
-    pub(crate) fn can_wtd_reset(&self, connection: &mut Connection) -> Result<bool, Error> {
-        const GPIO_STRAP: u32 = 0x3F40_4038;
-        const OPTION1: u32 = 0x3F40_8128;
-        const GPIO_STRAP_SPI_BOOT_MASK: u32 = 1 << 3;
-        const FORCE_DOWNLOAD_BOOT_MASK: u32 = 0x1;
-
-        Ok(
-            connection.read_reg(GPIO_STRAP)? & GPIO_STRAP_SPI_BOOT_MASK == 0 // GPIO0 low
-                && connection.read_reg(OPTION1)? & FORCE_DOWNLOAD_BOOT_MASK == 0,
-        )
     }
 
     /// Check if the magic value contains the specified value
@@ -202,17 +188,28 @@ impl Target for Esp32s2 {
 }
 
 #[cfg(feature = "serialport")]
-impl RtcWdtReset for Esp32s2 {
+impl super::RtcWdtReset for Esp32s2 {
     fn wdt_wprotect(&self) -> u32 {
-        0x3F40_8000 + 0x00AC
+        0x3F40_80AC
     }
-    fn wdt_wkey(&self) -> u32 {
-        0x50D8_3AA1
-    }
+
     fn wdt_config0(&self) -> u32 {
-        0x3F40_8000 + 0x0094
+        0x3F40_8094
     }
+
     fn wdt_config1(&self) -> u32 {
-        0x3F40_8000 + 0x0098
+        0x3F40_8098
+    }
+
+    fn can_rtc_wdt_reset(&self, connection: &mut Connection) -> Result<bool, Error> {
+        const GPIO_STRAP: u32 = 0x3F40_4038;
+        const OPTION1: u32 = 0x3F40_8128;
+        const GPIO_STRAP_SPI_BOOT_MASK: u32 = 1 << 3;
+        const FORCE_DOWNLOAD_BOOT_MASK: u32 = 0x1;
+
+        Ok(
+            connection.read_reg(GPIO_STRAP)? & GPIO_STRAP_SPI_BOOT_MASK == 0 // GPIO0 low
+                && connection.read_reg(OPTION1)? & FORCE_DOWNLOAD_BOOT_MASK == 0,
+        )
     }
 }

--- a/espflash/src/targets/esp32s3.rs
+++ b/espflash/src/targets/esp32s3.rs
@@ -3,9 +3,8 @@ use std::ops::Range;
 use xmas_elf::ElfFile;
 
 #[cfg(feature = "serialport")]
-use crate::connection::Connection;
+use crate::connection::{reset::RtcWdtReset, Connection};
 use crate::{
-    connection::reset::RtcWdtReset,
     flasher::{FlashData, FlashFrequency},
     image_format::IdfBootloaderFormat,
     targets::{Chip, Esp32Params, ReadEFuse, SpiRegisters, Target, XtalFrequency},
@@ -28,7 +27,9 @@ const PARAMS: Esp32Params = Esp32Params::new(
     include_bytes!("../../resources/bootloaders/esp32s3-bootloader.bin"),
 );
 
+#[cfg(feature = "serialport")]
 pub(crate) const UARTDEV_BUF_NO: u32 = 0x3FCE_F14C; // Address which indicates OTG in use
+#[cfg(feature = "serialport")]
 pub(crate) const UARTDEV_BUF_NO_USB_OTG: u32 = 3; // Value of UARTDEV_BUF_NO when OTG is in use
 
 /// ESP32-S2 Target
@@ -148,6 +149,7 @@ impl Target for Esp32s3 {
     }
 }
 
+#[cfg(feature = "serialport")]
 impl RtcWdtReset for Esp32s3 {
     fn wdt_wprotect(&self) -> u32 {
         0x6000_8000 + 0x00B0

--- a/espflash/src/targets/esp32s3.rs
+++ b/espflash/src/targets/esp32s3.rs
@@ -27,11 +27,6 @@ const PARAMS: Esp32Params = Esp32Params::new(
     include_bytes!("../../resources/bootloaders/esp32s3-bootloader.bin"),
 );
 
-#[cfg(feature = "serialport")]
-pub(crate) const UARTDEV_BUF_NO: u32 = 0x3FCE_F14C; // Address which indicates OTG in use
-#[cfg(feature = "serialport")]
-pub(crate) const UARTDEV_BUF_NO_USB_OTG: u32 = 3; // Value of UARTDEV_BUF_NO when OTG is in use
-
 /// ESP32-S2 Target
 pub struct Esp32s3;
 
@@ -159,5 +154,16 @@ impl super::RtcWdtReset for Esp32s3 {
             connection.read_reg(GPIO_STRAP)? & GPIO_STRAP_SPI_BOOT_MASK == 0 // GPIO0 low
                 && connection.read_reg(OPTION1)? & FORCE_DOWNLOAD_BOOT_MASK == 0,
         )
+    }
+}
+
+#[cfg(feature = "serialport")]
+impl super::UsbOtg for Esp32s3 {
+    fn uartdev_buf_no(&self) -> u32 {
+        0x3FCE_F14C
+    }
+
+    fn uartdev_buf_no_usb_otg(&self) -> u32 {
+        3
     }
 }

--- a/espflash/src/targets/flash_target/esp32.rs
+++ b/espflash/src/targets/flash_target/esp32.rs
@@ -260,7 +260,7 @@ impl FlashTarget for Esp32Target {
         }
 
         if reboot {
-            connection.reset_after(self.use_stub)?;
+            connection.reset_after(self.use_stub, self.chip)?;
         }
 
         Ok(())

--- a/espflash/src/targets/mod.rs
+++ b/espflash/src/targets/mod.rs
@@ -36,12 +36,12 @@ use crate::{
 
 mod esp32;
 mod esp32c2;
-mod esp32c3;
+pub(crate) mod esp32c3;
 mod esp32c6;
 mod esp32h2;
 mod esp32p4;
-mod esp32s2;
-mod esp32s3;
+pub(crate) mod esp32s2;
+pub(crate) mod esp32s3;
 
 #[cfg(feature = "serialport")]
 pub(crate) mod flash_target;

--- a/espflash/src/targets/mod.rs
+++ b/espflash/src/targets/mod.rs
@@ -144,27 +144,27 @@ impl Chip {
     }
 
     #[cfg(feature = "serialport")]
-    pub(crate) fn into_rtc_wdt_reset(&self) -> Result<Box<dyn RtcWdtReset>, Error> {
+    pub(crate) fn into_rtc_wdt_reset(self) -> Result<Box<dyn RtcWdtReset>, Error> {
         match self {
             Chip::Esp32c3 => Ok(Box::new(Esp32c3)),
             Chip::Esp32p4 => Ok(Box::new(Esp32p4)),
             Chip::Esp32s2 => Ok(Box::new(Esp32s2)),
             Chip::Esp32s3 => Ok(Box::new(Esp32s3)),
             _ => Err(Error::UnsupportedFeature {
-                chip: *self,
+                chip: self,
                 feature: "RTC WDT reset".into(),
             }),
         }
     }
 
     #[cfg(feature = "serialport")]
-    pub(crate) fn into_usb_otg(&self) -> Result<Box<dyn UsbOtg>, Error> {
+    pub(crate) fn into_usb_otg(self) -> Result<Box<dyn UsbOtg>, Error> {
         match self {
             Chip::Esp32p4 => Ok(Box::new(Esp32p4)),
             Chip::Esp32s2 => Ok(Box::new(Esp32s2)),
             Chip::Esp32s3 => Ok(Box::new(Esp32s3)),
             _ => Err(Error::UnsupportedFeature {
-                chip: *self,
+                chip: self,
                 feature: "USB OTG".into(),
             }),
         }

--- a/espflash/src/targets/mod.rs
+++ b/espflash/src/targets/mod.rs
@@ -39,7 +39,7 @@ mod esp32c2;
 pub(crate) mod esp32c3;
 mod esp32c6;
 mod esp32h2;
-mod esp32p4;
+pub(crate) mod esp32p4;
 pub(crate) mod esp32s2;
 pub(crate) mod esp32s3;
 


### PR DESCRIPTION
This is mostly experimental, so opening as a draft. 

I've been playing with (cc cc https://github.com/esp-rs/espflash/issues/691)  and I was able to reproduce the issue with espflash AND esptool as well, following the same steps as mentioned [here](https://github.com/esp-rs/espflash/issues/556#issuecomment-1921143340)
I looked into esptool and specifically to [this commit](https://github.com/espressif/esptool/commit/8298cdcc68a8063df1ca932d42e21555e15269b3#diff-24560e81a6dac1814c9801703e7c13e2983585356da84fedc207ac9437c42dab). `esptool` not using this fix as default for SERIAL_JTAG, it can be used manually with: 
`--after reset_watchdog`

The reasons (from esptool perspective) it's not on by default are: 
1. The RTC WDT hack is not available on all devices (e.g., the H2 doesn't have it).
2. On Linux, it causes the port to re-enumerate, meaning that instead of /dev/ttyUSB0, a new /dev/ttyUSB1 appears. This can cause the monitor to disconnect and not reconnect automatically.
3. On the C6 and H2 USB-Serial/JTAG controller, there is a bug that causes the port to disappear after a system reset and not reappear until a power cycle is performed. The RTC WDT reset is a system reset, so this issue occurs. So they left it by default only for USB-OTG and is optional for SERIAL_JTAG. On C6 it is NOT SUPPORTTED at all in esptool.

