### PR TITLE
Update HIL workflow to use `ubuntu-22.04`, build in container to resolve GLIBC errors

### DIFF
--- a/.github/workflows/hil.yml
+++ b/.github/workflows/hil.yml
@@ -29,20 +29,26 @@ concurrency:
 jobs:
   build-espflash:
     name: Build espflash
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
+    container:
+      image: ubuntu:20.04
+
     steps:
       - uses: actions/checkout@v4
         with:
           repository: ${{ github.event.inputs.repository || github.repository }}
           ref: ${{ github.event.inputs.branch || github.ref }}
 
-      - uses: ./.github/actions/setup-target
-        with:
-          arch: x86_64
-          target: x86_64-unknown-linux-gnu
+      - name: Install dependencies
+        env:
+          DEBIAN_FRONTEND: noninteractive
+        run: apt-get update && apt-get -y install curl musl-tools pkg-config
+
+      - name: Install toolchain
+        run: curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
 
       - name: Build espflash
-        run: cargo build --release
+        run: $HOME/.cargo/bin/cargo build --release
         working-directory: espflash
 
       - uses: actions/upload-artifact@v4
@@ -52,11 +58,22 @@ jobs:
           if-no-files-found: error
 
   run-target:
-    name: ${{ matrix.board.mcu }}${{ matrix.board.freq }}
     if: github.repository_owner == 'esp-rs'
+    name: ${{ matrix.board.mcu }}${{ matrix.board.freq }}
     needs: build-espflash
-    runs-on: [self-hosted, linux, x64, "${{ matrix.board.mcu }}${{ matrix.board.freq }}"]
+    runs-on:
+      [
+        self-hosted,
+        linux,
+        x64,
+        "${{ matrix.board.mcu }}${{ matrix.board.freq }}",
+      ]
+
+    env:
+      ESPFLASH_PORT: /dev/serial_ports/${{ matrix.board.mcu }}
+
     strategy:
+      fail-fast: false
       matrix:
         board:
           - mcu: esp32
@@ -68,9 +85,7 @@ jobs:
           - mcu: esp32h2
           - mcu: esp32s2
           - mcu: esp32s3
-      fail-fast: false
-    env:
-      ESPFLASH_PORT: /dev/serial_ports/${{ matrix.board.mcu }}
+
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
Part 1 of #786 

Still need to update the `release` workflow as well, but not entirely sure how to approach that yet. Can at least get HIL updated for now, though.