### PR TITLE
Don't expose `PartitionTable` struct in public APIs, simplify `IdfBootloaderFormat` constructor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `write-bin` now works for files whose lengths are not divisible by 4 (#780, #788)
 - `get_usb_pid` is now `usb_pid` and no longer needlessly returns a `Result` (#795)
 - `CodeSegment` and `RomSegment` have been merged into a single `Segment` struct (#796)
+- `IdfBootloaderFormat` has had its constructor's parameters reduced/simplified (#798)
 
 ### Fixed
 
@@ -36,6 +37,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Removed the `libudev` feature (#742)
 - The `FirmwareImage` trait no longer includes the `segments_with_load_addresses` function (#796)
+- Removed the `flasher::parse_partition_table` function (#798)
 
 ## [3.3.0] - 2025-01-13
 

--- a/cargo-espflash/src/main.rs
+++ b/cargo-espflash/src/main.rs
@@ -8,7 +8,6 @@ use cargo_metadata::{Message, MetadataCommand};
 use clap::{Args, CommandFactory, Parser, Subcommand};
 use espflash::{
     cli::{self, config::Config, monitor::monitor, *},
-    flasher::parse_partition_table,
     logging::initialize_logger,
     targets::{Chip, XtalFrequency},
     update::check_for_update,

--- a/espflash/src/bin/espflash.rs
+++ b/espflash/src/bin/espflash.rs
@@ -3,7 +3,6 @@ use std::{fs, path::PathBuf};
 use clap::{Args, CommandFactory, Parser, Subcommand};
 use espflash::{
     cli::{self, config::Config, monitor::monitor, *},
-    flasher::parse_partition_table,
     logging::initialize_logger,
     targets::{Chip, XtalFrequency},
     update::check_for_update,

--- a/espflash/src/cli/mod.rs
+++ b/espflash/src/cli/mod.rs
@@ -37,7 +37,6 @@ use crate::{
     connection::reset::{ResetAfterOperation, ResetBeforeOperation},
     error::{ElfError, Error, MissingPartition, MissingPartitionTable},
     flasher::{
-        parse_partition_table,
         FlashData,
         FlashFrequency,
         FlashMode,
@@ -896,6 +895,13 @@ pub fn partition_table(args: PartitionTableArgs) -> Result<()> {
     }
 
     Ok(())
+}
+
+/// Parse a [PartitionTable] from the provided path
+pub fn parse_partition_table(path: &Path) -> Result<PartitionTable, Error> {
+    let data = fs::read(path).map_err(|e| Error::FileOpenError(path.display().to_string(), e))?;
+
+    Ok(PartitionTable::try_from(data)?)
 }
 
 /// Pretty print a partition table

--- a/espflash/src/flasher/mod.rs
+++ b/espflash/src/flasher/mod.rs
@@ -500,9 +500,13 @@ impl FlashData {
 
         // If the '-T' option is provided, load the partition table from
         // the CSV or binary file at the specified path.
-        let partition_table = match partition_table {
-            Some(path) => Some(parse_partition_table(path)?),
-            None => None,
+        let partition_table = if let Some(path) = partition_table {
+            let data =
+                fs::read(path).map_err(|e| Error::FileOpenError(path.display().to_string(), e))?;
+
+            Some(PartitionTable::try_from(data)?)
+        } else {
+            None
         };
 
         Ok(FlashData {
@@ -627,13 +631,6 @@ pub struct DeviceInfo {
     pub features: Vec<String>,
     /// MAC address
     pub mac_address: String,
-}
-
-/// Parse a [PartitionTable] from the provided path
-pub fn parse_partition_table(path: &Path) -> Result<PartitionTable, Error> {
-    let data = fs::read(path).map_err(|e| Error::FileOpenError(path.display().to_string(), e))?;
-
-    Ok(PartitionTable::try_from(data)?)
 }
 
 /// Connect to and flash a target device

--- a/espflash/src/targets/esp32.rs
+++ b/espflash/src/targets/esp32.rs
@@ -183,17 +183,7 @@ impl Target for Esp32 {
             booloader,
         );
 
-        IdfBootloaderFormat::new(
-            image,
-            Chip::Esp32,
-            flash_data.min_chip_rev,
-            params,
-            flash_data.partition_table,
-            flash_data.partition_table_offset,
-            flash_data.target_app_partition,
-            flash_data.bootloader,
-            flash_data.flash_settings,
-        )
+        IdfBootloaderFormat::new(image, Chip::Esp32, flash_data, params)
     }
 
     #[cfg(feature = "serialport")]

--- a/espflash/src/targets/esp32c2.rs
+++ b/espflash/src/targets/esp32c2.rs
@@ -121,17 +121,7 @@ impl Target for Esp32c2 {
             booloader,
         );
 
-        IdfBootloaderFormat::new(
-            image,
-            Chip::Esp32c2,
-            flash_data.min_chip_rev,
-            params,
-            flash_data.partition_table,
-            flash_data.partition_table_offset,
-            flash_data.target_app_partition,
-            flash_data.bootloader,
-            flash_data.flash_settings,
-        )
+        IdfBootloaderFormat::new(image, Chip::Esp32c2, flash_data, params)
     }
 
     #[cfg(feature = "serialport")]

--- a/espflash/src/targets/esp32c3.rs
+++ b/espflash/src/targets/esp32c3.rs
@@ -90,17 +90,7 @@ impl Target for Esp32c3 {
             });
         }
 
-        IdfBootloaderFormat::new(
-            image,
-            Chip::Esp32c3,
-            flash_data.min_chip_rev,
-            PARAMS,
-            flash_data.partition_table,
-            flash_data.partition_table_offset,
-            flash_data.target_app_partition,
-            flash_data.bootloader,
-            flash_data.flash_settings,
-        )
+        IdfBootloaderFormat::new(image, Chip::Esp32c3, flash_data, PARAMS)
     }
 
     fn spi_registers(&self) -> SpiRegisters {

--- a/espflash/src/targets/esp32c6.rs
+++ b/espflash/src/targets/esp32c6.rs
@@ -85,17 +85,7 @@ impl Target for Esp32c6 {
             });
         }
 
-        IdfBootloaderFormat::new(
-            image,
-            Chip::Esp32c6,
-            flash_data.min_chip_rev,
-            PARAMS,
-            flash_data.partition_table,
-            flash_data.partition_table_offset,
-            flash_data.target_app_partition,
-            flash_data.bootloader,
-            flash_data.flash_settings,
-        )
+        IdfBootloaderFormat::new(image, Chip::Esp32c6, flash_data, PARAMS)
     }
 
     fn spi_registers(&self) -> SpiRegisters {

--- a/espflash/src/targets/esp32h2.rs
+++ b/espflash/src/targets/esp32h2.rs
@@ -92,17 +92,7 @@ impl Target for Esp32h2 {
             });
         }
 
-        IdfBootloaderFormat::new(
-            image,
-            Chip::Esp32h2,
-            flash_data.min_chip_rev,
-            PARAMS,
-            flash_data.partition_table,
-            flash_data.partition_table_offset,
-            flash_data.target_app_partition,
-            flash_data.bootloader,
-            flash_data.flash_settings,
-        )
+        IdfBootloaderFormat::new(image, Chip::Esp32h2, flash_data, PARAMS)
     }
 
     fn spi_registers(&self) -> SpiRegisters {

--- a/espflash/src/targets/esp32p4.rs
+++ b/espflash/src/targets/esp32p4.rs
@@ -81,17 +81,7 @@ impl Target for Esp32p4 {
             });
         }
 
-        IdfBootloaderFormat::new(
-            image,
-            Chip::Esp32p4,
-            flash_data.min_chip_rev,
-            PARAMS,
-            flash_data.partition_table,
-            flash_data.partition_table_offset,
-            flash_data.target_app_partition,
-            flash_data.bootloader,
-            flash_data.flash_settings,
-        )
+        IdfBootloaderFormat::new(image, Chip::Esp32p4, flash_data, PARAMS)
     }
 
     fn spi_registers(&self) -> SpiRegisters {

--- a/espflash/src/targets/esp32s2.rs
+++ b/espflash/src/targets/esp32s2.rs
@@ -159,17 +159,7 @@ impl Target for Esp32s2 {
             });
         }
 
