### PR TITLE
Remove the dependency on `xmas_elf`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1259,7 +1259,6 @@ dependencies = [
  "thiserror 2.0.10",
  "toml",
  "update-informer",
- "xmas-elf",
 ]
 
 [[package]]
@@ -5151,15 +5150,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "xmas-elf"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42c49817e78342f7f30a181573d82ff55b88a35f86ccaf07fc64b3008f56d1c6"
-dependencies = [
- "zero",
-]
-
-[[package]]
 name = "yoke"
 version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5182,12 +5172,6 @@ dependencies = [
  "syn 2.0.96",
  "synstructure",
 ]
-
-[[package]]
-name = "zero"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fe21bcc34ca7fe6dd56cc2cb1261ea59d6b93620215aefb5ea6032265527784"
 
 [[package]]
 name = "zerocopy"

--- a/espflash/Cargo.toml
+++ b/espflash/Cargo.toml
@@ -56,7 +56,6 @@ strum           = { version = "0.26.3", features = ["derive"] }
 thiserror       = "2.0.10"
 toml            = { version = "0.8.19", optional = true }
 update-informer = { version = "1.2.0", optional = true }
-xmas-elf        = "0.9.1"
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2.169"

--- a/espflash/src/cli/mod.rs
+++ b/espflash/src/cli/mod.rs
@@ -25,8 +25,8 @@ use esp_idf_part::{DataType, Partition, PartitionTable};
 use indicatif::{style::ProgressStyle, HumanCount, ProgressBar};
 use log::{debug, info, warn};
 use miette::{IntoDiagnostic, Result, WrapErr};
+use object::read::elf::ElfFile32 as ElfFile;
 use serialport::{FlowControl, SerialPortInfo, SerialPortType, UsbPortInfo};
