### PR TITLE
Option to supply custom defmt formats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add `watchdog-reset` strategy to `--after` subcommand (#779)
 - Add `ROM` version of `read-flash` command (#812)
 - `espflash` can detect the log format automatically from ESP-HAL metadata. Reqires `esp-println` 0.14 (presumably, yet to be released) (#809)
+- Add `--output-format` option to monitor (#818)
 
 ### Changed
 

--- a/espflash/src/cli/mod.rs
+++ b/espflash/src/cli/mod.rs
@@ -279,9 +279,12 @@ pub struct MonitorConfigArgs {
     /// Avoids restarting the device before monitoring
     #[arg(long, requires = "non_interactive")]
     no_reset: bool,
-    /// Logging format.
+    /// The encoding of the target's serial output.
     #[arg(long, short = 'L')]
     log_format: Option<LogFormat>,
+    /// The format of the printed defmt messages.
+    #[arg(long, short = 'F')]
+    output_format: Option<String>,
     /// External log processors to use (comma separated executables)
     #[arg(long)]
     processors: Option<String>,

--- a/espflash/src/cli/mod.rs
+++ b/espflash/src/cli/mod.rs
@@ -283,6 +283,10 @@ pub struct MonitorConfigArgs {
     #[arg(long, short = 'L')]
     log_format: Option<LogFormat>,
     /// The format of the printed defmt messages.
+    ///
+    /// You can also use one of two presets: oneline (default) and full.
+    ///
+    /// See <https://defmt.ferrous-systems.com/custom-log-output>
     #[arg(long, short = 'F')]
     output_format: Option<String>,
     /// External log processors to use (comma separated executables)

--- a/espflash/src/cli/monitor/mod.rs
+++ b/espflash/src/cli/monitor/mod.rs
@@ -109,8 +109,16 @@ pub fn monitor(
         .log_format
         .unwrap_or_else(|| deduce_log_format(elf))
     {
-        LogFormat::Defmt => Box::new(parser::esp_defmt::EspDefmt::new(elf)?),
-        LogFormat::Serial => Box::new(parser::serial::Serial),
+        LogFormat::Defmt => Box::new(parser::esp_defmt::EspDefmt::new(
+            elf,
+            monitor_args.output_format,
+        )?),
+        LogFormat::Serial => {
+            if monitor_args.output_format.is_some() {
+                warn!("Output format specified but log format is serial. Ignoring output format.");
+            }
+            Box::new(parser::serial::Serial)
+        }
     };
 
     let mut external_processors =

--- a/espflash/src/cli/monitor/parser/esp_defmt.rs
+++ b/espflash/src/cli/monitor/parser/esp_defmt.rs
@@ -132,7 +132,7 @@ impl EspDefmt {
         }
     }
 
-    pub fn new(elf: Option<&[u8]>) -> Result<Self> {
+    pub fn new(elf: Option<&[u8]>, _output_format: Option<String>) -> Result<Self> {
         Self::load_table(elf).map(|table| Self {
             delimiter: FrameDelimiter::new(),
             table,


### PR DESCRIPTION
The formatting options are identical to probe-rs's, except in espflash we can't control timestamp/location with switches. The user can supply a custom format string if such control is necessary.

Closes #520 
Closes #781