### PR TITLE
Align segment lengths after merging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed typos in error variant names (#782)
 - Fix `read-flash` which didn't work with some lengths (#804)
 - espflash can now flash an ESP32-S2 in download mode over USB (#813)
+- Fixed a case where esplash transformed the firmware elf in a way that made it unbootable (#831)
 
 ### Removed
 

--- a/espflash/src/image_format/esp_idf.rs
+++ b/espflash/src/image_format/esp_idf.rs
@@ -213,8 +213,10 @@ impl<'a> IdfBootloaderFormat<'a> {
 
         let mut data = bytes_of(&header).to_vec();
 
-        let flash_segments: Vec<_> = merge_adjacent_segments(rom_segments(chip, &elf).collect());
-        let mut ram_segments: Vec<_> = merge_adjacent_segments(ram_segments(chip, &elf).collect());
+        let flash_segments: Vec<_> =
+            pad_align_segments(merge_adjacent_segments(rom_segments(chip, &elf).collect()));
+        let mut ram_segments: Vec<_> =
+            pad_align_segments(merge_adjacent_segments(ram_segments(chip, &elf).collect()));
 
         let mut checksum = ESP_CHECKSUM_MAGIC;
         let mut segment_count = 0;
@@ -444,6 +446,11 @@ fn merge_adjacent_segments(mut segments: Vec<Segment<'_>>) -> Vec<Segment<'_>> {
     }
 
     merged
+}
+
+fn pad_align_segments(mut segments: Vec<Segment<'_>>) -> Vec<Segment<'_>> {
+    segments.iter_mut().for_each(|segment| segment.pad_align(4));
+    segments
 }
 
 /// Save a segment to the data buffer.

--- a/espflash/src/image_format/esp_idf.rs
+++ b/espflash/src/image_format/esp_idf.rs
@@ -213,6 +213,10 @@ impl<'a> IdfBootloaderFormat<'a> {
 
         let mut data = bytes_of(&header).to_vec();
 
+        // The bootloader needs segments to be 4-byte aligned, but ensuring that
+        // alignment by padding segments might result in overlapping segments. We
+        // need to merge adjacent segments first to avoid the possibility of them
+        // overlapping, and then do the padding.
         let flash_segments: Vec<_> =
             pad_align_segments(merge_adjacent_segments(rom_segments(chip, &elf).collect()));
         let mut ram_segments: Vec<_> =

--- a/espflash/src/image_format/mod.rs
+++ b/espflash/src/image_format/mod.rs
@@ -33,13 +33,12 @@ pub struct Segment<'a> {
 
 impl<'a> Segment<'a> {
     pub fn new(addr: u32, data: &'a [u8]) -> Self {
-        let mut segment = Segment {
+        // Do not pad the data here, as it might result in overlapping segments
+        // in the ELF file. The padding should be done after merging adjacent segments.
+        Segment {
             addr,
             data: Cow::Borrowed(data),
-        };
-        segment.pad_align(4);
-
-        segment
+        }
     }
 
     /// Split of the first `count` bytes into a new segment, adjusting the


### PR DESCRIPTION
Fixes #552 - the problem is that the reproducer elf has 2-byte aligned segments (functions in IRAM), and espflash used to 4-byte align segment lengths prematurely, causing them to overlap. This overlap then prevented merging segments, and the end result was an elf that the bootloader was not able to load.

The firmware seems to require some propriatery, or at least project-specific data to be present, so the firmware immediately panics, but it can boot with this PR.