### PR TITLE
Fix connecting to S2 over USB

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `address` and `size` in `erase-region` have to be multiples of 4096 (#771)
 - Fixed typos in error variant names (#782)
 - Fix `read-flash` which didn't work with some lengths (#804)
+- espflash can now flash an ESP32-S2 in download mode over USB (#813)
 
 ### Removed
 


### PR DESCRIPTION
Closes https://github.com/esp-rs/espflash/issues/656

```
cargo run --bin espflash board-info                                                                       
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.64s
     Running `target\debug\espflash.exe board-info`
[2025-03-24T14:50:24Z INFO ] Serial port: 'COM57'
[2025-03-24T14:50:24Z INFO ] Connecting...
[2025-03-24T14:50:24Z INFO ] Using flash stub
Chip type:         esp32s2 (revision v1.0)
Crystal frequency: 40 MHz
Flash size:        8MB
Features:          WiFi, No Embedded Flash, Embedded PSRAM 2MB, ADC and temperature sensor calibration in BLK2 of efuse V2
MAC address:       70:04:1d:fa:00:c4

Security Information:
=====================
Flags: 0x00000000 (0)
Key Purposes: [0, 0, 0, 0, 0, 0, 0]
Secure Boot: Disabled
Flash Encryption: Disabled
SPI Boot Crypt Count (SPI_BOOT_CRYPT_CNT): 0x0
```