### PR TITLE
Add (some level of) SDM support

### DIFF
--- a/espflash/src/cli/mod.rs
+++ b/espflash/src/cli/mod.rs
@@ -572,17 +572,21 @@ pub fn parse_chip_rev(chip_rev: &str) -> Result<u16> {
 /// Print information about a chip
 pub fn print_board_info(flasher: &mut Flasher) -> Result<()> {
     let info = flasher.device_info()?;
-
     print!("Chip type:         {}", info.chip);
+
     if let Some((major, minor)) = info.revision {
         println!(" (revision v{major}.{minor})");
     } else {
         println!();
     }
+
     println!("Crystal frequency: {}", info.crystal_frequency);
     println!("Flash size:        {}", info.flash_size);
     println!("Features:          {}", info.features.join(", "));
-    println!("MAC address:       {}", info.mac_address);
+
+    if let Some(mac) = info.mac_address {
+        println!("MAC address:       {}", mac);
+    }
 
     Ok(())
 }

--- a/espflash/src/connection/mod.rs
+++ b/espflash/src/connection/mod.rs
@@ -523,12 +523,15 @@ impl Connection {
     ///  Write a command and reads the response
     pub fn command(&mut self, command: Command<'_>) -> Result<CommandResponseValue, Error> {
         let ty = command.command_type();
+        info!("deb: Why");
         self.write_command(command).for_command(ty)?;
-
+        info!("deb: is");
         for _ in 0..100 {
             match self.read_response().for_command(ty)? {
                 Some(response) if response.return_op == ty as u8 => {
+                    info!("deb: nefailing (return_op {} and ty {})\nwhole resp: {:?})", response.return_op, ty, response);
                     return if response.error != 0 {
+                        info!("deb: resp error {}", response.error);
                         let _error = self.flush();
                         Err(Error::RomError(RomError::new(
                             command.command_type(),
@@ -537,6 +540,7 @@ impl Connection {
                     } else {
                         // Check if the response is a Vector and strip header (first 8 bytes)
                         // https://github.com/espressif/esptool/blob/749d1ad/esptool/loader.py#L481
+                        info!("deb: fuck");
                         let modified_value = match response.value {
                             CommandResponseValue::Vector(mut vec) if vec.len() >= 8 => {
                                 vec = vec[8..][..response.return_length as usize].to_vec();

--- a/espflash/src/connection/mod.rs
+++ b/espflash/src/connection/mod.rs
@@ -449,11 +449,17 @@ impl Connection {
                 // - https://docs.espressif.com/projects/esptool/en/latest/esp32/advanced-topics/serial-protocol.html?highlight=md5#response-packet
                 // - https://docs.espressif.com/projects/esptool/en/latest/esp32/advanced-topics/serial-protocol.html?highlight=md5#status-bytes
                 // - https://docs.espressif.com/projects/esptool/en/latest/esp32/advanced-topics/serial-protocol.html?highlight=md5#verifying-uploaded-data
+
+
+                // TODO: status len should be 2 for SDM
+
                 let status_len = if response.len() == 10 || response.len() == 26 {
                     2
                 } else {
                     4
                 };
+
+                let status_len = 2;
 
                 let value = match response.len() {
                     10 | 12 => CommandResponseValue::ValueU32(u32::from_le_bytes(
@@ -523,15 +529,11 @@ impl Connection {
     ///  Write a command and reads the response
     pub fn command(&mut self, command: Command<'_>) -> Result<CommandResponseValue, Error> {
         let ty = command.command_type();
-        info!("deb: Why");
         self.write_command(command).for_command(ty)?;
-        info!("deb: is");
         for _ in 0..100 {
             match self.read_response().for_command(ty)? {
                 Some(response) if response.return_op == ty as u8 => {
-                    info!("deb: nefailing (return_op {} and ty {})\nwhole resp: {:?})", response.return_op, ty, response);
                     return if response.error != 0 {
-                        info!("deb: resp error {}", response.error);
                         let _error = self.flush();
                         Err(Error::RomError(RomError::new(
                             command.command_type(),
@@ -540,7 +542,6 @@ impl Connection {
                     } else {
                         // Check if the response is a Vector and strip header (first 8 bytes)
                         // https://github.com/espressif/esptool/blob/749d1ad/esptool/loader.py#L481
-                        info!("deb: fuck");
                         let modified_value = match response.value {
                             CommandResponseValue::Vector(mut vec) if vec.len() >= 8 => {
                                 vec = vec[8..][..response.return_length as usize].to_vec();

--- a/espflash/src/connection/mod.rs
+++ b/espflash/src/connection/mod.rs
@@ -450,7 +450,6 @@ impl Connection {
                 // - https://docs.espressif.com/projects/esptool/en/latest/esp32/advanced-topics/serial-protocol.html?highlight=md5#status-bytes
                 // - https://docs.espressif.com/projects/esptool/en/latest/esp32/advanced-topics/serial-protocol.html?highlight=md5#verifying-uploaded-data
 
-
                 // TODO: status len should be 2 for SDM
 
                 let status_len = if response.len() == 10 || response.len() == 26 {

--- a/espflash/src/connection/mod.rs
+++ b/espflash/src/connection/mod.rs
@@ -124,6 +124,7 @@ pub struct Connection {
     decoder: SlipDecoder,
     after_operation: ResetAfterOperation,
     before_operation: ResetBeforeOperation,
+    pub(crate) secure_download_mode: bool,
 }
 
 impl Connection {
@@ -139,6 +140,7 @@ impl Connection {
             decoder: SlipDecoder::new(),
             after_operation,
             before_operation,
+            secure_download_mode: false,
         }
     }
 
@@ -450,15 +452,12 @@ impl Connection {
                 // - https://docs.espressif.com/projects/esptool/en/latest/esp32/advanced-topics/serial-protocol.html?highlight=md5#status-bytes
                 // - https://docs.espressif.com/projects/esptool/en/latest/esp32/advanced-topics/serial-protocol.html?highlight=md5#verifying-uploaded-data
 
-                // TODO: status len should be 2 for SDM
-
-                let status_len = if response.len() == 10 || response.len() == 26 {
-                    2
-                } else {
-                    4
-                };
-
-                let status_len = 2;
+                let status_len =
+                    if response.len() == 10 || response.len() == 26 || self.secure_download_mode {
+                        2
+                    } else {
+                        4
+                    };
 
                 let value = match response.len() {
                     10 | 12 => CommandResponseValue::ValueU32(u32::from_le_bytes(

--- a/espflash/src/flasher/mod.rs
+++ b/espflash/src/flasher/mod.rs
@@ -631,7 +631,7 @@ pub struct DeviceInfo {
     /// Device features
     pub features: Vec<String>,
     /// MAC address
-    pub mac_address: String,
+    pub mac_address: Option<String>,
 }
 
 /// Connect to and flash a target device
@@ -652,6 +652,8 @@ pub struct Flasher {
     verify: bool,
     /// Indicate skipping of already flashed regions
     skip: bool,
+    /// FUCKME
+    secure_download_mode: bool,
 }
 
 #[cfg(feature = "serialport")]
@@ -673,6 +675,8 @@ impl Flasher {
         let mut connection = Connection::new(serial, port_info, after_operation, before_operation);
         connection.begin()?;
         connection.set_timeout(DEFAULT_TIMEOUT)?;
+
+        let secure_download_mode = detect_sdm(&mut connection)?;
 
         let detected_chip = if before_operation != ResetBeforeOperation::NoResetNoSync {
             // Detect which chip we are connected to.
@@ -701,6 +705,7 @@ impl Flasher {
             use_stub,
             verify,
             skip,
+            secure_download_mode,
         };
 
         if before_operation == ResetBeforeOperation::NoResetNoSync {
@@ -709,11 +714,19 @@ impl Flasher {
 
         // Load flash stub if enabled
         if use_stub {
-            info!("Using flash stub");
-            flasher.load_stub()?;
+            if !secure_download_mode {
+                info!("Using flash stub");
+                flasher.load_stub()?;
+            } else {
+                warn!("Stub is not supported in Secure Download Mode, setting --no-stub");
+                flasher.use_stub = !use_stub;
+            }
         }
 
-        flasher.spi_autodetect()?;
+        if !secure_download_mode {
+            flasher.spi_autodetect()?;
+        }
+        
 
         // Now that we have established a connection and detected the chip and flash
         // size, we can set the baud rate of the connection to the configured value.
@@ -735,7 +748,7 @@ impl Flasher {
         let mut target = self
             .chip
             .flash_target(self.spi_params, self.use_stub, false, false);
-        target.begin(&mut self.connection).flashing()?;
+        target.begin(&mut self.connection, self.secure_download_mode).flashing()?;
         Ok(())
     }
 
@@ -751,7 +764,7 @@ impl Flasher {
                 .into_target()
                 .max_ram_block_size(&mut self.connection)?,
         );
-        ram_target.begin(&mut self.connection).flashing()?;
+        ram_target.begin(&mut self.connection, self.secure_download_mode).flashing()?;
 
         let (text_addr, text) = stub.text();
         debug!("Write {} byte stub text", text.len());
@@ -764,6 +777,7 @@ impl Flasher {
                     data: Cow::Borrowed(&text),
                 },
                 &mut None,
+                self.secure_download_mode,
             )
             .flashing()?;
 
@@ -778,6 +792,7 @@ impl Flasher {
                     data: Cow::Borrowed(&data),
                 },
                 &mut None,
+                self.secure_download_mode,
             )
             .flashing()?;
 
@@ -982,14 +997,25 @@ impl Flasher {
         let chip = self.chip();
         let target = chip.into_target();
 
-        let revision = Some(target.chip_revision(self.connection())?);
+        // chip_revision reads from efuse, which is not possible in Secure Download Mode        
+        let revision = if !self.secure_download_mode {
+            Some(target.chip_revision(self.connection())?)
+        } else {
+            None
+        };
+    
         let crystal_frequency = target.crystal_freq(self.connection())?;
         let features = target
             .chip_features(self.connection())?
             .iter()
             .map(|s| s.to_string())
             .collect::<Vec<_>>();
-        let mac_address = target.mac_address(self.connection())?;
+
+        let mac_address = if !self.secure_download_mode {
+            Some(target.mac_address(self.connection())?)
+        } else {
+            None
+        };
 
         let info = DeviceInfo {
             chip,
@@ -1022,11 +1048,11 @@ impl Flasher {
                 .into_target()
                 .max_ram_block_size(&mut self.connection)?,
         );
-        target.begin(&mut self.connection).flashing()?;
+        target.begin(&mut self.connection, self.secure_download_mode).flashing()?;
 
         for segment in ram_segments(self.chip, &elf) {
             target
-                .write_segment(&mut self.connection, segment, &mut progress)
+                .write_segment(&mut self.connection, segment, &mut progress, self.secure_download_mode)
                 .flashing()?;
         }
 
@@ -1044,7 +1070,7 @@ impl Flasher {
         let mut target =
             self.chip
                 .flash_target(self.spi_params, self.use_stub, self.verify, self.skip);
-        target.begin(&mut self.connection).flashing()?;
+        target.begin(&mut self.connection, self.secure_download_mode).flashing()?;
 
         let chip_revision = Some(
             self.chip
@@ -1063,7 +1089,7 @@ impl Flasher {
 
         for segment in image.flash_segments() {
             target
-                .write_segment(&mut self.connection, segment, &mut progress)
+                .write_segment(&mut self.connection, segment, &mut progress, self.secure_download_mode)
                 .flashing()?;
         }
 
@@ -1096,13 +1122,17 @@ impl Flasher {
         segments: &[Segment<'_>],
         mut progress: Option<&mut dyn ProgressCallbacks>,
     ) -> Result<(), Error> {
+        info!("deb: write_bins_to_flash: flash target");
         let mut target = self
             .chip
             .flash_target(self.spi_params, self.use_stub, false, false);
-        target.begin(&mut self.connection).flashing()?;
+        info!("deb: write_bins_to_flash: begin");
+        target.begin(&mut self.connection, self.secure_download_mode).flashing()?;
+        info!("deb: write_bins_to_flash: writing segments");
         for segment in segments {
-            target.write_segment(&mut self.connection, segment.borrow(), &mut progress)?;
+            target.write_segment(&mut self.connection, segment.borrow(), &mut progress, self.secure_download_mode)?;
         }
+        info!("deb: write_bins_to_flash: finish");
         target.finish(&mut self.connection, true).flashing()?;
 
         Ok(())
@@ -1381,4 +1411,14 @@ fn detect_chip(connection: &mut Connection, use_stub: bool) -> Result<Chip, Erro
             Ok(chip)
         }
     }
+}
+
+fn detect_sdm(connection: &mut Connection) -> Result<bool, Error> {
+    match connection.read_reg(CHIP_DETECT_MAGIC_REG_ADDR) {
+        Ok(_) => return Ok(false),
+        Err(_) => {
+            log::warn!("Secure Download Mode is enabled on this chip");
+            return Ok(true);
+        }
+    };
 }

--- a/espflash/src/flasher/mod.rs
+++ b/espflash/src/flasher/mod.rs
@@ -652,8 +652,6 @@ pub struct Flasher {
     verify: bool,
     /// Indicate skipping of already flashed regions
     skip: bool,
-    /// FUCKME
-    secure_download_mode: bool,
 }
 
 #[cfg(feature = "serialport")]
@@ -676,7 +674,7 @@ impl Flasher {
         connection.begin()?;
         connection.set_timeout(DEFAULT_TIMEOUT)?;
 
-        let secure_download_mode = detect_sdm(&mut connection)?;
+        let sdm = detect_sdm(&mut connection)?;
 
         let detected_chip = if before_operation != ResetBeforeOperation::NoResetNoSync {
             // Detect which chip we are connected to.
@@ -705,7 +703,6 @@ impl Flasher {
             use_stub,
             verify,
             skip,
-            secure_download_mode,
         };
 
         if before_operation == ResetBeforeOperation::NoResetNoSync {
@@ -714,7 +711,7 @@ impl Flasher {
 
         // Load flash stub if enabled
         if use_stub {
-            if !secure_download_mode {
+            if !sdm {
                 info!("Using flash stub");
                 flasher.load_stub()?;
             } else {
@@ -723,7 +720,7 @@ impl Flasher {
             }
         }
 
-        if !secure_download_mode {
+        if !sdm {
             flasher.spi_autodetect()?;
         }
 
@@ -747,9 +744,7 @@ impl Flasher {
         let mut target = self
             .chip
             .flash_target(self.spi_params, self.use_stub, false, false);
-        target
-            .begin(&mut self.connection, self.secure_download_mode)
-            .flashing()?;
+        target.begin(&mut self.connection).flashing()?;
         Ok(())
     }
 
@@ -765,9 +760,7 @@ impl Flasher {
                 .into_target()
                 .max_ram_block_size(&mut self.connection)?,
         );
-        ram_target
-            .begin(&mut self.connection, self.secure_download_mode)
-            .flashing()?;
+        ram_target.begin(&mut self.connection).flashing()?;
 
         let (text_addr, text) = stub.text();
         debug!("Write {} byte stub text", text.len());
@@ -999,7 +992,7 @@ impl Flasher {
         let target = chip.into_target();
 
         // chip_revision reads from efuse, which is not possible in Secure Download Mode
-        let revision = if !self.secure_download_mode {
+        let revision = if !self.connection.secure_download_mode {
             Some(target.chip_revision(self.connection())?)
         } else {
             None
@@ -1012,7 +1005,7 @@ impl Flasher {
             .map(|s| s.to_string())
             .collect::<Vec<_>>();
 
-        let mac_address = if !self.secure_download_mode {
+        let mac_address = if !self.connection.secure_download_mode {
             Some(target.mac_address(self.connection())?)
         } else {
             None
@@ -1049,9 +1042,7 @@ impl Flasher {
                 .into_target()
                 .max_ram_block_size(&mut self.connection)?,
         );
-        target
-            .begin(&mut self.connection, self.secure_download_mode)
-            .flashing()?;
+        target.begin(&mut self.connection).flashing()?;
 
         for segment in ram_segments(self.chip, &elf) {
             target
@@ -1073,9 +1064,7 @@ impl Flasher {
         let mut target =
             self.chip
                 .flash_target(self.spi_params, self.use_stub, self.verify, self.skip);
-        target
-            .begin(&mut self.connection, self.secure_download_mode)
-            .flashing()?;
+        target.begin(&mut self.connection).flashing()?;
 
         let chip_revision = Some(
             self.chip
@@ -1131,12 +1120,10 @@ impl Flasher {
             .chip
             .flash_target(self.spi_params, self.use_stub, false, false);
 
-        target
-            .begin(&mut self.connection, self.secure_download_mode)
-            .flashing()?;
+        target.begin(&mut self.connection).flashing()?;
 
         for segment in segments {
-            if self.secure_download_mode {
+            if self.connection.secure_download_mode {
                 target.write_segment_sdm(&mut self.connection, segment.borrow(), &mut progress)?;
             } else {
                 target.write_segment(&mut self.connection, segment.borrow(), &mut progress)?;
@@ -1428,6 +1415,7 @@ fn detect_sdm(connection: &mut Connection) -> Result<bool, Error> {
         Ok(_) => return Ok(false),
         Err(_) => {
             log::warn!("Secure Download Mode is enabled on this chip");
+            connection.secure_download_mode = true;
             return Ok(true);
         }
     };

--- a/espflash/src/flasher/mod.rs
+++ b/espflash/src/flasher/mod.rs
@@ -777,7 +777,6 @@ impl Flasher {
                     data: Cow::Borrowed(&text),
                 },
                 &mut None,
-                self.secure_download_mode,
             )
             .flashing()?;
 
@@ -792,7 +791,6 @@ impl Flasher {
                     data: Cow::Borrowed(&data),
                 },
                 &mut None,
-                self.secure_download_mode,
             )
             .flashing()?;
 
@@ -1052,7 +1050,7 @@ impl Flasher {
 
         for segment in ram_segments(self.chip, &elf) {
             target
-                .write_segment(&mut self.connection, segment, &mut progress, self.secure_download_mode)
+                .write_segment(&mut self.connection, segment, &mut progress)
                 .flashing()?;
         }
 
@@ -1089,7 +1087,7 @@ impl Flasher {
 
         for segment in image.flash_segments() {
             target
-                .write_segment(&mut self.connection, segment, &mut progress, self.secure_download_mode)
+                .write_segment(&mut self.connection, segment, &mut progress)
                 .flashing()?;
         }
 
@@ -1122,17 +1120,20 @@ impl Flasher {
         segments: &[Segment<'_>],
         mut progress: Option<&mut dyn ProgressCallbacks>,
     ) -> Result<(), Error> {
-        info!("deb: write_bins_to_flash: flash target");
         let mut target = self
             .chip
             .flash_target(self.spi_params, self.use_stub, false, false);
-        info!("deb: write_bins_to_flash: begin");
+
         target.begin(&mut self.connection, self.secure_download_mode).flashing()?;
-        info!("deb: write_bins_to_flash: writing segments");
+        
         for segment in segments {
-            target.write_segment(&mut self.connection, segment.borrow(), &mut progress, self.secure_download_mode)?;
+            if self.secure_download_mode {
+                target.write_segment_sdm(&mut self.connection, segment.borrow(), &mut progress)?;
+            } else {
+                target.write_segment(&mut self.connection, segment.borrow(), &mut progress)?;
+            }
         }
-        info!("deb: write_bins_to_flash: finish");
+        
         target.finish(&mut self.connection, true).flashing()?;
 
         Ok(())

--- a/espflash/src/flasher/mod.rs
+++ b/espflash/src/flasher/mod.rs
@@ -726,7 +726,6 @@ impl Flasher {
         if !secure_download_mode {
             flasher.spi_autodetect()?;
         }
-        
 
         // Now that we have established a connection and detected the chip and flash
         // size, we can set the baud rate of the connection to the configured value.
@@ -748,7 +747,9 @@ impl Flasher {
         let mut target = self
             .chip
             .flash_target(self.spi_params, self.use_stub, false, false);
-        target.begin(&mut self.connection, self.secure_download_mode).flashing()?;
+        target
+            .begin(&mut self.connection, self.secure_download_mode)
+            .flashing()?;
         Ok(())
     }
 
@@ -764,7 +765,9 @@ impl Flasher {
                 .into_target()
                 .max_ram_block_size(&mut self.connection)?,
         );
-        ram_target.begin(&mut self.connection, self.secure_download_mode).flashing()?;
+        ram_target
+            .begin(&mut self.connection, self.secure_download_mode)
+            .flashing()?;
 
         let (text_addr, text) = stub.text();
         debug!("Write {} byte stub text", text.len());
@@ -995,13 +998,13 @@ impl Flasher {
         let chip = self.chip();
         let target = chip.into_target();
 
-        // chip_revision reads from efuse, which is not possible in Secure Download Mode        
+        // chip_revision reads from efuse, which is not possible in Secure Download Mode
         let revision = if !self.secure_download_mode {
             Some(target.chip_revision(self.connection())?)
         } else {
             None
         };
-    
+
         let crystal_frequency = target.crystal_freq(self.connection())?;
         let features = target
             .chip_features(self.connection())?
@@ -1046,7 +1049,9 @@ impl Flasher {
                 .into_target()
                 .max_ram_block_size(&mut self.connection)?,
         );
-        target.begin(&mut self.connection, self.secure_download_mode).flashing()?;
+        target
+            .begin(&mut self.connection, self.secure_download_mode)
+            .flashing()?;
 
         for segment in ram_segments(self.chip, &elf) {
             target
@@ -1068,7 +1073,9 @@ impl Flasher {
         let mut target =
             self.chip
                 .flash_target(self.spi_params, self.use_stub, self.verify, self.skip);
-        target.begin(&mut self.connection, self.secure_download_mode).flashing()?;
+        target
+            .begin(&mut self.connection, self.secure_download_mode)
+            .flashing()?;
 
         let chip_revision = Some(
             self.chip
@@ -1124,8 +1131,10 @@ impl Flasher {
             .chip
             .flash_target(self.spi_params, self.use_stub, false, false);
 
-        target.begin(&mut self.connection, self.secure_download_mode).flashing()?;
-        
+        target
+            .begin(&mut self.connection, self.secure_download_mode)
+            .flashing()?;
+
         for segment in segments {
             if self.secure_download_mode {
                 target.write_segment_sdm(&mut self.connection, segment.borrow(), &mut progress)?;
@@ -1133,7 +1142,7 @@ impl Flasher {
                 target.write_segment(&mut self.connection, segment.borrow(), &mut progress)?;
             }
         }
-        
+
         target.finish(&mut self.connection, true).flashing()?;
 
         Ok(())

--- a/espflash/src/targets/flash_target/esp32.rs
+++ b/espflash/src/targets/flash_target/esp32.rs
@@ -55,15 +55,20 @@ impl Esp32Target {
 
 #[cfg(feature = "serialport")]
 impl FlashTarget for Esp32Target {
-    fn begin(&mut self, connection: &mut Connection) -> Result<(), Error> {
+    fn begin(&mut self, connection: &mut Connection, secure_download_mode: bool) -> Result<(), Error> {
         connection.with_timeout(CommandType::SpiAttach.timeout(), |connection| {
             let command = if self.use_stub {
                 Command::SpiAttachStub {
                     spi_params: self.spi_attach_params,
                 }
             } else {
-                Command::SpiAttach {
-                    spi_params: self.spi_attach_params,
+                if secure_download_mode {
+                    Command::SpiAttach { 
+                        spi_params: SpiAttachParams::default()}
+                } else {
+                    Command::SpiAttach {
+                        spi_params: self.spi_attach_params,
+                    }
                 }
             };
 
@@ -140,112 +145,170 @@ impl FlashTarget for Esp32Target {
         connection: &mut Connection,
         segment: Segment<'_>,
         progress: &mut Option<&mut dyn ProgressCallbacks>,
+        secure_download_mode: bool,
     ) -> Result<(), Error> {
         let addr = segment.addr;
 
-        let mut md5_hasher = Md5::new();
-        md5_hasher.update(&segment.data);
-        let checksum_md5 = md5_hasher.finalize();
+        if !secure_download_mode {
+            let mut md5_hasher = Md5::new();
+            md5_hasher.update(&segment.data);
+            let checksum_md5 = md5_hasher.finalize();
 
-        if self.skip {
-            let flash_checksum_md5: u128 =
-                connection.with_timeout(CommandType::FlashMd5.timeout(), |connection| {
-                    connection
-                        .command(Command::FlashMd5 {
-                            offset: addr,
-                            size: segment.data.len() as u32,
-                        })?
-                        .try_into()
-                })?;
+            if self.skip {
+                let flash_checksum_md5: u128 =
+                    connection.with_timeout(CommandType::FlashMd5.timeout(), |connection| {
+                        connection
+                            .command(Command::FlashMd5 {
+                                offset: addr,
+                                size: segment.data.len() as u32,
+                            })?
+                            .try_into()
+                    })?;
 
-            if checksum_md5.as_slice() == flash_checksum_md5.to_be_bytes() {
-                info!(
-                    "Segment at address '0x{:x}' has not changed, skipping write",
-                    addr
-                );
-                return Ok(());
+                if checksum_md5.as_slice() == flash_checksum_md5.to_be_bytes() {
+                    info!(
+                        "Segment at address '0x{:x}' has not changed, skipping write",
+                        addr
+                    );
+                    return Ok(());
+                }
             }
-        }
 
-        let mut encoder = ZlibEncoder::new(Vec::new(), Compression::best());
-        encoder.write_all(&segment.data)?;
-        let compressed = encoder.finish()?;
+            let mut encoder = ZlibEncoder::new(Vec::new(), Compression::best());
+            encoder.write_all(&segment.data)?;
+            let compressed = encoder.finish()?;
 
-        let target = self.chip.into_target();
-        let flash_write_size = target.flash_write_size(connection)?;
-        let block_count = compressed.len().div_ceil(flash_write_size);
-        let erase_count = segment.data.len().div_ceil(FLASH_SECTOR_SIZE);
+            let target = self.chip.into_target();
+            let flash_write_size = target.flash_write_size(connection)?;
+            let block_count = compressed.len().div_ceil(flash_write_size);
+            let erase_count = segment.data.len().div_ceil(FLASH_SECTOR_SIZE);
 
-        // round up to sector size
-        let erase_size = (erase_count * FLASH_SECTOR_SIZE) as u32;
-
-        connection.with_timeout(
-            CommandType::FlashDeflBegin.timeout_for_size(erase_size),
-            |connection| {
-                connection.command(Command::FlashDeflBegin {
-                    size: segment.data.len() as u32,
-                    blocks: block_count as u32,
-                    block_size: flash_write_size as u32,
-                    offset: addr,
-                    supports_encryption: self.chip != Chip::Esp32 && !self.use_stub,
-                })?;
-                Ok(())
-            },
-        )?;
-        self.need_deflate_end = true;
-
-        let chunks = compressed.chunks(flash_write_size);
-        let num_chunks = chunks.len();
-
-        if let Some(cb) = progress.as_mut() {
-            cb.init(addr, num_chunks)
-        }
-
-        // decode the chunks to see how much data the device will have to save
-        let mut decoder = ZlibDecoder::new(Vec::new());
-        let mut decoded_size = 0;
-
-        for (i, block) in chunks.enumerate() {
-            decoder.write_all(block)?;
-            decoder.flush()?;
-            let size = decoder.get_ref().len() - decoded_size;
-            decoded_size = decoder.get_ref().len();
+            // round up to sector size
+            let erase_size = (erase_count * FLASH_SECTOR_SIZE) as u32;
 
             connection.with_timeout(
-                CommandType::FlashDeflData.timeout_for_size(size as u32),
+                CommandType::FlashDeflBegin.timeout_for_size(erase_size),
                 |connection| {
-                    connection.command(Command::FlashDeflData {
-                        sequence: i as u32,
-                        pad_to: 0,
-                        pad_byte: 0xff,
-                        data: block,
+                    connection.command(Command::FlashDeflBegin {
+                        size: segment.data.len() as u32,
+                        blocks: block_count as u32,
+                        block_size: flash_write_size as u32,
+                        offset: addr,
+                        supports_encryption: self.chip != Chip::Esp32 && !self.use_stub,
+                    })?;
+                    Ok(())
+                },
+            )?;
+            self.need_deflate_end = true;
+
+            let chunks = compressed.chunks(flash_write_size);
+            let num_chunks = chunks.len();
+
+            if let Some(cb) = progress.as_mut() {
+                cb.init(addr, num_chunks)
+            }
+
+            // decode the chunks to see how much data the device will have to save
+            let mut decoder = ZlibDecoder::new(Vec::new());
+            let mut decoded_size = 0;
+
+            for (i, block) in chunks.enumerate() {
+                decoder.write_all(block)?;
+                decoder.flush()?;
+                let size = decoder.get_ref().len() - decoded_size;
+                decoded_size = decoder.get_ref().len();
+
+                connection.with_timeout(
+                    CommandType::FlashDeflData.timeout_for_size(size as u32),
+                    |connection| {
+                        connection.command(Command::FlashDeflData {
+                            sequence: i as u32,
+                            pad_to: 0,
+                            pad_byte: 0xff,
+                            data: block,
+                        })?;
+                        Ok(())
+                    },
+                )?;
+
+                if let Some(cb) = progress.as_mut() {
+                    cb.update(i + 1)
+                }
+            }
+
+            if let Some(cb) = progress.as_mut() {
+                cb.finish()
+            }
+
+            if self.verify {
+                let flash_checksum_md5: u128 =
+                    connection.with_timeout(CommandType::FlashMd5.timeout(), |connection| {
+                        connection
+                            .command(Command::FlashMd5 {
+                                offset: addr,
+                                size: segment.data.len() as u32,
+                            })?
+                            .try_into()
+                    })?;
+
+                if checksum_md5.as_slice() != flash_checksum_md5.to_be_bytes() {
+                    return Err(Error::VerifyFailed);
+                }
+            }
+        } else {
+            let target = self.chip.into_target();
+            let flash_write_size = target.flash_write_size(connection)?;
+            let block_count = segment.data.len().div_ceil(flash_write_size);
+
+            connection.with_timeout(
+                CommandType::FlashBegin.timeout_for_size(segment.data.len() as u32),
+                |connection| {
+                    connection.command(Command::FlashBegin {
+                        size: segment.data.len() as u32,
+                        blocks: block_count as u32,
+                        block_size: flash_write_size as u32,
+                        offset: addr,
+                        supports_encryption: false,
                     })?;
                     Ok(())
                 },
             )?;
 
-            if let Some(cb) = progress.as_mut() {
-                cb.update(i + 1)
-            }
-        }
+            let mut attempt = 0;
 
-        if let Some(cb) = progress.as_mut() {
-            cb.finish()
-        }
+            let mut remaining_data = &segment.data[..];  
 
-        if self.verify {
-            let flash_checksum_md5: u128 =
-                connection.with_timeout(CommandType::FlashMd5.timeout(), |connection| {
-                    connection
-                        .command(Command::FlashMd5 {
-                            offset: addr,
-                            size: segment.data.len() as u32,
-                        })?
-                        .try_into()
-                })?;
-
-            if checksum_md5.as_slice() != flash_checksum_md5.to_be_bytes() {
-                return Err(Error::VerifyFailed);
+            while !remaining_data.is_empty() {
+                attempt += 1;
+            
+                let block_size = std::cmp::min(flash_write_size, remaining_data.len());
+                let block = &remaining_data[..block_size];
+            
+                let padding_needed = flash_write_size.saturating_sub(block.len());
+            
+                let block_vec = if padding_needed > 0 {
+                    let mut owned = block.to_vec();
+                    owned.extend(std::iter::repeat(0xFF).take(padding_needed));
+                    owned
+                } else {
+                    block.to_vec()
+                };
+                
+                connection.with_timeout(
+                    CommandType::FlashData.timeout_for_size(remaining_data.len() as u32),
+                    |connection| {
+                        connection.command(Command::FlashData {
+                            data: &block_vec,
+                            pad_to: 0,
+                            pad_byte: 0,
+                            sequence: attempt,
+                        })?;
+                        Ok(())
+                    },
+                )?;
+                
+                // Advance our view into the data without modifying the original
+                remaining_data = &remaining_data[block_size..];
             }
         }
 

--- a/espflash/src/targets/flash_target/esp32.rs
+++ b/espflash/src/targets/flash_target/esp32.rs
@@ -140,175 +140,194 @@ impl FlashTarget for Esp32Target {
         Ok(())
     }
 
+    fn write_segment_sdm(
+        &mut self,
+        connection: &mut Connection,
+        segment: Segment<'_>,
+        progress: &mut Option<&mut dyn ProgressCallbacks>,
+    ) -> Result<(), Error> {
+        let addr = segment.addr;
+
+        let target = self.chip.into_target();
+        let flash_write_size = target.flash_write_size(connection)?;
+        let block_count = segment.data.len().div_ceil(flash_write_size);
+
+        connection.with_timeout(
+            CommandType::FlashBegin.timeout_for_size(segment.data.len() as u32),
+            |connection| {
+                connection.command(Command::FlashBegin {
+                    size: segment.data.len() as u32,
+                    blocks: block_count as u32,
+                    block_size: flash_write_size as u32,
+                    offset: addr,
+                    supports_encryption: false,
+                })?;
+                Ok(())
+            },
+        )?;
+
+        if let Some(cb) = progress.as_mut() {
+            cb.init(addr, block_count)
+        }
+
+        let mut remaining_data = &segment.data[..];
+
+        for i in 0.. {
+            if remaining_data.is_empty() {
+                break;
+            }
+        
+            let block_size = std::cmp::min(flash_write_size, remaining_data.len());
+            let block = &remaining_data[..block_size];
+        
+            let padding_needed = flash_write_size.saturating_sub(block.len());
+        
+            let block_vec = if padding_needed > 0 {
+                let mut owned = block.to_vec();
+                owned.extend(std::iter::repeat(0xFF).take(padding_needed));
+                owned
+            } else {
+                block.to_vec()
+            };
+            
+            connection.with_timeout(
+                CommandType::FlashData.timeout_for_size(remaining_data.len() as u32),
+                |connection| {
+                    connection.command(Command::FlashData {
+                        data: &block_vec,
+                        pad_to: 0,
+                        pad_byte: 0,
+                        sequence: i,
+                    })?;
+                    Ok(())
+                },
+            )?;
+            
+            remaining_data = &remaining_data[block_size..];
+
+            if let Some(cb) = progress.as_mut() {
+                cb.update(i as usize + 1)
+            }
+        }
+
+        if let Some(cb) = progress.as_mut() {
+            cb.finish()
+        }
+
+        Ok(())
+    }
+
     fn write_segment(
         &mut self,
         connection: &mut Connection,
         segment: Segment<'_>,
         progress: &mut Option<&mut dyn ProgressCallbacks>,
-        secure_download_mode: bool,
     ) -> Result<(), Error> {
         let addr = segment.addr;
 
-        if !secure_download_mode {
-            let mut md5_hasher = Md5::new();
-            md5_hasher.update(&segment.data);
-            let checksum_md5 = md5_hasher.finalize();
+        let mut md5_hasher = Md5::new();
+        md5_hasher.update(&segment.data);
+        let checksum_md5 = md5_hasher.finalize();
 
-            if self.skip {
-                let flash_checksum_md5: u128 =
-                    connection.with_timeout(CommandType::FlashMd5.timeout(), |connection| {
-                        connection
-                            .command(Command::FlashMd5 {
-                                offset: addr,
-                                size: segment.data.len() as u32,
-                            })?
-                            .try_into()
-                    })?;
+        if self.skip {
+            let flash_checksum_md5: u128 =
+                connection.with_timeout(CommandType::FlashMd5.timeout(), |connection| {
+                    connection
+                        .command(Command::FlashMd5 {
+                            offset: addr,
+                            size: segment.data.len() as u32,
+                        })?
+                        .try_into()
+                })?;
 
-                if checksum_md5.as_slice() == flash_checksum_md5.to_be_bytes() {
-                    info!(
-                        "Segment at address '0x{:x}' has not changed, skipping write",
-                        addr
-                    );
-                    return Ok(());
-                }
+            if checksum_md5.as_slice() == flash_checksum_md5.to_be_bytes() {
+                info!(
+                    "Segment at address '0x{:x}' has not changed, skipping write",
+                    addr
+                );
+                return Ok(());
             }
+        }
 
-            let mut encoder = ZlibEncoder::new(Vec::new(), Compression::best());
-            encoder.write_all(&segment.data)?;
-            let compressed = encoder.finish()?;
+        let mut encoder = ZlibEncoder::new(Vec::new(), Compression::best());
+        encoder.write_all(&segment.data)?;
+        let compressed = encoder.finish()?;
 
-            let target = self.chip.into_target();
-            let flash_write_size = target.flash_write_size(connection)?;
-            let block_count = compressed.len().div_ceil(flash_write_size);
-            let erase_count = segment.data.len().div_ceil(FLASH_SECTOR_SIZE);
+        let target = self.chip.into_target();
+        let flash_write_size = target.flash_write_size(connection)?;
+        let block_count = compressed.len().div_ceil(flash_write_size);
+        let erase_count = segment.data.len().div_ceil(FLASH_SECTOR_SIZE);
 
-            // round up to sector size
-            let erase_size = (erase_count * FLASH_SECTOR_SIZE) as u32;
+        // round up to sector size
+        let erase_size = (erase_count * FLASH_SECTOR_SIZE) as u32;
+
+        connection.with_timeout(
+            CommandType::FlashDeflBegin.timeout_for_size(erase_size),
+            |connection| {
+                connection.command(Command::FlashDeflBegin {
+                    size: segment.data.len() as u32,
+                    blocks: block_count as u32,
+                    block_size: flash_write_size as u32,
+                    offset: addr,
+                    supports_encryption: self.chip != Chip::Esp32 && !self.use_stub,
+                })?;
+                Ok(())
+            },
+        )?;
+        self.need_deflate_end = true;
+
+        let chunks = compressed.chunks(flash_write_size);
+        let num_chunks = chunks.len();
+
+        if let Some(cb) = progress.as_mut() {
+            cb.init(addr, num_chunks)
+        }
+
+        // decode the chunks to see how much data the device will have to save
+        let mut decoder = ZlibDecoder::new(Vec::new());
+        let mut decoded_size = 0;
+
+        for (i, block) in chunks.enumerate() {
+            decoder.write_all(block)?;
+            decoder.flush()?;
+            let size = decoder.get_ref().len() - decoded_size;
+            decoded_size = decoder.get_ref().len();
 
             connection.with_timeout(
-                CommandType::FlashDeflBegin.timeout_for_size(erase_size),
+                CommandType::FlashDeflData.timeout_for_size(size as u32),
                 |connection| {
-                    connection.command(Command::FlashDeflBegin {
-                        size: segment.data.len() as u32,
-                        blocks: block_count as u32,
-                        block_size: flash_write_size as u32,
-                        offset: addr,
-                        supports_encryption: self.chip != Chip::Esp32 && !self.use_stub,
-                    })?;
-                    Ok(())
-                },
-            )?;
-            self.need_deflate_end = true;
-
-            let chunks = compressed.chunks(flash_write_size);
-            let num_chunks = chunks.len();
-
-            if let Some(cb) = progress.as_mut() {
-                cb.init(addr, num_chunks)
-            }
-
-            // decode the chunks to see how much data the device will have to save
-            let mut decoder = ZlibDecoder::new(Vec::new());
-            let mut decoded_size = 0;
-
-            for (i, block) in chunks.enumerate() {
-                decoder.write_all(block)?;
-                decoder.flush()?;
-                let size = decoder.get_ref().len() - decoded_size;
-                decoded_size = decoder.get_ref().len();
-
-                connection.with_timeout(
-                    CommandType::FlashDeflData.timeout_for_size(size as u32),
-                    |connection| {
-                        connection.command(Command::FlashDeflData {
-                            sequence: i as u32,
-                            pad_to: 0,
-                            pad_byte: 0xff,
-                            data: block,
-                        })?;
-                        Ok(())
-                    },
-                )?;
-
-                if let Some(cb) = progress.as_mut() {
-                    cb.update(i + 1)
-                }
-            }
-
-            if let Some(cb) = progress.as_mut() {
-                cb.finish()
-            }
-
-            if self.verify {
-                let flash_checksum_md5: u128 =
-                    connection.with_timeout(CommandType::FlashMd5.timeout(), |connection| {
-                        connection
-                            .command(Command::FlashMd5 {
-                                offset: addr,
-                                size: segment.data.len() as u32,
-                            })?
-                            .try_into()
-                    })?;
-
-                if checksum_md5.as_slice() != flash_checksum_md5.to_be_bytes() {
-                    return Err(Error::VerifyFailed);
-                }
-            }
-        } else {
-            let target = self.chip.into_target();
-            let flash_write_size = target.flash_write_size(connection)?;
-            let block_count = segment.data.len().div_ceil(flash_write_size);
-
-            connection.with_timeout(
-                CommandType::FlashBegin.timeout_for_size(segment.data.len() as u32),
-                |connection| {
-                    connection.command(Command::FlashBegin {
-                        size: segment.data.len() as u32,
-                        blocks: block_count as u32,
-                        block_size: flash_write_size as u32,
-                        offset: addr,
-                        supports_encryption: false,
+                    connection.command(Command::FlashDeflData {
+                        sequence: i as u32,
+                        pad_to: 0,
+                        pad_byte: 0xff,
+                        data: block,
                     })?;
                     Ok(())
                 },
             )?;
 
-            let mut attempt = 0;
+            if let Some(cb) = progress.as_mut() {
+                cb.update(i + 1)
+            }
+        }
 
-            let mut remaining_data = &segment.data[..];  
+        if let Some(cb) = progress.as_mut() {
+            cb.finish()
+        }
 
-            while !remaining_data.is_empty() {
-                attempt += 1;
-            
-                let block_size = std::cmp::min(flash_write_size, remaining_data.len());
-                let block = &remaining_data[..block_size];
-            
-                let padding_needed = flash_write_size.saturating_sub(block.len());
-            
-                let block_vec = if padding_needed > 0 {
-                    let mut owned = block.to_vec();
-                    owned.extend(std::iter::repeat(0xFF).take(padding_needed));
-                    owned
-                } else {
-                    block.to_vec()
-                };
-                
-                connection.with_timeout(
-                    CommandType::FlashData.timeout_for_size(remaining_data.len() as u32),
-                    |connection| {
-                        connection.command(Command::FlashData {
-                            data: &block_vec,
-                            pad_to: 0,
-                            pad_byte: 0,
-                            sequence: attempt,
-                        })?;
-                        Ok(())
-                    },
-                )?;
-                
-                // Advance our view into the data without modifying the original
-                remaining_data = &remaining_data[block_size..];
+        if self.verify {
+            let flash_checksum_md5: u128 =
+                connection.with_timeout(CommandType::FlashMd5.timeout(), |connection| {
+                    connection
+                        .command(Command::FlashMd5 {
+                            offset: addr,
+                            size: segment.data.len() as u32,
+                        })?
+                        .try_into()
+                })?;
+
+            if checksum_md5.as_slice() != flash_checksum_md5.to_be_bytes() {
+                return Err(Error::VerifyFailed);
             }
         }
 

--- a/espflash/src/targets/flash_target/esp32.rs
+++ b/espflash/src/targets/flash_target/esp32.rs
@@ -55,7 +55,11 @@ impl Esp32Target {
 
 #[cfg(feature = "serialport")]
 impl FlashTarget for Esp32Target {
-    fn begin(&mut self, connection: &mut Connection, secure_download_mode: bool) -> Result<(), Error> {
+    fn begin(
+        &mut self,
+        connection: &mut Connection,
+        secure_download_mode: bool,
+    ) -> Result<(), Error> {
         connection.with_timeout(CommandType::SpiAttach.timeout(), |connection| {
             let command = if self.use_stub {
                 Command::SpiAttachStub {
@@ -63,8 +67,9 @@ impl FlashTarget for Esp32Target {
                 }
             } else {
                 if secure_download_mode {
-                    Command::SpiAttach { 
-                        spi_params: SpiAttachParams::default()}
+                    Command::SpiAttach {
+                        spi_params: SpiAttachParams::default(),
+                    }
                 } else {
                     Command::SpiAttach {
                         spi_params: self.spi_attach_params,
@@ -176,12 +181,12 @@ impl FlashTarget for Esp32Target {
             if remaining_data.is_empty() {
                 break;
             }
-        
+
             let block_size = std::cmp::min(flash_write_size, remaining_data.len());
             let block = &remaining_data[..block_size];
-        
+
             let padding_needed = flash_write_size.saturating_sub(block.len());
-        
+
             let block_vec = if padding_needed > 0 {
                 let mut owned = block.to_vec();
                 owned.extend(std::iter::repeat(0xFF).take(padding_needed));
@@ -189,7 +194,7 @@ impl FlashTarget for Esp32Target {
             } else {
                 block.to_vec()
             };
-            
+
             connection.with_timeout(
                 CommandType::FlashData.timeout_for_size(remaining_data.len() as u32),
                 |connection| {
@@ -202,7 +207,7 @@ impl FlashTarget for Esp32Target {
                     Ok(())
                 },
             )?;
-            
+
             remaining_data = &remaining_data[block_size..];
 
             if let Some(cb) = progress.as_mut() {

--- a/espflash/src/targets/flash_target/esp32.rs
+++ b/espflash/src/targets/flash_target/esp32.rs
@@ -55,18 +55,14 @@ impl Esp32Target {
 
 #[cfg(feature = "serialport")]
 impl FlashTarget for Esp32Target {
-    fn begin(
-        &mut self,
-        connection: &mut Connection,
-        secure_download_mode: bool,
-    ) -> Result<(), Error> {
+    fn begin(&mut self, connection: &mut Connection) -> Result<(), Error> {
         connection.with_timeout(CommandType::SpiAttach.timeout(), |connection| {
             let command = if self.use_stub {
                 Command::SpiAttachStub {
                     spi_params: self.spi_attach_params,
                 }
             } else {
-                if secure_download_mode {
+                if connection.secure_download_mode {
                     Command::SpiAttach {
                         spi_params: SpiAttachParams::default(),
                     }

--- a/espflash/src/targets/flash_target/mod.rs
+++ b/espflash/src/targets/flash_target/mod.rs
@@ -18,7 +18,11 @@ pub trait ProgressCallbacks {
 /// Operations for interacting with a flash target
 pub trait FlashTarget {
     /// Begin the flashing operation
-    fn begin(&mut self, connection: &mut Connection, secure_download_mode: bool) -> Result<(), Error>;
+    fn begin(
+        &mut self,
+        connection: &mut Connection,
+        secure_download_mode: bool,
+    ) -> Result<(), Error>;
 
     /// Write a segment to the target device
     fn write_segment(
@@ -28,8 +32,8 @@ pub trait FlashTarget {
         progress: &mut Option<&mut dyn ProgressCallbacks>,
     ) -> Result<(), Error>;
 
-     /// Write a segment to the target device in SDM mode
-     fn write_segment_sdm(
+    /// Write a segment to the target device in SDM mode
+    fn write_segment_sdm(
         &mut self,
         connection: &mut Connection,
         segment: Segment<'_>,

--- a/espflash/src/targets/flash_target/mod.rs
+++ b/espflash/src/targets/flash_target/mod.rs
@@ -26,7 +26,14 @@ pub trait FlashTarget {
         connection: &mut Connection,
         segment: Segment<'_>,
         progress: &mut Option<&mut dyn ProgressCallbacks>,
-        secure_download_mode: bool,
+    ) -> Result<(), Error>;
+
+     /// Write a segment to the target device in SDM mode
+     fn write_segment_sdm(
+        &mut self,
+        connection: &mut Connection,
+        segment: Segment<'_>,
+        progress: &mut Option<&mut dyn ProgressCallbacks>,
     ) -> Result<(), Error>;
 
     /// Complete the flashing operation

--- a/espflash/src/targets/flash_target/mod.rs
+++ b/espflash/src/targets/flash_target/mod.rs
@@ -18,11 +18,7 @@ pub trait ProgressCallbacks {
 /// Operations for interacting with a flash target
 pub trait FlashTarget {
     /// Begin the flashing operation
-    fn begin(
-        &mut self,
-        connection: &mut Connection,
-        secure_download_mode: bool,
-    ) -> Result<(), Error>;
+    fn begin(&mut self, connection: &mut Connection) -> Result<(), Error>;
 
     /// Write a segment to the target device
     fn write_segment(

--- a/espflash/src/targets/flash_target/mod.rs
+++ b/espflash/src/targets/flash_target/mod.rs
@@ -18,7 +18,7 @@ pub trait ProgressCallbacks {
 /// Operations for interacting with a flash target
 pub trait FlashTarget {
     /// Begin the flashing operation
-    fn begin(&mut self, connection: &mut Connection) -> Result<(), Error>;
+    fn begin(&mut self, connection: &mut Connection, secure_download_mode: bool) -> Result<(), Error>;
 
     /// Write a segment to the target device
     fn write_segment(
@@ -26,6 +26,7 @@ pub trait FlashTarget {
         connection: &mut Connection,
         segment: Segment<'_>,
         progress: &mut Option<&mut dyn ProgressCallbacks>,
+        secure_download_mode: bool,
     ) -> Result<(), Error>;
 
     /// Complete the flashing operation

--- a/espflash/src/targets/flash_target/ram.rs
+++ b/espflash/src/targets/flash_target/ram.rs
@@ -36,12 +36,20 @@ impl FlashTarget for RamTarget {
         Ok(())
     }
 
+    fn write_segment_sdm(
+            &mut self,
+            _connection: &mut Connection,
+            _segment: Segment<'_>,
+            _progress: &mut Option<&mut dyn ProgressCallbacks>,
+        ) -> Result<(), Error> {
+        todo!()
+    }
+
     fn write_segment(
         &mut self,
         connection: &mut Connection,
         segment: Segment<'_>,
         progress: &mut Option<&mut dyn ProgressCallbacks>,
-        _secure_download_mode: bool,
     ) -> Result<(), Error> {
         let addr = segment.addr;
 

--- a/espflash/src/targets/flash_target/ram.rs
+++ b/espflash/src/targets/flash_target/ram.rs
@@ -32,7 +32,7 @@ impl Default for RamTarget {
 
 #[cfg(feature = "serialport")]
 impl FlashTarget for RamTarget {
-    fn begin(&mut self, _connection: &mut Connection) -> Result<(), Error> {
+    fn begin(&mut self, _connection: &mut Connection, _secure_download_mode: bool) -> Result<(), Error> {
         Ok(())
     }
 
@@ -41,6 +41,7 @@ impl FlashTarget for RamTarget {
         connection: &mut Connection,
         segment: Segment<'_>,
         progress: &mut Option<&mut dyn ProgressCallbacks>,
+        _secure_download_mode: bool,
     ) -> Result<(), Error> {
         let addr = segment.addr;
 

--- a/espflash/src/targets/flash_target/ram.rs
+++ b/espflash/src/targets/flash_target/ram.rs
@@ -32,16 +32,20 @@ impl Default for RamTarget {
 
 #[cfg(feature = "serialport")]
 impl FlashTarget for RamTarget {
-    fn begin(&mut self, _connection: &mut Connection, _secure_download_mode: bool) -> Result<(), Error> {
+    fn begin(
+        &mut self,
+        _connection: &mut Connection,
+        _secure_download_mode: bool,
+    ) -> Result<(), Error> {
         Ok(())
     }
 
     fn write_segment_sdm(
-            &mut self,
-            _connection: &mut Connection,
-            _segment: Segment<'_>,
-            _progress: &mut Option<&mut dyn ProgressCallbacks>,
-        ) -> Result<(), Error> {
+        &mut self,
+        _connection: &mut Connection,
+        _segment: Segment<'_>,
+        _progress: &mut Option<&mut dyn ProgressCallbacks>,
+    ) -> Result<(), Error> {
         todo!()
     }
 

--- a/espflash/src/targets/flash_target/ram.rs
+++ b/espflash/src/targets/flash_target/ram.rs
@@ -32,11 +32,7 @@ impl Default for RamTarget {
 
 #[cfg(feature = "serialport")]
 impl FlashTarget for RamTarget {
-    fn begin(
-        &mut self,
-        _connection: &mut Connection,
-        _secure_download_mode: bool,
-    ) -> Result<(), Error> {
+    fn begin(&mut self, _connection: &mut Connection) -> Result<(), Error> {
         Ok(())
     }
 


### PR DESCRIPTION
closes https://github.com/esp-rs/espflash/issues/726

Initial issue contains just a little bit of lie: espflash didn't work with SDM almost at all 😅 
After this is merged, at least board-info and write-bin (mentioned in the original issue) functions will be supported.

No extra flags are needed, user will be able to just execute:
`espflash write-bin 0x0 --monitor <bin-name>`

I recommend setting a higher baudrate as otherwise flashing in SDM takes a lot of time.
Also, `--no-stub` is applied automatically when tool detects that connected chip is in SDM mode. 
