### PR TITLE
Update flash size 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `get_usb_pid` is now `usb_pid` and no longer needlessly returns a `Result` (#795)
 - `CodeSegment` and `RomSegment` have been merged into a single `Segment` struct (#796)
 - `IdfBootloaderFormat` has had its constructor's parameters reduced/simplified (#798)
+- Update flash size when creating the app partition (#797)
 
 ### Fixed
 

--- a/cargo-espflash/src/main.rs
+++ b/cargo-espflash/src/main.rs
@@ -345,6 +345,7 @@ fn flash(args: FlashArgs, config: &Config) -> Result<()> {
             config,
             build_ctx.bootloader_path.as_deref(),
             build_ctx.partition_table_path.as_deref(),
+            Some(&mut flasher),
         )?;
 
         if args.flash_args.erase_parts.is_some() || args.flash_args.erase_data_parts.is_some() {
@@ -588,6 +589,7 @@ fn save_image(args: SaveImageArgs, config: &Config) -> Result<()> {
         config,
         build_ctx.bootloader_path.as_deref(),
         build_ctx.partition_table_path.as_deref(),
+        None,
     )?;
 
     let xtal_freq = args

--- a/cargo-espflash/src/main.rs
+++ b/cargo-espflash/src/main.rs
@@ -8,6 +8,7 @@ use cargo_metadata::{Message, MetadataCommand};
 use clap::{Args, CommandFactory, Parser, Subcommand};
 use espflash::{
     cli::{self, config::Config, monitor::monitor, *},
+    flasher::FlashSize,
     logging::initialize_logger,
     targets::{Chip, XtalFrequency},
     update::check_for_update,
@@ -329,12 +330,18 @@ fn flash(args: FlashArgs, config: &Config) -> Result<()> {
 
     print_board_info(&mut flasher)?;
 
+    let mut flash_config = args.build_args.flash_config_args;
+    flash_config.flash_size = flash_config
+        .flash_size
+        .or_else(|| flasher.flash_detect().ok().flatten())
+        .or_else(|| Some(FlashSize::default()));
+
     if args.flash_args.ram {
         flasher.load_elf_to_ram(&elf_data, Some(&mut EspflashProgress::default()))?;
     } else {
         let flash_data = make_flash_data(
             args.flash_args.image,
-            &args.build_args.flash_config_args,
+            &flash_config,
             config,
             build_ctx.bootloader_path.as_deref(),
             build_ctx.partition_table_path.as_deref(),
@@ -570,9 +577,14 @@ fn save_image(args: SaveImageArgs, config: &Config) -> Result<()> {
     println!("Merge:             {}", args.save_image_args.merge);
     println!("Skip padding:      {}", args.save_image_args.skip_padding);
 
+    let mut flash_config = args.build_args.flash_config_args;
+    flash_config.flash_size = flash_config
+        .flash_size
+        .or_else(|| Some(FlashSize::default()));
+
     let flash_data = make_flash_data(
         args.save_image_args.image,
-        &args.build_args.flash_config_args,
+        &flash_config,
         config,
         build_ctx.bootloader_path.as_deref(),
         build_ctx.partition_table_path.as_deref(),

--- a/espflash/src/bin/espflash.rs
+++ b/espflash/src/bin/espflash.rs
@@ -3,6 +3,7 @@ use std::{fs, path::PathBuf};
 use clap::{Args, CommandFactory, Parser, Subcommand};
 use espflash::{
     cli::{self, config::Config, monitor::monitor, *},
+    flasher::FlashSize,
     logging::initialize_logger,
     targets::{Chip, XtalFrequency},
     update::check_for_update,
@@ -242,16 +243,16 @@ fn flash(args: FlashArgs, config: &Config) -> Result<()> {
     // Read the ELF data from the build path and load it to the target.
     let elf_data = fs::read(&args.image).into_diagnostic()?;
 
+    let mut flash_config = args.flash_config_args;
+    flash_config.flash_size = flash_config
+        .flash_size
+        .or_else(|| flasher.flash_detect().ok().flatten())
+        .or_else(|| Some(FlashSize::default()));
+
     if args.flash_args.ram {
         flasher.load_elf_to_ram(&elf_data, Some(&mut EspflashProgress::default()))?;
     } else {
-        let flash_data = make_flash_data(
-            args.flash_args.image,
-            &args.flash_config_args,
-            config,
-            None,
-            None,
-        )?;
+        let flash_data = make_flash_data(args.flash_args.image, &flash_config, config, None, None)?;
 
         if args.flash_args.erase_parts.is_some() || args.flash_args.erase_data_parts.is_some() {
             erase_partitions(
@@ -297,9 +298,14 @@ fn save_image(args: SaveImageArgs, config: &Config) -> Result<()> {
     println!("Merge:             {}", args.save_image_args.merge);
     println!("Skip padding:      {}", args.save_image_args.skip_padding);
 
+    let mut flash_config = args.flash_config_args;
+    flash_config.flash_size = flash_config
+        .flash_size
+        .or_else(|| Some(FlashSize::default()));
+
     let flash_data = make_flash_data(
         args.save_image_args.image,
-        &args.flash_config_args,
+        &flash_config,
         config,
         None,
         None,

--- a/espflash/src/cli/mod.rs
+++ b/espflash/src/cli/mod.rs
@@ -946,34 +946,12 @@ fn pretty_print(table: PartitionTable) {
     println!("{pretty}");
 }
 
-pub fn make_flash_settings(
-    flash_config_args: &FlashConfigArgs,
-    config: &Config,
-    flasher: Option<&mut Flasher>,
-) -> FlashSettings {
-    let flash_size = flash_config_args
-        .flash_size // First try command line args
-        .or(config.flash.size) // Then try config file
-        .or_else(|| {
-            // Then try auto-detection if flasher available
-            flasher.and_then(|f| f.flash_detect().ok().flatten())
-        })
-        .or_else(|| Some(FlashSize::default())); // Finally fall back to default
-
-    FlashSettings::new(
-        flash_config_args.flash_mode.or(config.flash.mode),
-        flash_size,
-        flash_config_args.flash_freq.or(config.flash.freq),
-    )
-}
-
 pub fn make_flash_data(
     image_args: ImageArgs,
     flash_config_args: &FlashConfigArgs,
     config: &Config,
     default_bootloader: Option<&Path>,
     default_partition_table: Option<&Path>,
-    flasher: Option<&mut Flasher>,
 ) -> Result<FlashData, Error> {
     let bootloader = image_args
         .bootloader
@@ -997,7 +975,12 @@ pub fn make_flash_data(
         println!("Partition table:   {}", path.display());
     }
 
-    let flash_settings = make_flash_settings(flash_config_args, config, flasher);
+    let flash_settings = FlashSettings::new(
+        flash_config_args.flash_mode.or(config.flash.mode),
+        flash_config_args.flash_size,
+        flash_config_args.flash_freq.or(config.flash.freq),
+    );
+
     FlashData::new(
         bootloader,
         partition_table,

--- a/espflash/src/flasher/mod.rs
+++ b/espflash/src/flasher/mod.rs
@@ -840,7 +840,7 @@ impl Flasher {
         Err(Error::FlashConnect)
     }
 
-    fn flash_detect(&mut self) -> Result<Option<FlashSize>, Error> {
+    pub fn flash_detect(&mut self) -> Result<Option<FlashSize>, Error> {
         const FLASH_RETRY: u8 = 0xFF;
 
         let flash_id = self.spi_command(CommandType::FlashDetect, &[], 24)?;


### PR DESCRIPTION
With this PR we will update the flash size in the following order:
1. Provided by `--flash-size` arg
2. Config file 
3. Detect if we can (if we are flashing we can try to detect, but `save-image` cant)
4. Used the default flash size: 4Mb

We have to pass `flasher` arround which is not ideal... I initially though of https://github.com/esp-rs/espflash/commit/cfef334b24b1bf1bf6629272f9a6ea268f46f7a8 but that results in lots of duplicated code.

## Tests 
I generated an std template: `cargo generate esp-rs/esp-idf-template cargo` for S3 and with the default configurations. Updated the code to:
```rust
// Define a large static array (roughly 1MB)
// 1MB = 1 * 1024 * 1024 bytes
static LARGE_ARRAY: [u8; 1 * 1024 * 1024] = [0; 1 * 1024 * 1024];

fn main() {
    // It is necessary to call this function once. Otherwise some patches to the runtime
    // implemented by esp-idf-sys might not link properly. See https://github.com/esp-rs/esp-idf-template/issues/71
    esp_idf_svc::sys::link_patches();

    // Bind the log crate to the ESP Logging facilities
    esp_idf_svc::log::EspLogger::initialize_default();

    // Access the array to prevent it from being optimized away
    log::info!("Hello, world! Array size: {} bytes", LARGE_ARRAY.len());
    log::info!("First byte: {}", LARGE_ARRAY[0]);
}
```
When building this, we get the following elf:
```
❯ eza -l target/xtensa-esp32s3-espidf/release/app-size
.rwxr-xr-x 1.8M sergio 28 Feb 15:41 target/xtensa-esp32s3-espidf/release/app-size
```
When triying to flash it with `espflash@4.0.0-dev` (installed a few days ago):
```
❯ espflash flash target/xtensa-esp32s3-espidf/release/app-size
[2025-02-28T14:52:13Z INFO ] Serial port: '/dev/ttyUSB1'
[2025-02-28T14:52:13Z INFO ] Connecting...
[2025-02-28T14:52:13Z INFO ] Using flash stub
[2025-02-28T14:52:14Z WARN ] Setting baud rate higher than 115,200 can cause issues
Chip type:         esp32s3 (revision v0.1)
Crystal frequency: 40 MHz
Flash size:        8MB
Features:          WiFi, BLE
MAC address:       60:55:f9:f5:20:d4
Error: espflash::image_too_big (link)

  × Supplied ELF image of 1455472B is too big, and doesn't fit configured app partition of 1048576B
  help: Reduce the size of the binary or increase the size of the app partition.
```

When using this patch:
```
❯ cargo r -r --bin espflash -- flash /home/sergio/Documents/Espressif/tests/app-size/target/xtensa-esp32s3-espidf/release/app-size
    Finished `release` profile [optimized] target(s) in 0.12s
     Running `target/release/espflash flash /home/sergio/Documents/Espressif/tests/app-size/target/xtensa-esp32s3-espidf/release/app-size`
[2025-02-28T14:53:51Z INFO ] Serial port: '/dev/ttyUSB1'
[2025-02-28T14:53:51Z INFO ] Connecting...
[2025-02-28T14:53:51Z INFO ] Using flash stub
[2025-02-28T14:53:52Z WARN ] Setting baud rate higher than 115,200 can cause issues
Chip type:         esp32s3 (revision v0.1)
Crystal frequency: 40 MHz
Flash size:        8MB
Features:          WiFi, BLE
MAC address:       60:55:f9:f5:20:d4
App/part. size:    1,455,472/8,323,072 bytes, 17.49%
[00:00:00] [========================================]      14/14      0x0                                                                                                                                                                                   
[00:00:00] [========================================]       1/1       0x8000                                                                                                                                                                                
[00:00:15] [========================================]     235/235     0x10000                                                                                                                                                                               [2025-02-28T14:54:18Z INFO ] Flashing has completed!

espflash on  feat/flash-size [$] via 🦀 v1.87.0-nightly took 27s 
```