### PR TITLE
Remove the dependency on `hex`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1243,7 +1243,6 @@ dependencies = [
  "env_logger",
  "esp-idf-part",
  "flate2",
- "hex",
  "indicatif",
  "libc",
  "log",
@@ -2355,9 +2354,6 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
-dependencies = [
- "serde",
-]
 
 [[package]]
 name = "hkdf"

--- a/espflash/Cargo.toml
+++ b/espflash/Cargo.toml
@@ -41,7 +41,6 @@ directories     = { version = "5.0.1", optional = true }
 env_logger      = { version = "0.11.6", optional = true }
 esp-idf-part    = "0.5.0"
 flate2          = "1.0.35"
-hex             = { version = "0.4.3", features = ["serde"] }
 indicatif       = { version = "0.17.9", optional = true }
 log             = "0.4.22"
 md-5            = "0.10.6"


### PR DESCRIPTION
- Removed the dependency on the `hex` package
- Renamed (de)serialization functions (just thought they could be a bit more clear, internal-only anyway)