-use xmas_elf::ElfFile;
 
 use self::{
     config::Config,
@@ -35,7 +35,7 @@ use self::{
 };
 use crate::{
     connection::reset::{ResetAfterOperation, ResetBeforeOperation},
-    error::{ElfError, Error, MissingPartition, MissingPartitionTable},
+    error::{Error, MissingPartition, MissingPartitionTable},
     flasher::{
         FlashData,
         FlashFrequency,
@@ -607,9 +607,7 @@ pub fn save_elf_as_image(
     skip_padding: bool,
     xtal_freq: XtalFrequency,
 ) -> Result<()> {
-    let elf = ElfFile::new(elf_data)
-        .map_err(ElfError::from)
-        .into_diagnostic()?;
+    let elf = ElfFile::parse(elf_data).into_diagnostic()?;
 
     if merge {
         // To get a chip revision, the connection is needed

--- a/espflash/src/error.rs
+++ b/espflash/src/error.rs
@@ -181,7 +181,7 @@ pub enum Error {
         code(espflash::invalid_elf),
         help("Try running `cargo clean` and rebuilding the image")
     )]
-    InvalidElf(#[from] ElfError),
+    InvalidElf(#[from] object::Error),
 
     #[error("The bootloader returned an error")]
     #[cfg(feature = "serialport")]
@@ -491,17 +491,6 @@ impl From<String> for MissingPartition {
     help("Try providing a CSV or binary paritition table with the `--partition-table` argument.")
 )]
 pub struct MissingPartitionTable;
-
-/// Invalid ELF file error
-#[derive(Debug, Error)]
-#[error("{0}")]
-pub struct ElfError(&'static str);
-
-impl From<&'static str> for ElfError {
-    fn from(err: &'static str) -> Self {
-        ElfError(err)
-    }
-}
 
 #[cfg(feature = "serialport")]
 pub(crate) trait ResultExt {

--- a/espflash/src/image_format/esp_idf.rs
+++ b/espflash/src/image_format/esp_idf.rs
@@ -4,8 +4,8 @@ use std::{borrow::Cow, io::Write, iter::once, mem::size_of};
 
 use bytemuck::{bytes_of, from_bytes, Pod, Zeroable};
 use esp_idf_part::{AppType, DataType, Partition, PartitionTable, SubType, Type};
+use object::{read::elf::ElfFile32 as ElfFile, Endianness};
 use sha2::{Digest, Sha256};
-use xmas_elf::ElfFile;
 
 use super::{ram_segments, rom_segments, Segment};
 use crate::{
@@ -190,7 +190,7 @@ impl<'a> IdfBootloaderFormat<'a> {
         // write the header of the app
         // use the same settings as the bootloader
         // just update the entry point
-        header.entry = elf.header.pt2.entry_point() as u32;
+        header.entry = elf.elf_header().e_entry.get(Endianness::Little);
         header.wp_pin = WP_PIN_DISABLED;
         header.chip_id = params.chip_id;
         header.min_chip_rev_full = flash_data.min_chip_rev;

--- a/espflash/src/targets/esp32.rs
+++ b/espflash/src/targets/esp32.rs
@@ -1,6 +1,6 @@
 use std::ops::Range;
 
-use xmas_elf::ElfFile;
+use object::read::elf::ElfFile32 as ElfFile;
 
 #[cfg(feature = "serialport")]
 use crate::{connection::Connection, targets::bytes_to_mac_addr};

--- a/espflash/src/targets/esp32c2.rs
+++ b/espflash/src/targets/esp32c2.rs
@@ -1,7 +1,7 @@
 use std::{collections::HashMap, ops::Range};
 
 use log::debug;
-use xmas_elf::ElfFile;
+use object::read::elf::ElfFile32 as ElfFile;
 
 #[cfg(feature = "serialport")]
 use crate::{connection::Connection, targets::bytes_to_mac_addr};

--- a/espflash/src/targets/esp32c3.rs
+++ b/espflash/src/targets/esp32c3.rs
@@ -1,6 +1,6 @@
 use std::ops::Range;
 
-use xmas_elf::ElfFile;
+use object::read::elf::ElfFile32 as ElfFile;
 
 #[cfg(feature = "serialport")]
 use crate::connection::Connection;

--- a/espflash/src/targets/esp32c6.rs
+++ b/espflash/src/targets/esp32c6.rs
@@ -1,6 +1,6 @@
 use std::ops::Range;
 
-use xmas_elf::ElfFile;
+use object::read::elf::ElfFile32 as ElfFile;
 
 #[cfg(feature = "serialport")]
 use crate::connection::Connection;

--- a/espflash/src/targets/esp32h2.rs
+++ b/espflash/src/targets/esp32h2.rs
@@ -1,6 +1,6 @@
 use std::{collections::HashMap, ops::Range};
 
-use xmas_elf::ElfFile;
+use object::read::elf::ElfFile32 as ElfFile;
 
 #[cfg(feature = "serialport")]
 use crate::connection::Connection;

--- a/espflash/src/targets/esp32p4.rs
+++ b/espflash/src/targets/esp32p4.rs
@@ -1,6 +1,6 @@
 use std::ops::Range;
 
-use xmas_elf::ElfFile;
+use object::read::elf::ElfFile32 as ElfFile;
 
 #[cfg(feature = "serialport")]
 use crate::connection::Connection;

--- a/espflash/src/targets/esp32s2.rs
+++ b/espflash/src/targets/esp32s2.rs
@@ -1,6 +1,6 @@
 use std::ops::Range;
 
-use xmas_elf::ElfFile;
+use object::read::elf::ElfFile32 as ElfFile;
 
 #[cfg(feature = "serialport")]
 use super::flash_target::MAX_RAM_BLOCK_SIZE;

--- a/espflash/src/targets/esp32s3.rs
+++ b/espflash/src/targets/esp32s3.rs
@@ -1,6 +1,6 @@
 use std::ops::Range;
 
-use xmas_elf::ElfFile;
+use object::read::elf::ElfFile32 as ElfFile;
 
 #[cfg(feature = "serialport")]
 use crate::connection::Connection;

--- a/espflash/src/targets/mod.rs
+++ b/espflash/src/targets/mod.rs
@@ -6,9 +6,9 @@
 
 use std::collections::HashMap;
 
+use object::read::elf::ElfFile32 as ElfFile;
 use serde::{Deserialize, Serialize};
 use strum::{Display, EnumIter, EnumString, VariantNames};
-use xmas_elf::ElfFile;
 
 #[cfg(feature = "serialport")]
 pub use self::flash_target::{Esp32Target, RamTarget};


### PR DESCRIPTION
While these changes _technically_ have user-facing effects, we need to remove `ElfFile` from the public API anyway so I will not add a `CHANGELOG.md` entry here, since it will just be obsolete once #803 is resolved anyway.