### PR TITLE
Remove unused dependencies, deduplicate some functions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -448,8 +448,6 @@ dependencies = [
  "cargo",
  "cargo_metadata",
  "clap",
- "env_logger",
- "esp-idf-part",
  "espflash",
  "log",
  "miette",

--- a/cargo-espflash/Cargo.toml
+++ b/cargo-espflash/Cargo.toml
@@ -23,8 +23,6 @@ pkg-fmt = "zip"
 [dependencies]
 cargo_metadata = "0.19.1"
 clap           = { version = "4.5.24", features = ["derive", "wrap_help"] }
-env_logger     = "0.11.6"
-esp-idf-part   = "0.5.0"
 espflash       = { version = "4.0.0-dev", path = "../espflash" }
 log            = "0.4.22"
 miette         = { version = "7.4.0", features = ["fancy"] }

--- a/cargo-espflash/src/main.rs
+++ b/cargo-espflash/src/main.rs
@@ -280,23 +280,6 @@ pub fn erase_parts(args: ErasePartsArgs, config: &Config) -> Result<()> {
     Ok(())
 }
 
-fn reset(args: ConnectArgs, config: &Config) -> Result<()> {
-    let mut args = args.clone();
-    args.no_stub = true;
-    let mut flash = connect(&args, config, true, true)?;
-    info!("Resetting target device");
-    flash.connection().reset()?;
-
-    Ok(())
-}
-
-fn hold_in_reset(args: ConnectArgs, config: &Config) -> Result<()> {
-    connect(&args, config, true, true)?;
-    info!("Holding target device in reset");
-
-    Ok(())
-}
-
 fn flash(args: FlashArgs, config: &Config) -> Result<()> {
     let metadata = PackageMetadata::load(&args.build_args.package)?;
     let cargo_config = CargoConfig::load(&metadata.workspace_root, &metadata.package_root);

--- a/espflash/src/bin/espflash.rs
+++ b/espflash/src/bin/espflash.rs
@@ -201,23 +201,6 @@ pub fn erase_parts(args: ErasePartsArgs, config: &Config) -> Result<()> {
     Ok(())
 }
 
-fn reset(args: ConnectArgs, config: &Config) -> Result<()> {
-    let mut args = args.clone();
-    args.no_stub = true;
-    let mut flash = connect(&args, config, true, true)?;
-    info!("Resetting target device");
-    flash.connection().reset()?;
-
-    Ok(())
-}
-
-fn hold_in_reset(args: ConnectArgs, config: &Config) -> Result<()> {
-    connect(&args, config, true, true)?;
-    info!("Holding target device in reset");
-
-    Ok(())
-}
-
 fn flash(args: FlashArgs, config: &Config) -> Result<()> {
     let mut flasher = connect(
         &args.connect_args,

--- a/espflash/src/cli/mod.rs
+++ b/espflash/src/cli/mod.rs
@@ -1045,6 +1045,23 @@ pub fn write_bin(args: WriteBinArgs, config: &Config) -> Result<()> {
     Ok(())
 }
 
+pub fn reset(args: ConnectArgs, config: &Config) -> Result<()> {
+    let mut args = args.clone();
+    args.no_stub = true;
+    let mut flash = connect(&args, config, true, true)?;
+    info!("Resetting target device");
+    flash.connection().reset()?;
+
+    Ok(())
+}
+
+pub fn hold_in_reset(args: ConnectArgs, config: &Config) -> Result<()> {
+    connect(&args, config, true, true)?;
+    info!("Holding target device in reset");
+
+    Ok(())
+}
+
 mod test {
     use clap::Parser;
 


### PR DESCRIPTION
Nothing of interest here, just some cleanup:

- Removed a couple unused dependencies from `cargo-espflash`
- Noticed that both binaries contained two identical functions, so pulled them into the `cli` module