### PR TITLE
[cargo-espflash]: Add write-bin subcommand

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add `no-reset` flag to `monitor` subcommands (#737)
 - Add an environment variable to set monitoring baudrate (`MONITOR_BAUD`) (#737)
 - Add list-ports command to list available serial ports. (#761)
+- [cargo-espflash]: Add `write-bin` subcommand (#789)
 
 ### Changed
 

--- a/cargo-espflash/README.md
+++ b/cargo-espflash/README.md
@@ -71,6 +71,7 @@ Commands:
   read-flash       Read SPI flash content
   reset            Reset the target device
   save-image       Generate a binary application image and save it to a local disk
+  write-bin        Write a binary file to a specific address in a target device's flash
   help             Print this message or the help of the given subcommand(s)
 
 Options:

--- a/cargo-espflash/src/main.rs
+++ b/cargo-espflash/src/main.rs
@@ -117,6 +117,8 @@ enum Commands {
     /// Otherwise, each segment will be saved as individual binaries, prefixed
     /// with their intended addresses in flash.
     SaveImage(SaveImageArgs),
+    /// Write a binary file to a specific address in a target device's flash
+    WriteBin(WriteBinArgs),
 }
 
 #[derive(Debug, Args)]
@@ -240,6 +242,7 @@ fn main() -> Result<()> {
         Commands::ReadFlash(args) => read_flash(args, &config),
         Commands::Reset(args) => reset(args, &config),
         Commands::SaveImage(args) => save_image(args, &config),
+        Commands::WriteBin(args) => write_bin(args, &config),
     }
 }
 

--- a/espflash/src/cli/mod.rs
+++ b/espflash/src/cli/mod.rs
@@ -12,8 +12,8 @@
 
 use std::{
     collections::HashMap,
-    fs,
-    io::Write,
+    fs::{self, File},
+    io::{Read, Write},
     num::ParseIntError,
     path::{Path, PathBuf},
 };
@@ -313,6 +313,20 @@ pub struct ListPortsArgs {
     /// Only print the name of the ports and nothing else. Useful for scripting.
     #[arg(short, long)]
     pub name_only: bool,
+}
+
+/// Writes a binary file to a specific address in the chip's flash
+#[derive(Debug, Args)]
+#[non_exhaustive]
+pub struct WriteBinArgs {
+    /// Address at which to write the binary file
+    #[arg(value_parser = parse_u32)]
+    pub address: u32,
+    /// File containing the binary data to write
+    pub file: String,
+    /// Connection configuration
+    #[clap(flatten)]
+    connect_args: ConnectArgs,
 }
 
 /// Parses an integer, in base-10 or hexadecimal format, into a [u32]
@@ -970,6 +984,31 @@ pub fn make_flash_data(
         flash_settings,
         image_args.min_chip_rev,
     )
+}
+
+pub fn write_bin(args: WriteBinArgs, config: &Config) -> Result<()> {
+    let mut flasher = connect(&args.connect_args, config, false, false)?;
+    print_board_info(&mut flasher)?;
+
+    let mut f = File::open(&args.file).into_diagnostic()?;
+
+    // If the file size is not divisible by 4, we need to pad `FF` bytes to the end
+    let size = f.metadata().into_diagnostic()?.len();
+    let mut padded_bytes = 0;
+    if size % 4 != 0 {
+        padded_bytes = 4 - (size % 4);
+    }
+    let mut buffer = Vec::with_capacity(size.try_into().into_diagnostic()?);
+    f.read_to_end(&mut buffer).into_diagnostic()?;
+    buffer.extend(std::iter::repeat(0xFF).take(padded_bytes as usize));
+
+    flasher.write_bin_to_flash(
+        args.address,
+        &buffer,
+        Some(&mut EspflashProgress::default()),
+    )?;
+
+    Ok(())
 }
 
 mod test {

--- a/espflash/src/cli/mod.rs
+++ b/espflash/src/cli/mod.rs
@@ -986,6 +986,7 @@ pub fn make_flash_data(
     )
 }
 
+/// Write a binary to the flash memory of a target device
 pub fn write_bin(args: WriteBinArgs, config: &Config) -> Result<()> {
     let mut flasher = connect(&args.connect_args, config, false, false)?;
     print_board_info(&mut flasher)?;


### PR DESCRIPTION
For some reason we were missing this command. Unless there is a reason for it, which I cant think off, we should have the same commands as in `espflash`