-        IdfBootloaderFormat::new(
-            image,
-            Chip::Esp32s2,
-            flash_data.min_chip_rev,
-            PARAMS,
-            flash_data.partition_table,
-            flash_data.partition_table_offset,
-            flash_data.target_app_partition,
-            flash_data.bootloader,
-            flash_data.flash_settings,
-        )
+        IdfBootloaderFormat::new(image, Chip::Esp32s2, flash_data, PARAMS)
     }
 
     #[cfg(feature = "serialport")]

--- a/espflash/src/targets/esp32s3.rs
+++ b/espflash/src/targets/esp32s3.rs
@@ -109,17 +109,7 @@ impl Target for Esp32s3 {
             });
         }
 
-        IdfBootloaderFormat::new(
-            image,
-            Chip::Esp32s3,
-            flash_data.min_chip_rev,
-            PARAMS,
-            flash_data.partition_table,
-            flash_data.partition_table_offset,
-            flash_data.target_app_partition,
-            flash_data.bootloader,
-            flash_data.flash_settings,
-        )
+        IdfBootloaderFormat::new(image, Chip::Esp32s3, flash_data, PARAMS)
     }
 
     fn spi_registers(&self) -> SpiRegisters {

--- a/espflash/src/targets/mod.rs
+++ b/espflash/src/targets/mod.rs
@@ -6,7 +6,6 @@
 
 use std::collections::HashMap;
 
-use esp_idf_part::{AppType, DataType, Partition, PartitionTable, SubType, Type};
 use serde::{Deserialize, Serialize};
 use strum::{Display, EnumIter, EnumString, VariantNames};
 
@@ -34,9 +33,6 @@ use crate::{
     },
     Error,
 };
-
-/// Max partition size is 16 MB
-const MAX_PARTITION_SIZE: u32 = 16 * 1000 * 1024;
 
 mod esp32;
 mod esp32c2;
@@ -206,42 +202,6 @@ impl Esp32Params {
             flash_freq,
             default_bootloader: bootloader,
         }
-    }
-
-    /// Generates a default partition table.
-    ///
-    /// `flash_size` is used to scale app partition when present, otherwise the
-    /// paramameter defaults are used.
-    pub fn default_partition_table(&self, flash_size: Option<u32>) -> PartitionTable {
-        PartitionTable::new(vec![
-            Partition::new(
-                String::from("nvs"),
-                Type::Data,
-                SubType::Data(DataType::Nvs),
-                self.nvs_addr,
-                self.nvs_size,
-                false,
-            ),
-            Partition::new(
-                String::from("phy_init"),
-                Type::Data,
-                SubType::Data(DataType::Phy),
-                self.phy_init_data_addr,
-                self.phy_init_data_size,
-                false,
-            ),
-            Partition::new(
-                String::from("factory"),
-                Type::App,
-                SubType::App(AppType::Factory),
-                self.app_addr,
-                core::cmp::min(
-                    flash_size.map_or(self.app_size, |size| size - self.app_addr),
-                    MAX_PARTITION_SIZE,
-                ),
-                false,
-            ),
-        ])
     }
 }
 


### PR DESCRIPTION
Closes #790 