### PR TITLE
Allow flashing binary to a named partition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added chip detection based on security info, where supported (#814)
 - `espflash` can detect the chip from ESP-HAL metadata to prevent flashing firmware built for a different device. Reqires `esp-hal` 1.0.0-beta.0 (presumably, yet to be released) (#816)
 - `espflash` no longer allows flashing a too-big partition table (#830)
+- Allow specifying a partition label for `write-bin`, add `--partition-table`. (#828)
 
 ### Changed
 

--- a/cargo-espflash/src/main.rs
+++ b/cargo-espflash/src/main.rs
@@ -117,7 +117,8 @@ enum Commands {
     /// Otherwise, each segment will be saved as individual binaries, prefixed
     /// with their intended addresses in flash.
     SaveImage(SaveImageArgs),
-    /// Write a binary file to a specific address in a target device's flash
+    /// Write a binary file to a specific address or partition in a target
+    /// device's flash
     WriteBin(WriteBinArgs),
 }
 

--- a/espflash/src/bin/espflash.rs
+++ b/espflash/src/bin/espflash.rs
@@ -88,7 +88,8 @@ enum Commands {
     /// Otherwise, each segment will be saved as individual binaries, prefixed
     /// with their intended addresses in flash.
     SaveImage(SaveImageArgs),
-    /// Write a binary file to a specific address in a target device's flash
+    /// Write a binary file to a specific address or partition in a target
+    /// device's flash
     WriteBin(WriteBinArgs),
 }
 

--- a/espflash/tests/scripts/write-bin.sh
+++ b/espflash/tests/scripts/write-bin.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+part_table="espflash/tests/data/partitions.csv"
 
 # https://github.com/esp-rs/espflash/issues/622 reproducer
 echo -ne "\x01\xa0" >binary_file.bin
@@ -10,6 +11,25 @@ if [[ ! $result =~ "Binary successfully written to flash!" ]]; then
 fi
 
 result=$(espflash read-flash 0 64 flash_content.bin 2>&1)
+echo "$result"
+if [[ ! $result =~ "Flash content successfully read and written to" ]]; then
+    echo "Failed to read flash content"
+    exit 1
+fi
+# Check that the flash_content.bin contains the '01 a0' bytes
+if ! grep -q -a -F $'\x01\xa0' flash_content.bin; then
+    echo "Failed verifying content"
+    exit 1
+fi
+
+result=$(espflash write-bin nvs binary_file.bin --partition-table $part_table 2>&1)
+echo "$result"
+if [[ ! $result =~ "Binary successfully written to flash!" ]]; then
+    echo "Failed to write binary to the nvs partition label"
+    exit 1
+fi
+
+result=$(espflash read-flash 0x9000 64 flash_content.bin 2>&1)
 echo "$result"
 if [[ ! $result =~ "Flash content successfully read and written to" ]]; then
     echo "Failed to read flash content"


### PR DESCRIPTION
Closes #631

This PR allows specifying a partition label for `write-bin`, in addition to a numeric address. If a partition label is passed, espflash tries to parse the provided/configured partition table, and resolve the label. This information is then used to a) check the size of the flashed binary and b) specify the address where the binary should be written.

As an alternative approach, we might read back the partition table from the device itself. Since users have the option to configure a partition table in a config file, this option would need a `--read-idf-partition-table-from-device` or similar flag, meaning it can still be implemented without breaking the command's current behaviour.