### PR TITLE
Check chip using metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `espflash` can detect the log format automatically from ESP-HAL metadata. Reqires `esp-println` 0.14 (presumably, yet to be released) (#809)
 - Add `--output-format` option to monitor (#818)
 - Added chip detection based on security info, where supported (#814)
+- `espflash` can detect the chip from ESP-HAL metadata to prevent flashing firmware built for a different device. Reqires `esp-hal` 1.0.0-beta.0 (presumably, yet to be released) (#816)
 
 ### Changed
 

--- a/cargo-espflash/src/main.rs
+++ b/cargo-espflash/src/main.rs
@@ -313,6 +313,7 @@ fn flash(args: FlashArgs, config: &Config) -> Result<()> {
     let elf_data = fs::read(build_ctx.artifact_path.clone()).into_diagnostic()?;
 
     print_board_info(&mut flasher)?;
+    ensure_chip_compatibility(chip, Some(elf_data.as_slice()))?;
 
     let mut flash_config = args.build_args.flash_config_args;
     flash_config.flash_size = flash_config

--- a/espflash/src/bin/espflash.rs
+++ b/espflash/src/bin/espflash.rs
@@ -226,6 +226,7 @@ fn flash(args: FlashArgs, config: &Config) -> Result<()> {
     let elf_data = fs::read(&args.image).into_diagnostic()?;
 
     print_board_info(&mut flasher)?;
+    ensure_chip_compatibility(chip, Some(elf_data.as_slice()))?;
 
     let mut flash_config = args.flash_config_args;
     flash_config.flash_size = flash_config

--- a/espflash/src/cli/monitor/mod.rs
+++ b/espflash/src/cli/monitor/mod.rs
@@ -39,7 +39,7 @@ pub mod external_processors;
 pub mod parser;
 
 mod line_endings;
-pub(crate) mod symbols;
+mod symbols;
 
 #[cfg_attr(feature = "cli", derive(clap::ValueEnum))]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Display, EnumIter, EnumString, VariantNames)]

--- a/espflash/src/cli/monitor/symbols.rs
+++ b/espflash/src/cli/monitor/symbols.rs
@@ -98,18 +98,4 @@ impl<'sym> Symbols<'sym> {
             }
         })?
     }
-
-    pub(crate) fn symbol_data(
-        &self,
-        section_name: Option<&str>,
-        name_bytes: &[u8],
-    ) -> Option<&'sym [u8]> {
-        let sym = self.object.symbol_by_name_bytes(name_bytes)?;
-
-        let section = match section_name {
-            Some(section_name) => self.object.section_by_name(section_name)?,
-            None => self.object.section_by_index(sym.section_index()?).ok()?,
-        };
-        section.data_range(sym.address(), sym.size()).ok().flatten()
-    }
 }

--- a/espflash/src/error.rs
+++ b/espflash/src/error.rs
@@ -221,6 +221,13 @@ pub enum Error {
         help("`address` and `size` must be multiples of 0x1000 (4096)")
     )]
     InvalidEraseRegionArgument { address: u32, size: u32 },
+
+    #[error("The firmware was built for {elf}, but the detected chip is {detected}")]
+    #[diagnostic(
+        code(espflash::chip_mismatch),
+        help("Ensure that the device is connected and your host recognizes the serial adapter")
+    )]
+    FirmwareChipMismatch { elf: String, detected: Chip },
 }
 
 #[cfg(feature = "serialport")]

--- a/espflash/src/image_format/metadata.rs
+++ b/espflash/src/image_format/metadata.rs
@@ -1,0 +1,73 @@
+use std::{collections::HashMap, error::Error};
+
+use object::{File, Object, ObjectSection, ObjectSymbol};
+
+#[derive(Debug, Clone)]
+pub struct Metadata {
+    symbols: HashMap<String, Vec<u8>>,
+}
+
+impl Metadata {
+    fn empty() -> Self {
+        Self {
+            symbols: HashMap::new(),
+        }
+    }
+
+    pub fn from_bytes(bytes: Option<&[u8]>) -> Self {
+        match Self::try_from(bytes) {
+            Ok(metadata) => metadata,
+            Err(_) => Self::empty(),
+        }
+    }
+
+    pub fn try_from(bytes: Option<&[u8]>) -> Result<Self, Box<dyn Error>> {
+        const METADATA_SECTION: &str = ".espressif.metadata";
+
+        let Some(bytes) = bytes else {
+            return Ok(Self::empty());
+        };
+
+        let object = File::parse(bytes)?;
+        if object.section_by_name(METADATA_SECTION).is_none() {
+            return Ok(Self::empty());
+        }
+
+        let mut this = Self::empty();
+        for symbol in object.symbols() {
+            let Some(sym_section_idx) = symbol.section_index() else {
+                continue;
+            };
+            let sym_section = object.section_by_index(sym_section_idx)?;
+            if sym_section.name().ok() != Some(METADATA_SECTION) {
+                // Skip symbols that are not in the metadata section.
+                continue;
+            }
+
+            let name = symbol.name()?.to_string();
+            let data = sym_section
+                .data_range(symbol.address(), symbol.size())?
+                .map(|b| b.to_vec());
+
+            if let Some(data) = data {
+                this.symbols.insert(name, data);
+            }
+        }
+
+        Ok(this)
+    }
+
+    fn read_string<'f>(&'f self, name: &str) -> Option<&'f str> {
+        self.symbols
+            .get(name)
+            .and_then(|data| std::str::from_utf8(data).ok())
+    }
+
+    pub fn chip_name(&self) -> Option<&str> {
+        self.read_string("build_info.CHIP_NAME")
+    }
+
+    pub fn log_format(&self) -> Option<&str> {
+        self.read_string("espflash.LOG_FORMAT")
+    }
+}

--- a/espflash/src/image_format/mod.rs
+++ b/espflash/src/image_format/mod.rs
@@ -16,10 +16,11 @@ use object::{
     ObjectSection as _,
 };
 
-pub use self::esp_idf::IdfBootloaderFormat;
+pub use self::{esp_idf::IdfBootloaderFormat, metadata::Metadata};
 use crate::targets::Chip;
 
 mod esp_idf;
+mod metadata;
 
 /// A segment of code from the source ELF
 #[derive(Default, Clone, Eq)]


### PR DESCRIPTION
This PR reads chip name from the .elf and prevents flashing if it differs from the detected device.