### PR TITLE
Refactor and simplify the `elf` module a bit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 
 - Removed the `libudev` feature (#742)
+- The `FirmwareImage` trait no longer includes the `segments_with_load_addresses` function (#796)
 
 ## [3.3.0] - 2025-01-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The `command`, `elf` and `error` modules are no longer public (#772)
 - `write-bin` now works for files whose lengths are not divisible by 4 (#780, #788)
 - `get_usb_pid` is now `usb_pid` and no longer needlessly returns a `Result` (#795)
+- `CodeSegment` and `RomSegment` have been merged into a single `Segment` struct (#796)
 
 ### Fixed
 

--- a/espflash/src/flasher/mod.rs
+++ b/espflash/src/flasher/mod.rs
@@ -17,9 +17,10 @@ use serde::{Deserialize, Serialize};
 #[cfg(feature = "serialport")]
 use serialport::UsbPortInfo;
 use strum::{Display, EnumIter, IntoEnumIterator, VariantNames};
-#[cfg(feature = "serialport")]
-pub(crate) use stubs::{FLASH_SECTOR_SIZE, FLASH_WRITE_SIZE};
+use xmas_elf::ElfFile;
 
+#[cfg(feature = "serialport")]
+pub(crate) use self::stubs::{FLASH_SECTOR_SIZE, FLASH_WRITE_SIZE};
 #[cfg(feature = "serialport")]
 pub use crate::targets::flash_target::ProgressCallbacks;
 #[cfg(feature = "serialport")]
@@ -30,7 +31,7 @@ use crate::{
         Connection,
         Port,
     },
-    elf::{ElfFirmwareImage, FirmwareImage, RomSegment},
+    elf::{FirmwareImage, RomSegment},
     error::{ConnectionError, ResultExt},
     flasher::stubs::{
         FlashStub,
@@ -40,8 +41,8 @@ use crate::{
     },
 };
 use crate::{
+    error::{ElfError, Error},
     targets::{Chip, XtalFrequency},
-    Error,
 };
 
 #[cfg(feature = "serialport")]
@@ -1013,20 +1014,20 @@ impl Flasher {
         elf_data: &[u8],
         mut progress: Option<&mut dyn ProgressCallbacks>,
     ) -> Result<(), Error> {
-        let image = ElfFirmwareImage::try_from(elf_data)?;
-        if image.rom_segments(self.chip).next().is_some() {
+        let elf = ElfFile::new(elf_data).map_err(ElfError::from)?;
+        if elf.rom_segments(self.chip).next().is_some() {
             return Err(Error::ElfNotRamLoadable);
         }
 
         let mut target = self.chip.ram_target(
-            Some(image.entry()),
+            Some(elf.entry()),
             self.chip
                 .into_target()
                 .max_ram_block_size(&mut self.connection)?,
         );
         target.begin(&mut self.connection).flashing()?;
 
-        for segment in image.ram_segments(self.chip) {
+        for segment in elf.ram_segments(self.chip) {
             target
                 .write_segment(&mut self.connection, segment.into(), &mut progress)
                 .flashing()?;
@@ -1043,7 +1044,7 @@ impl Flasher {
         mut progress: Option<&mut dyn ProgressCallbacks>,
         xtal_freq: XtalFrequency,
     ) -> Result<(), Error> {
-        let image = ElfFirmwareImage::try_from(elf_data)?;
+        let elf = ElfFile::new(elf_data).map_err(ElfError::from)?;
 
         let mut target =
             self.chip
@@ -1056,12 +1057,10 @@ impl Flasher {
                 .chip_revision(&mut self.connection)?,
         );
 
-        let image = self.chip.into_target().get_flash_image(
-            &image,
-            flash_data,
-            chip_revision,
-            xtal_freq,
-        )?;
+        let image =
+            self.chip
+                .into_target()
+                .get_flash_image(&elf, flash_data, chip_revision, xtal_freq)?;
 
         // When the `cli` feature is enabled, display the image size information.
         #[cfg(feature = "cli")]

--- a/espflash/src/flasher/mod.rs
+++ b/espflash/src/flasher/mod.rs
@@ -31,7 +31,7 @@ use crate::{
         Connection,
         Port,
     },
-    elf::{FirmwareImage, RomSegment},
+    elf::{FirmwareImage, Segment},
     error::{ConnectionError, ResultExt},
     flasher::stubs::{
         FlashStub,
@@ -761,7 +761,7 @@ impl Flasher {
         ram_target
             .write_segment(
                 &mut self.connection,
-                RomSegment {
+                Segment {
                     addr: text_addr,
                     data: Cow::Borrowed(&text),
                 },
@@ -775,7 +775,7 @@ impl Flasher {
         ram_target
             .write_segment(
                 &mut self.connection,
-                RomSegment {
+                Segment {
                     addr: data_addr,
                     data: Cow::Borrowed(&data),
                 },
@@ -1029,7 +1029,7 @@ impl Flasher {
 
         for segment in elf.ram_segments(self.chip) {
             target
-                .write_segment(&mut self.connection, segment.into(), &mut progress)
+                .write_segment(&mut self.connection, segment, &mut progress)
                 .flashing()?;
         }
 
@@ -1084,7 +1084,7 @@ impl Flasher {
         data: &[u8],
         progress: Option<&mut dyn ProgressCallbacks>,
     ) -> Result<(), Error> {
-        let segment = RomSegment {
+        let segment = Segment {
             addr,
             data: Cow::from(data),
         };
@@ -1098,7 +1098,7 @@ impl Flasher {
     /// Load multiple bin images to flash at specific addresses
     pub fn write_bins_to_flash(
         &mut self,
-        segments: &[RomSegment<'_>],
+        segments: &[Segment<'_>],
         mut progress: Option<&mut dyn ProgressCallbacks>,
     ) -> Result<(), Error> {
         let mut target = self

--- a/espflash/src/lib.rs
+++ b/espflash/src/lib.rs
@@ -29,7 +29,10 @@
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![deny(missing_debug_implementations, rust_2018_idioms)]
 
-pub use self::error::Error;
+pub use self::{
+    elf::{FirmwareImage, Segment},
+    error::Error,
+};
 
 #[cfg(feature = "serialport")]
 #[cfg_attr(docsrs, doc(cfg(feature = "serialport")))]

--- a/espflash/src/targets/flash_target/esp32.rs
+++ b/espflash/src/targets/flash_target/esp32.rs
@@ -17,7 +17,7 @@ use crate::{
     targets::FlashTarget,
 };
 use crate::{
-    elf::RomSegment,
+    elf::Segment,
     flasher::{SpiAttachParams, FLASH_SECTOR_SIZE},
     targets::Chip,
     Error,
@@ -138,7 +138,7 @@ impl FlashTarget for Esp32Target {
     fn write_segment(
         &mut self,
         connection: &mut Connection,
-        segment: RomSegment<'_>,
+        segment: Segment<'_>,
         progress: &mut Option<&mut dyn ProgressCallbacks>,
     ) -> Result<(), Error> {
         let addr = segment.addr;

--- a/espflash/src/targets/flash_target/mod.rs
+++ b/espflash/src/targets/flash_target/mod.rs
@@ -1,6 +1,6 @@
 pub(crate) use self::ram::MAX_RAM_BLOCK_SIZE;
 pub use self::{esp32::Esp32Target, ram::RamTarget};
-use crate::{connection::Connection, elf::RomSegment, Error};
+use crate::{connection::Connection, elf::Segment, Error};
 
 mod esp32;
 mod ram;
@@ -24,7 +24,7 @@ pub trait FlashTarget {
     fn write_segment(
         &mut self,
         connection: &mut Connection,
-        segment: RomSegment<'_>,
+        segment: Segment<'_>,
         progress: &mut Option<&mut dyn ProgressCallbacks>,
     ) -> Result<(), Error>;
 

--- a/espflash/src/targets/flash_target/ram.rs
+++ b/espflash/src/targets/flash_target/ram.rs
@@ -7,7 +7,7 @@ use crate::{
     flasher::ProgressCallbacks,
     targets::FlashTarget,
 };
-use crate::{elf::RomSegment, Error};
+use crate::{elf::Segment, Error};
 
 pub const MAX_RAM_BLOCK_SIZE: usize = 0x1800;
 
@@ -39,7 +39,7 @@ impl FlashTarget for RamTarget {
     fn write_segment(
         &mut self,
         connection: &mut Connection,
-        segment: RomSegment<'_>,
+        segment: Segment<'_>,
         progress: &mut Option<&mut dyn ProgressCallbacks>,
     ) -> Result<(), Error> {
         let addr = segment.addr;


### PR DESCRIPTION
- Eliminated the `ElfFirmwareImage` struct, as this was essentially just wrapping `xmas_elf::ElfFile`
- Merged `RomSegment` and `CodeSegment` structs into a new `Segment` struct, as they were identical
- Re-export a couple types from the `elf` module which are present in public APIs
- Removed unused `segments_with_load_addresses` function from `FirmwareImage` trait