### PR TITLE
Add no_std support w/ alloc & embedded-io

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -282,7 +282,7 @@ checksum = "3fa76293b4f7bb636ab88fd78228235b5248b4d05cc589aed610f954af5d7c7a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn",
 ]
 
 [[package]]
@@ -384,7 +384,7 @@ dependencies = [
  "thiserror 1.0.69",
  "time",
  "toml",
- "toml_edit 0.22.22",
+ "toml_edit",
  "tracing",
  "tracing-chrome",
  "tracing-subscriber",
@@ -569,7 +569,7 @@ dependencies = [
  "anstream",
  "anstyle",
  "clap_lex",
- "strsim 0.11.1",
+ "strsim",
  "terminal_size",
 ]
 
@@ -594,7 +594,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn",
 ]
 
 [[package]]
@@ -627,7 +627,7 @@ dependencies = [
  "nom",
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn",
 ]
 
 [[package]]
@@ -891,9 +891,9 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.14.4"
+version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b750cb3417fd1b327431a470f388520309479ab0bf5e323505daf0290cd3850"
+checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
 dependencies = [
  "darling_core",
  "darling_macro",
@@ -901,27 +901,27 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.14.4"
+version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "109c1ca6e6b7f82cc233a97004ea8ed7ca123a9af07a8230878fcfda9b158bf0"
+checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
 dependencies = [
  "fnv",
  "ident_case",
  "proc-macro2",
  "quote",
- "strsim 0.10.0",
- "syn 1.0.109",
+ "strsim",
+ "syn",
 ]
 
 [[package]]
 name = "darling_macro"
-version = "0.14.4"
+version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4aab4dbc9f7611d8b55048a3a16d2d010c2c8334e46304b40ac1cc14bf3b48e"
+checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
  "darling_core",
  "quote",
- "syn 1.0.109",
+ "syn",
 ]
 
 [[package]]
@@ -980,25 +980,27 @@ dependencies = [
 
 [[package]]
 name = "deku"
-version = "0.16.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "819b87cc7a05b3abe3fc38e59b3980a5fd3162f25a247116441a9171d3e84481"
+checksum = "709ade444d53896e60f6265660eb50480dd08b77bfc822e5dcc233b88b0b2fba"
 dependencies = [
  "bitvec",
  "deku_derive",
+ "no_std_io",
+ "rustversion",
 ]
 
 [[package]]
 name = "deku_derive"
-version = "0.16.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e2ca12572239215a352a74ad7c776d7e8a914f8a23511c6cbedddd887e5009e"
+checksum = "d7534973f93f9de83203e41c8ddd32d230599fa73fa889f3deb1580ccd186913"
 dependencies = [
  "darling",
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn",
 ]
 
 [[package]]
@@ -1076,7 +1078,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn",
 ]
 
 [[package]]
@@ -1139,6 +1141,21 @@ dependencies = [
  "sec1",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "embedded-io"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
+
+[[package]]
+name = "embedded-io-adapters"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b03facd2b544d24916f312a6026c1b548b8af012f788a554d498afdc8ef9c775"
+dependencies = [
+ "embedded-io",
 ]
 
 [[package]]
@@ -1208,19 +1225,16 @@ dependencies = [
 [[package]]
 name = "esp-idf-part"
 version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59f50b6c32370067087b46087cd5333f2dfe678f0b01223fa70fde6f15449844"
 dependencies = [
  "csv",
  "deku",
- "heapless",
- "md5",
+ "md-5",
  "parse_int",
  "regex",
  "serde",
  "serde_plain",
  "strum",
- "thiserror 1.0.69",
+ "thiserror 2.0.10",
 ]
 
 [[package]]
@@ -1239,9 +1253,12 @@ dependencies = [
  "defmt-decoder",
  "dialoguer",
  "directories",
+ "embedded-io",
+ "embedded-io-adapters",
  "env_logger",
  "esp-idf-part",
  "flate2",
+ "heapless",
  "indicatif",
  "libc",
  "log",
@@ -1558,7 +1575,7 @@ dependencies = [
  "gix-utils",
  "itoa",
  "thiserror 2.0.10",
- "winnow 0.6.22",
+ "winnow",
 ]
 
 [[package]]
@@ -1640,7 +1657,7 @@ dependencies = [
  "smallvec",
  "thiserror 2.0.10",
  "unicode-bom",
- "winnow 0.6.22",
+ "winnow",
 ]
 
 [[package]]
@@ -1906,7 +1923,7 @@ dependencies = [
  "itoa",
  "smallvec",
  "thiserror 2.0.10",
- "winnow 0.6.22",
+ "winnow",
 ]
 
 [[package]]
@@ -2038,7 +2055,7 @@ dependencies = [
  "gix-utils",
  "maybe-async",
  "thiserror 2.0.10",
- "winnow 0.6.22",
+ "winnow",
 ]
 
 [[package]]
@@ -2070,7 +2087,7 @@ dependencies = [
  "gix-validate",
  "memmap2",
  "thiserror 2.0.10",
- "winnow 0.6.22",
+ "winnow",
 ]
 
 [[package]]
@@ -2336,7 +2353,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bfb9eb618601c89945a70e254898da93b13be0388091d42117462b265bb3fad"
 dependencies = [
  "hash32",
- "serde",
  "stable_deref_trait",
 ]
 
@@ -2605,7 +2621,7 @@ checksum = "1ec89e9337638ecdc08744df490b221a7399bf8d164eb52a665454e60e075ad6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn",
 ]
 
 [[package]]
@@ -2964,7 +2980,7 @@ checksum = "5cf92c10c7e361d6b99666ec1c6f9805b0bea2c3bd8c78dc6fe98ac5bd78db11"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn",
 ]
 
 [[package]]
@@ -2976,12 +2992,6 @@ dependencies = [
  "cfg-if",
  "digest",
 ]
-
-[[package]]
-name = "md5"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "490cc448043f947bae3cbee9c203358d62dbee0db12107a74be5c30ccfd09771"
 
 [[package]]
 name = "memchr"
@@ -3026,7 +3036,7 @@ checksum = "23c9b935fbe1d6cbd1dac857b54a688145e2d93f48db36010514d0f612d0ad67"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn",
 ]
 
 [[package]]
@@ -3092,6 +3102,15 @@ dependencies = [
  "cfg-if",
  "cfg_aliases",
  "libc",
+]
+
+[[package]]
+name = "no_std_io"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fa5f306a6f2c01b4fd172f29bb46195b1764061bf926c75e96ff55df3178208"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -3205,7 +3224,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn",
 ]
 
 [[package]]
@@ -3439,12 +3458,11 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-crate"
-version = "1.3.1"
+version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f4c021e1093a56626774e81216a4ce732a735e5bad4868a03f3ed65ca0c3919"
+checksum = "8ecf48c7ca261d60b74ab1a7b20da18bede46776b2e55535cb958eb595c5fa7b"
 dependencies = [
- "once_cell",
- "toml_edit 0.19.15",
+ "toml_edit",
 ]
 
 [[package]]
@@ -3935,7 +3953,7 @@ checksum = "5a9bf7cf98d04a2b28aead066b7496853d4779c9cc183c440dbac457641e19a0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn",
 ]
 
 [[package]]
@@ -4173,12 +4191,6 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "strsim"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
-
-[[package]]
-name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
@@ -4202,7 +4214,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.96",
+ "syn",
 ]
 
 [[package]]
@@ -4234,17 +4246,6 @@ checksum = "b7401a30af6cb5818bb64852270bb722533397edcfc7344954a38f420819ece2"
 
 [[package]]
 name = "syn"
-version = "1.0.109"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
-dependencies = [
- "proc-macro2",
- "quote",
- "unicode-ident",
-]
-
-[[package]]
-name = "syn"
 version = "2.0.96"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d5d0adab1ae378d7f53bdebc67a39f1f151407ef230f0ce2883572f5d8985c80"
@@ -4271,7 +4272,7 @@ checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn",
 ]
 
 [[package]]
@@ -4350,7 +4351,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn",
 ]
 
 [[package]]
@@ -4361,7 +4362,7 @@ checksum = "9e9465d30713b56a37ede7185763c3492a91be2f5fa68d958c44e41ab9248beb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn",
 ]
 
 [[package]]
@@ -4464,7 +4465,7 @@ dependencies = [
  "serde",
  "serde_spanned",
  "toml_datetime",
- "toml_edit 0.22.22",
+ "toml_edit",
 ]
 
 [[package]]
@@ -4478,17 +4479,6 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.19.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
-dependencies = [
- "indexmap",
- "toml_datetime",
- "winnow 0.5.40",
-]
-
-[[package]]
-name = "toml_edit"
 version = "0.22.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ae48d6208a266e853d946088ed816055e556cc6028c5e8e2b84d9fa5dd7c7f5"
@@ -4497,7 +4487,7 @@ dependencies = [
  "serde",
  "serde_spanned",
  "toml_datetime",
- "winnow 0.6.22",
+ "winnow",
 ]
 
 [[package]]
@@ -4546,7 +4536,7 @@ checksum = "395ae124c09f9e6918a2310af6038fba074bcf474ac352496d5910dd59a2226d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn",
 ]
 
 [[package]]
@@ -4824,7 +4814,7 @@ dependencies = [
  "log",
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn",
  "wasm-bindgen-shared",
 ]
 
@@ -4859,7 +4849,7 @@ checksum = "30d7a95b763d3c45903ed6c81f156801839e5ee968bb07e534c44df0fcd330c2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -5110,15 +5100,6 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
-version = "0.5.40"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f593a95398737aeed53e489c785df13f3618e41dbcd6718c6addbf1395aa6876"
-dependencies = [
- "memchr",
-]
-
-[[package]]
-name = "winnow"
 version = "0.6.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39281189af81c07ec09db316b302a3e67bf9bd7cbf6c820b50e35fee9c2fa980"
@@ -5167,7 +5148,7 @@ checksum = "2380878cad4ac9aac1e2435f3eb4020e8374b5f13c296cb75b4620ff8e229154"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn",
  "synstructure",
 ]
 
@@ -5189,7 +5170,7 @@ checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn",
 ]
 
 [[package]]
@@ -5209,7 +5190,7 @@ checksum = "595eed982f7d355beb85837f651fa22e90b3c044842dc7f2c2842c086f295808"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn",
  "synstructure",
 ]
 
@@ -5238,5 +5219,5 @@ checksum = "6eafa6dfb17584ea3e2bd6e76e0cc15ad7af12b09abdd1ca55961bed9b1063c6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1225,6 +1225,7 @@ dependencies = [
 [[package]]
 name = "esp-idf-part"
 version = "0.5.0"
+source = "git+https://github.com/i404788/esp-idf-part.git#094ab03c1e99281e8de4e3e45dc5374b5ad89445"
 dependencies = [
  "csv",
  "deku",

--- a/espflash/Cargo.toml
+++ b/espflash/Cargo.toml
@@ -38,7 +38,7 @@ defmt-decoder   = { version = "=0.4.0", features = ["unstable"], optional = true
 dialoguer       = { version = "0.11.0", optional = true }
 directories     = { version = "5.0.1", optional = true }
 env_logger      = { version = "0.11.6", optional = true }
-esp-idf-part    = { path = "../../esp-idf-part", default-features = false }
+esp-idf-part    = { git = "https://github.com/i404788/esp-idf-part.git", default-features = false }
 flate2          = { version = "1.0.35", optional = true }
 indicatif       = { version = "0.17.9", optional = true }
 log             = "0.4.22"

--- a/espflash/Cargo.toml
+++ b/espflash/Cargo.toml
@@ -26,7 +26,7 @@ required-features = ["cli", "serialport"]
 
 [dependencies]
 addr2line       = { version = "0.24.2", optional = true }
-base64          = "0.22.1"
+base64          = { version = "0.22.1", default-features = false }
 bitflags        = "2.9.0"
 bytemuck        = { version = "1.21.0", features = ["derive"] }
 clap            = { version = "4.5.24", features = ["derive", "env", "wrap_help"], optional = true }
@@ -38,22 +38,26 @@ defmt-decoder   = { version = "=0.4.0", features = ["unstable"], optional = true
 dialoguer       = { version = "0.11.0", optional = true }
 directories     = { version = "5.0.1", optional = true }
 env_logger      = { version = "0.11.6", optional = true }
-esp-idf-part    = "0.5.0"
-flate2          = "1.0.35"
+esp-idf-part    = { path = "../../esp-idf-part", default-features = false }
+flate2          = { version = "1.0.35", optional = true }
 indicatif       = { version = "0.17.9", optional = true }
 log             = "0.4.22"
-md-5            = "0.10.6"
-miette          = "7.4.0"
-object          = "0.36.7"
+md-5            = { version = "0.10.6", default-features = false}
+miette          = { version = "7.4.0", optional = true}
+object          = { version = "0.36.7", default-features = false, features = ['read'] }
 regex           = { version = "1.11.1", optional = true }
-serde           = { version = "1.0.217", features = ["derive"] }
+serde           = { version = "1.0.217", features = ["derive"], default-features = false }
 serialport      = { version = "4.7.0", default-features = false, optional = true }
-sha2            = "0.10.8"
+sha2            = { version = "0.10.8", default-features = false}
 slip-codec      = { version = "0.4.0", optional = true }
-strum           = { version = "0.26.3", features = ["derive"] }
-thiserror       = "2.0.10"
+strum           = { version = "0.26.3", default-features = false, features = ["derive"] }
+thiserror       = { version = "2.0.10", default-features = false }
 toml            = { version = "0.8.19", optional = true }
 update-informer = { version = "1.2.0", optional = true }
+
+heapless        = { version = "0.8.0" }
+embedded-io     = { version = "0.6.1", features = ["alloc"]}
+embedded-io-adapters     = { version = "0.6.1"}
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2.169"
@@ -75,7 +79,10 @@ cli = [
     "dep:update-informer",
     "miette/fancy",
     "serialport",
+    "std"
 ]
 
 # Enables connecting to a device via serial port
-serialport = ["dep:regex", "dep:serialport", "dep:slip-codec", "dep:toml"]
+serialport = ["dep:regex", "dep:serialport", "dep:slip-codec", "dep:toml", "std"]
+
+std = ["dep:miette", "dep:flate2", "object/default", "serde/std", "thiserror/std", "strum/std", "esp-idf-part/std", "md-5/std", "sha2/std", "base64/std", "embedded-io/std", "embedded-io-adapters/std"]

--- a/espflash/src/cli/mod.rs
+++ b/espflash/src/cli/mod.rs
@@ -11,12 +11,14 @@
 //! [espflash]: https://crates.io/crates/espflash
 
 use std::{
-    collections::HashMap,
     fs::{self, File},
     io::{Read, Write},
     num::ParseIntError,
     path::{Path, PathBuf},
 };
+
+use alloc::collections::BTreeMap;
+use alloc::vec::Vec;
 
 use clap::{Args, ValueEnum};
 use clap_complete::Shell;
@@ -35,13 +37,7 @@ use crate::{
     connection::reset::{ResetAfterOperation, ResetBeforeOperation},
     error::{Error, MissingPartition, MissingPartitionTable},
     flasher::{
-        FlashData,
-        FlashFrequency,
-        FlashMode,
-        FlashSettings,
-        FlashSize,
-        Flasher,
-        ProgressCallbacks,
+        FlashData, FlashFrequency, FlashMode, FlashSettings, FlashSize, Flasher, ProgressCallbacks,
         FLASH_SECTOR_SIZE,
     },
     image_format::Metadata,
@@ -830,7 +826,7 @@ pub fn erase_partitions(
                 .ok_or_else(|| MissingPartition::from(label))?;
 
             parts_to_erase
-                .get_or_insert(HashMap::new())
+                .get_or_insert(BTreeMap::new())
                 .insert(part.offset(), part);
         }
     }
@@ -845,7 +841,7 @@ pub fn erase_partitions(
                     && part.subtype() == esp_idf_part::SubType::Data(ty)
                 {
                     parts_to_erase
-                        .get_or_insert(HashMap::new())
+                        .get_or_insert(BTreeMap::new())
                         .insert(part.offset(), part);
                 }
             }

--- a/espflash/src/error.rs
+++ b/espflash/src/error.rs
@@ -2,9 +2,16 @@
 
 #[cfg(feature = "serialport")]
 use std::fmt::{Display, Formatter};
-use std::{array::TryFromSliceError, io};
 
+use core::array::TryFromSliceError;
+use core::convert::Infallible;
+
+#[cfg(feature = "std")]
+use std::io;
+
+#[cfg(feature = "std")]
 use miette::Diagnostic;
+
 #[cfg(feature = "serialport")]
 use slip_codec::SlipError;
 use strum::VariantNames;
@@ -13,141 +20,174 @@ use thiserror::Error;
 #[cfg(feature = "cli")]
 use crate::cli::monitor::parser::esp_defmt::DefmtError;
 #[cfg(feature = "serialport")]
-use crate::connection::command::CommandType;
+use crate::command::CommandType;
 use crate::{
     flasher::{FlashFrequency, FlashSize},
     targets::Chip,
 };
 
+use alloc::string::String;
+use alloc::vec::Vec;
+
 /// All possible errors returned by espflash
-#[derive(Debug, Diagnostic, Error)]
+#[derive(Debug, Error)]
+#[cfg_attr(feature = "std", derive(Diagnostic))]
 #[non_exhaustive]
 pub enum Error {
     #[error("App partition not found")]
-    #[diagnostic(code(espflash::app_partition_not_found))]
+    #[cfg_attr(feature = "std", diagnostic(code(espflash::app_partition_not_found)))]
     AppPartitionNotFound,
 
     #[error("Operation was cancelled by the user")]
-    #[diagnostic(code(espflash::cancelled))]
+    #[cfg_attr(feature = "std", diagnostic(code(espflash::cancelled)))]
     Cancelled,
 
     #[error("{0}")]
-    #[diagnostic(
+    #[cfg_attr(feature = "std", diagnostic(
         code(espflash::chip_detect_error),
         help("Supported chips are: {}\n\
               If your chip is supported, try hard-resetting the device and try again",
              Chip::VARIANTS.join(", "))
-    )]
+    ))]
     ChipDetectError(String),
 
     #[error("Chip provided with `-c/--chip` ({0}) does not match the detected chip ({1})")]
-    #[diagnostic(
+    #[cfg_attr(feature = "std", diagnostic(
         code(espflash::chip_mismatch),
         help("Ensure that the correct chip is selected, or remove the `-c/--chip` option to autodetect the chip")
-    )]
+    ))]
     ChipMismatch(String, String),
 
     #[error("Chip not argument provided, this is required when using the `--before no-reset-no-sync` option")]
-    #[diagnostic(
-        code(espflash::chip_not_provided),
-        help("Ensure that you provide the `-c/--chip` option with the proper chip")
+    #[cfg_attr(
+        feature = "std",
+        diagnostic(
+            code(espflash::chip_not_provided),
+            help("Ensure that you provide the `-c/--chip` option with the proper chip")
+        )
     )]
     ChipNotProvided,
 
     #[error("Corrupt data, expected {0:2x?} bytes but receved {1:2x?} bytes")]
-    #[diagnostic(code(espflash::read_flash::corrupt_data))]
+    #[cfg_attr(feature = "std", diagnostic(code(espflash::read_flash::corrupt_data)))]
     CorruptData(usize, usize),
 
     #[error("MD5 digest missmatch: expected {0:2x?}, received: {1:2x?}")]
-    #[diagnostic(code(espflash::read_flash::digest_mismatch))]
+    #[cfg_attr(
+        feature = "std",
+        diagnostic(code(espflash::read_flash::digest_mismatch))
+    )]
     DigestMismatch(Vec<u8>, Vec<u8>),
 
     #[error("Supplied ELF image can not be run from RAM, as it includes segments mapped to ROM addresses")]
-    #[diagnostic(
+    #[cfg_attr(feature = "std", diagnostic(
         code(espflash::not_ram_loadable),
         help("Either build the binary to be all in RAM, or remove the `--ram` option to load the image to flash")
-    )]
+    ))]
     ElfNotRamLoadable,
 
     #[error(
         "Supplied ELF image of {0}B is too big, and doesn't fit configured app partition of {1}B"
     )]
-    #[diagnostic(
+    #[cfg_attr(feature = "std", diagnostic(
         code(espflash::image_too_big),
         help("Reduce the size of the binary or increase the size of the app partition."),
         url("https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/partition-tables.html#built-in-partition-tables")
-    )]
+    ))]
     ElfTooBig(u32, u32),
 
     #[error("Failed to connect to on-device flash")]
-    #[diagnostic(code(espflash::flash_connect))]
+    #[cfg_attr(feature = "std", diagnostic(code(espflash::flash_connect)))]
     FlashConnect,
 
     #[error("Expected MD5 digest (16 bytes), received: {0:#x} bytes")]
-    #[diagnostic(code(espflash::read_flash::incorrect_digest_length))]
+    #[cfg_attr(
+        feature = "std",
+        diagnostic(code(espflash::read_flash::incorrect_digest_length))
+    )]
     IncorrectDigestLength(usize),
 
     #[error("Incorrect response from the stub/ROM loader")]
-    #[diagnostic(code(espflash::read_flash::incorrect_response))]
+    #[cfg_attr(
+        feature = "std",
+        diagnostic(code(espflash::read_flash::incorrect_response))
+    )]
     IncorrectResponse,
 
     #[error("The provided bootloader binary is invalid")]
     InvalidBootloader,
 
     #[error("Specified bootloader path is not a .bin file")]
-    #[diagnostic(code(espflash::invalid_bootloader_path))]
+    #[cfg_attr(feature = "std", diagnostic(code(espflash::invalid_bootloader_path)))]
     InvalidBootloaderPath,
 
     #[error("The flash size '{0}' is invalid")]
-    #[diagnostic(
-        code(espflash::invalid_flash_size),
-        help("The accepted values are: {:?}", FlashSize::VARIANTS)
+    #[cfg_attr(
+        feature = "std",
+        diagnostic(
+            code(espflash::invalid_flash_size),
+            help("The accepted values are: {:?}", FlashSize::VARIANTS)
+        )
     )]
     InvalidFlashSize(String),
 
-    #[cfg(not(feature = "serialport"))]
-    #[error(transparent)]
-    IoError(#[from] io::Error),
-
+    // #[cfg(not(feature = "serialport"))]
+    // #[error(transparent)]
+    // IoError(#[from] io::Error),
     #[error("Specified partition table path is not a .bin or .csv file")]
-    #[diagnostic(code(espflash::invalid_partition_table_path))]
+    #[cfg_attr(
+        feature = "std",
+        diagnostic(code(espflash::invalid_partition_table_path))
+    )]
     InvalidPartitionTablePath,
 
     #[error("No serial ports could be detected")]
-    #[diagnostic(
+    #[cfg_attr(feature = "std", diagnostic(
         code(espflash::no_serial),
         help("Make sure you have connected a device to the host system. If the device is connected but not listed, try using the `--list-all-ports` flag.")
-    )]
+    ))]
     NoSerial,
 
     #[error("Read more bytes than expected")]
-    #[diagnostic(code(espflash::read_flash::read_more_than_expected))]
+    #[cfg_attr(
+        feature = "std",
+        diagnostic(code(espflash::read_flash::read_more_than_expected))
+    )]
     ReadMoreThanExpected,
 
     #[error("This command requires using the RAM stub")]
-    #[diagnostic(
-        code(espflash::stub_required),
-        help("Don't use the `--no-stub` option with the command")
+    #[cfg_attr(
+        feature = "std",
+        diagnostic(
+            code(espflash::stub_required),
+            help("Don't use the `--no-stub` option with the command")
+        )
     )]
     StubRequired,
 
     #[error("The serial port '{0}' could not be found")]
-    #[diagnostic(
-        code(espflash::serial_not_found),
-        help("Make sure the correct device is connected to the host system")
+    #[cfg_attr(
+        feature = "std",
+        diagnostic(
+            code(espflash::serial_not_found),
+            help("Make sure the correct device is connected to the host system")
+        )
     )]
     SerialNotFound(String),
 
     #[error("The {chip} does not support {feature}")]
-    #[diagnostic(code(espflash::unsupported_feature))]
+    #[cfg_attr(feature = "std", diagnostic(code(espflash::unsupported_feature)))]
     UnsupportedFeature { chip: Chip, feature: String },
 
     #[error("Flash chip not supported, unrecognized flash ID: {0:#x}")]
-    #[diagnostic(code(espflash::unrecognized_flash))]
+    #[cfg_attr(feature = "std", diagnostic(code(espflash::unrecognized_flash)))]
     UnsupportedFlash(u8),
 
     #[error("The specified flash frequency '{frequency}' is not supported by the {chip}")]
-    #[diagnostic(code(espflash::unsupported_flash_frequency))]
+    #[cfg_attr(
+        feature = "std",
+        diagnostic(code(espflash::unsupported_flash_frequency))
+    )]
     UnsupportedFlashFrequency {
         chip: Chip,
         frequency: FlashFrequency,
@@ -156,7 +196,7 @@ pub enum Error {
     #[error(
         "Minimum supported revision is {major}.{minor}, connected device's revision is {found_major}.{found_minor}"
     )]
-    #[diagnostic(code(espflash::unsupported_chip_revision))]
+    #[cfg_attr(feature = "std", diagnostic(code(espflash::unsupported_chip_revision)))]
     UnsupportedChipRevision {
         major: u16,
         minor: u16,
@@ -165,46 +205,50 @@ pub enum Error {
     },
 
     #[error("Failed to parse chip revision: {chip_rev}. Chip revision must be in the format `major.minor`")]
-    #[diagnostic(code(espflash::cli::parse_chip_rev_error))]
+    #[cfg_attr(feature = "std", diagnostic(code(espflash::cli::parse_chip_rev_error)))]
     ParseChipRevError { chip_rev: String },
 
     #[error("Error while connecting to device")]
-    #[diagnostic(transparent)]
+    #[cfg_attr(feature = "std", diagnostic(transparent))]
     Connection(#[source] ConnectionError),
 
     #[error("Communication error while flashing device")]
-    #[diagnostic(transparent)]
+    #[cfg_attr(feature = "std", diagnostic(transparent))]
     Flashing(#[source] ConnectionError),
 
     #[error("Supplied ELF image is not valid")]
-    #[diagnostic(
-        code(espflash::invalid_elf),
-        help("Try running `cargo clean` and rebuilding the image")
+    #[cfg_attr(
+        feature = "std",
+        diagnostic(
+            code(espflash::invalid_elf),
+            help("Try running `cargo clean` and rebuilding the image")
+        )
     )]
     InvalidElf(#[from] object::Error),
 
     #[error("The bootloader returned an error")]
     #[cfg(feature = "serialport")]
-    #[diagnostic(transparent)]
+    #[cfg_attr(feature = "std", diagnostic(transparent))]
     RomError(#[from] RomError),
 
     #[cfg(feature = "cli")]
     #[error(transparent)]
-    #[diagnostic(transparent)]
+    #[cfg_attr(feature = "std", diagnostic(transparent))]
     Defmt(#[from] DefmtError),
 
     #[error("Verification of flash content failed")]
-    #[diagnostic(code(espflash::verify_failed))]
+    #[cfg_attr(feature = "std", diagnostic(code(espflash::verify_failed)))]
     VerifyFailed,
 
     #[cfg(feature = "cli")]
     #[error(transparent)]
-    #[diagnostic(code(espflash::dialoguer_error))]
+    #[cfg_attr(feature = "std", diagnostic(code(espflash::dialoguer_error)))]
     DialoguerError(#[from] dialoguer::Error),
 
     #[error(transparent)]
     TryFromSlice(#[from] TryFromSliceError),
 
+    #[cfg(feature = "std")]
     #[error("Failed to open file: {0}")]
     FileOpenError(String, #[source] io::Error),
 
@@ -212,29 +256,46 @@ pub enum Error {
     Partition(#[from] esp_idf_part::Error),
 
     #[error("Invalid response: {0}")]
-    #[diagnostic(code(espflash::invalid_response))]
+    #[cfg_attr(feature = "std", diagnostic(code(espflash::invalid_response)))]
     InvalidResponse(String),
 
     #[error("Invalid `address`({address})  and/or `size`({size}) argument(s)")]
-    #[diagnostic(
-        code(espflash::erase_region::invalid_argument),
-        help("`address` and `size` must be multiples of 0x1000 (4096)")
+    #[cfg_attr(
+        feature = "std",
+        diagnostic(
+            code(espflash::erase_region::invalid_argument),
+            help("`address` and `size` must be multiples of 0x1000 (4096)")
+        )
     )]
     InvalidEraseRegionArgument { address: u32, size: u32 },
 
     #[error("The firmware was built for {elf}, but the detected chip is {detected}")]
-    #[diagnostic(
-        code(espflash::chip_mismatch),
-        help("Ensure that the device is connected and your host recognizes the serial adapter")
+    #[cfg_attr(
+        feature = "std",
+        diagnostic(
+            code(espflash::chip_mismatch),
+            help(
+                "Ensure that the device is connected and your host recognizes the serial adapter"
+            )
+        )
     )]
     FirmwareChipMismatch { elf: String, detected: Chip },
 
     #[error("The partition table does not fit into the flash ({0})")]
-    #[diagnostic(
-        code(espflash::partition_table::does_not_fit),
-        help("Make sure you set the correct flash size with the `--flash-size` option")
+    #[cfg_attr(
+        feature = "std",
+        diagnostic(
+            code(espflash::partition_table::does_not_fit),
+            help("Make sure you set the correct flash size with the `--flash-size` option")
+        )
     )]
     PartitionTableDoesNotFit(FlashSize),
+}
+
+impl From<Infallible> for Error {
+    fn from(_: Infallible) -> Self {
+        unreachable!()
+    }
 }
 
 #[cfg(feature = "serialport")]
@@ -260,63 +321,72 @@ impl From<SlipError> for Error {
 }
 
 /// Connection-related errors
-#[derive(Debug, Diagnostic, Error)]
+#[derive(Debug, Error)]
+#[cfg_attr(feature = "std", derive(Diagnostic))]
 #[non_exhaustive]
 pub enum ConnectionError {
     #[error("Failed to connect to the device")]
-    #[diagnostic(
+    #[cfg_attr(feature = "std", diagnostic(
         code(espflash::connection_failed),
         help("Ensure that the device is connected and the reset and boot pins are not being held down")
-    )]
+    ))]
     ConnectionFailed,
 
     #[error("Serial port not found")]
-    #[diagnostic(
-        code(espflash::connection_failed),
-        help("Ensure that the device is connected and your host recognizes the serial adapter")
+    #[cfg_attr(
+        feature = "std",
+        diagnostic(
+            code(espflash::connection_failed),
+            help(
+                "Ensure that the device is connected and your host recognizes the serial adapter"
+            )
+        )
     )]
     DeviceNotFound,
 
     #[error("Received packet has invalid SLIP framing")]
-    #[diagnostic(
+    #[cfg_attr(feature = "std", diagnostic(
         code(espflash::slip_framing),
         help("Try hard-resetting the device and try again, if the error persists your ROM may be corrupted")
-    )]
+    ))]
     FramingError,
 
     #[error("Invalid stub handshake response received")]
     InvalidStubHandshake,
 
     #[error("Download mode successfully detected, but getting no sync reply")]
-    #[diagnostic(
-        code(espflash::no_sync_reply),
-        help("The serial TX path seems to be down")
+    #[cfg_attr(
+        feature = "std",
+        diagnostic(
+            code(espflash::no_sync_reply),
+            help("The serial TX path seems to be down")
+        )
     )]
     NoSyncReply,
 
     #[error("Received packet to large for buffer")]
-    #[diagnostic(
+    #[cfg_attr(feature = "std", diagnostic(
         code(espflash::oversized_packet),
         help("Try hard-resetting the device and try again, if the error persists your ROM may be corrupted")
-    )]
+    ))]
     OverSizedPacket,
 
     #[error("Failed to read the available bytes on the serial port. Available bytes: {0}, Read bytes: {1}")]
-    #[diagnostic(code(espflash::read_missmatch))]
+    #[cfg_attr(feature = "std", diagnostic(code(espflash::read_missmatch)))]
     ReadMissmatch(u32, u32),
 
     #[cfg(feature = "serialport")]
     #[error("Timeout while running {0}command")]
-    #[diagnostic(code(espflash::timeout))]
+    #[cfg_attr(feature = "std", diagnostic(code(espflash::timeout)))]
     Timeout(TimedOutCommand),
 
     #[cfg(feature = "serialport")]
     #[error("IO error while using serial port: {0}")]
-    #[diagnostic(code(espflash::serial_error))]
+    #[cfg_attr(feature = "std", diagnostic(code(espflash::serial_error)))]
     Serial(#[source] serialport::Error),
 
     #[error("Wrong boot mode detected ({0})! The chip needs to be in download mode.")]
-    #[diagnostic(code(espflash::wrong_boot_mode))]
+    #[cfg_attr(feature = "std", diagnostic(code(espflash::wrong_boot_mode)))]
     WrongBootMode(String),
 }
 
@@ -378,82 +448,83 @@ impl From<CommandType> for TimedOutCommand {
 }
 
 /// Errors originating from a device's ROM functionality
-#[derive(Clone, Copy, Debug, Default, Diagnostic, Error, strum::FromRepr)]
+#[derive(Clone, Copy, Debug, Default, Error, strum::FromRepr)]
+#[cfg_attr(feature = "std", derive(Diagnostic))]
 #[non_exhaustive]
 #[repr(u8)]
 #[cfg(feature = "serialport")]
 pub enum RomErrorKind {
     #[error("Invalid message received")]
-    #[diagnostic(code(espflash::rom::invalid_message))]
+    #[cfg_attr(feature = "std", diagnostic(code(espflash::rom::invalid_message)))]
     InvalidMessage = 0x05,
 
     #[error("Bootloader failed to execute command")]
-    #[diagnostic(code(espflash::rom::failed))]
+    #[cfg_attr(feature = "std", diagnostic(code(espflash::rom::failed)))]
     FailedToAct = 0x06,
 
     #[error("Received message has invalid CRC")]
-    #[diagnostic(code(espflash::rom::crc))]
+    #[cfg_attr(feature = "std", diagnostic(code(espflash::rom::crc)))]
     InvalidCrc = 0x07,
 
     #[error("Bootloader failed to write to flash")]
-    #[diagnostic(code(espflash::rom::flash_write))]
+    #[cfg_attr(feature = "std", diagnostic(code(espflash::rom::flash_write)))]
     FlashWriteError = 0x08,
 
     #[error("Bootloader failed to read from flash")]
-    #[diagnostic(code(espflash::rom::flash_read))]
+    #[cfg_attr(feature = "std", diagnostic(code(espflash::rom::flash_read)))]
     FlashReadError = 0x09,
 
     #[error("Invalid length for flash read")]
-    #[diagnostic(code(espflash::rom::flash_read_length))]
+    #[cfg_attr(feature = "std", diagnostic(code(espflash::rom::flash_read_length)))]
     FlashReadLengthError = 0x0a,
 
     #[error("Malformed compressed data received")]
-    #[diagnostic(code(espflash::rom::deflate))]
+    #[cfg_attr(feature = "std", diagnostic(code(espflash::rom::deflate)))]
     DeflateError = 0x0b,
 
     #[error("Bad data length")]
-    #[diagnostic(code(espflash::rom::data_len))]
+    #[cfg_attr(feature = "std", diagnostic(code(espflash::rom::data_len)))]
     BadDataLen = 0xc0,
 
     #[error("Bad data checksum")]
-    #[diagnostic(code(espflash::rom::data_crc))]
+    #[cfg_attr(feature = "std", diagnostic(code(espflash::rom::data_crc)))]
     BadDataChecksum = 0xc1,
 
     #[error("Bad block size")]
-    #[diagnostic(code(espflash::rom::block_size))]
+    #[cfg_attr(feature = "std", diagnostic(code(espflash::rom::block_size)))]
     BadBlocksize = 0xc2,
 
     #[error("Invalid command")]
-    #[diagnostic(code(espflash::rom::cmd))]
+    #[cfg_attr(feature = "std", diagnostic(code(espflash::rom::cmd)))]
     InvalidCommand = 0xc3,
 
     #[error("SPI operation failed")]
-    #[diagnostic(code(espflash::rom::spi))]
+    #[cfg_attr(feature = "std", diagnostic(code(espflash::rom::spi)))]
     FailedSpiOp = 0xc4,
 
     #[error("SPI unlock failed")]
-    #[diagnostic(code(espflash::rom::spi_unlock))]
+    #[cfg_attr(feature = "std", diagnostic(code(espflash::rom::spi_unlock)))]
     FailedSpiUnlock = 0xc5,
 
     #[error("Not in flash mode")]
-    #[diagnostic(code(espflash::rom::flash_mode))]
+    #[cfg_attr(feature = "std", diagnostic(code(espflash::rom::flash_mode)))]
     NotInFlashMode = 0xc6,
 
     #[error("Error when uncompressing the data")]
-    #[diagnostic(code(espflash::rom::inflate))]
+    #[cfg_attr(feature = "std", diagnostic(code(espflash::rom::inflate)))]
     InflateError = 0xc7,
 
     #[error("Didn't receive enough data")]
-    #[diagnostic(code(espflash::rom::not_enough))]
+    #[cfg_attr(feature = "std", diagnostic(code(espflash::rom::not_enough)))]
     NotEnoughData = 0xc8,
 
     #[error("Received too much data")]
-    #[diagnostic(code(espflash::rom::too_much_data))]
+    #[cfg_attr(feature = "std", diagnostic(code(espflash::rom::too_much_data)))]
     TooMuchData = 0xc9,
 
     #[default]
     #[error("Other")]
-    #[diagnostic(code(espflash::rom::other))]
+    #[cfg_attr(feature = "std", diagnostic(code(espflash::rom::other)))]
     Other = 0xff,
 }
 
@@ -465,7 +536,8 @@ impl From<u8> for RomErrorKind {
 }
 
 /// An error originating from a device's ROM functionality
-#[derive(Clone, Copy, Debug, Diagnostic, Error)]
+#[derive(Clone, Copy, Debug, Error)]
+#[cfg_attr(feature = "std", derive(Diagnostic))]
 #[error("Error while running {command} command")]
 #[cfg(feature = "serialport")]
 #[non_exhaustive]
@@ -483,11 +555,15 @@ impl RomError {
 }
 
 /// Missing partition error
-#[derive(Debug, Diagnostic, Error)]
+#[derive(Debug, Error)]
+#[cfg_attr(feature = "std", derive(Diagnostic))]
 #[error("Missing partition")]
-#[diagnostic(
-    code(espflash::partition_table::missing_partition),
-    help("Partition table must contain the partition of type `{0}` to be erased")
+#[cfg_attr(
+    feature = "std",
+    diagnostic(
+        code(espflash::partition_table::missing_partition),
+        help("Partition table must contain the partition of type `{0}` to be erased")
+    )
 )]
 pub struct MissingPartition(String);
 
@@ -498,11 +574,17 @@ impl From<String> for MissingPartition {
 }
 
 /// Missing partition table error
-#[derive(Debug, Error, Diagnostic)]
+#[derive(Debug, Error)]
+#[cfg_attr(feature = "std", derive(Diagnostic))]
 #[error("No partition table could be found")]
-#[diagnostic(
-    code(espflash::partition_table::missing_partition_table),
-    help("Try providing a CSV or binary paritition table with the `--partition-table` argument.")
+#[cfg_attr(
+    feature = "std",
+    diagnostic(
+        code(espflash::partition_table::missing_partition_table),
+        help(
+            "Try providing a CSV or binary paritition table with the `--partition-table` argument."
+        )
+    )
 )]
 pub struct MissingPartitionTable;
 

--- a/espflash/src/image_format/metadata.rs
+++ b/espflash/src/image_format/metadata.rs
@@ -1,16 +1,20 @@
-use std::{collections::HashMap, error::Error};
+use alloc::boxed::Box;
+use alloc::collections::BTreeMap;
+use alloc::string::{String, ToString};
+use alloc::vec::Vec;
+use core::error::Error;
 
 use object::{File, Object, ObjectSection, ObjectSymbol};
 
 #[derive(Debug, Clone)]
 pub struct Metadata {
-    symbols: HashMap<String, Vec<u8>>,
+    symbols: BTreeMap<String, Vec<u8>>,
 }
 
 impl Metadata {
     fn empty() -> Self {
         Self {
-            symbols: HashMap::new(),
+            symbols: BTreeMap::new(),
         }
     }
 
@@ -60,7 +64,7 @@ impl Metadata {
     fn read_string<'f>(&'f self, name: &str) -> Option<&'f str> {
         self.symbols
             .get(name)
-            .and_then(|data| std::str::from_utf8(data).ok())
+            .and_then(|data| core::str::from_utf8(data).ok())
     }
 
     pub fn chip_name(&self) -> Option<&str> {

--- a/espflash/src/image_format/mod.rs
+++ b/espflash/src/image_format/mod.rs
@@ -1,7 +1,9 @@
 //! Binary application image formats
 
-use std::{
-    borrow::Cow,
+use alloc::borrow::Cow;
+use alloc::boxed::Box;
+
+use core::{
     cmp::Ordering,
     fmt::{Debug, Formatter},
     mem::take,
@@ -11,9 +13,7 @@ use std::{
 use object::{
     elf::SHT_PROGBITS,
     read::elf::{ElfFile32 as ElfFile, SectionHeader},
-    Endianness,
-    Object as _,
-    ObjectSection as _,
+    Endianness, Object as _, ObjectSection as _,
 };
 
 pub use self::{esp_idf::IdfBootloaderFormat, metadata::Metadata};
@@ -122,7 +122,7 @@ impl AddAssign<&'_ Segment<'_>> for Segment<'_> {
 }
 
 impl Debug for Segment<'_> {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter<'_>) -> alloc::fmt::Result {
         f.debug_struct("CodeSegment")
             .field("addr", &self.addr)
             .field("size", &self.size())

--- a/espflash/src/lib.rs
+++ b/espflash/src/lib.rs
@@ -25,7 +25,7 @@
 //!
 //! [espflash]: https://crates.io/crates/espflash
 //! [cargo-binstall]: https://github.com/cargo-bins/cargo-binstall
-
+#![cfg_attr(not(feature = "std"), no_std)]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![deny(missing_debug_implementations, rust_2018_idioms)]
 
@@ -34,11 +34,15 @@ pub use self::{error::Error, image_format::Segment};
 #[cfg(feature = "serialport")]
 #[cfg_attr(docsrs, doc(cfg(feature = "serialport")))]
 pub mod connection;
+
+pub mod command;
 pub mod flasher;
 pub mod image_format;
 pub mod targets;
 
 mod error;
+
+extern crate alloc;
 
 // Command-line interface
 #[cfg(feature = "cli")]

--- a/espflash/src/targets/esp32.rs
+++ b/espflash/src/targets/esp32.rs
@@ -1,4 +1,4 @@
-use std::ops::Range;
+use core::ops::Range;
 
 #[cfg(feature = "serialport")]
 use crate::{connection::Connection, targets::bytes_to_mac_addr};

--- a/espflash/src/targets/esp32c2.rs
+++ b/espflash/src/targets/esp32c2.rs
@@ -1,4 +1,5 @@
-use std::{collections::HashMap, ops::Range};
+use alloc::collections::BTreeMap;
+use core::ops::Range;
 
 use log::debug;
 
@@ -81,12 +82,12 @@ impl Target for Esp32c2 {
         Ok(norm_xtal)
     }
 
-    fn flash_frequency_encodings(&self) -> HashMap<FlashFrequency, u8> {
+    fn flash_frequency_encodings(&self) -> BTreeMap<FlashFrequency, u8> {
         use FlashFrequency::*;
 
         let encodings = [(_15Mhz, 0x2), (_20Mhz, 0x1), (_30Mhz, 0x0), (_60Mhz, 0xF)];
 
-        HashMap::from(encodings)
+        BTreeMap::from(encodings)
     }
 
     fn flash_image<'a>(

--- a/espflash/src/targets/esp32c3.rs
+++ b/espflash/src/targets/esp32c3.rs
@@ -1,4 +1,4 @@
-use std::ops::Range;
+use core::ops::Range;
 
 #[cfg(feature = "serialport")]
 use crate::connection::Connection;

--- a/espflash/src/targets/esp32c6.rs
+++ b/espflash/src/targets/esp32c6.rs
@@ -1,4 +1,4 @@
-use std::ops::Range;
+use core::ops::Range;
 
 #[cfg(feature = "serialport")]
 use crate::connection::Connection;

--- a/espflash/src/targets/esp32h2.rs
+++ b/espflash/src/targets/esp32h2.rs
@@ -1,4 +1,5 @@
-use std::{collections::HashMap, ops::Range};
+use alloc::collections::BTreeMap;
+use core::ops::Range;
 
 #[cfg(feature = "serialport")]
 use crate::connection::Connection;
@@ -71,12 +72,12 @@ impl Target for Esp32h2 {
         Ok(XtalFrequency::_32Mhz)
     }
 
-    fn flash_frequency_encodings(&self) -> HashMap<FlashFrequency, u8> {
+    fn flash_frequency_encodings(&self) -> BTreeMap<FlashFrequency, u8> {
         use FlashFrequency::*;
 
         let encodings = [(_12Mhz, 0x2), (_16Mhz, 0x1), (_24Mhz, 0x0), (_48Mhz, 0xF)];
 
-        HashMap::from(encodings)
+        BTreeMap::from(encodings)
     }
 
     fn flash_image<'a>(

--- a/espflash/src/targets/esp32p4.rs
+++ b/espflash/src/targets/esp32p4.rs
@@ -1,4 +1,4 @@
-use std::ops::Range;
+use core::ops::Range;
 
 #[cfg(feature = "serialport")]
 use crate::connection::Connection;

--- a/espflash/src/targets/esp32s2.rs
+++ b/espflash/src/targets/esp32s2.rs
@@ -1,4 +1,4 @@
-use std::ops::Range;
+use core::ops::Range;
 
 #[cfg(feature = "serialport")]
 use super::flash_target::MAX_RAM_BLOCK_SIZE;

--- a/espflash/src/targets/esp32s3.rs
+++ b/espflash/src/targets/esp32s3.rs
@@ -1,4 +1,4 @@
-use std::ops::Range;
+use core::ops::Range;
 
 #[cfg(feature = "serialport")]
 use crate::connection::Connection;

--- a/espflash/src/targets/flash_target/esp32.rs
+++ b/espflash/src/targets/flash_target/esp32.rs
@@ -9,10 +9,8 @@ use md5::{Digest, Md5};
 
 #[cfg(feature = "serialport")]
 use crate::{
-    connection::{
-        command::{Command, CommandType},
-        Connection,
-    },
+    command::{Command, CommandType},
+    connection::Connection,
     flasher::ProgressCallbacks,
     targets::FlashTarget,
 };

--- a/espflash/src/targets/flash_target/ram.rs
+++ b/espflash/src/targets/flash_target/ram.rs
@@ -1,9 +1,7 @@
 #[cfg(feature = "serialport")]
 use crate::{
-    connection::{
-        command::{Command, CommandType},
-        Connection,
-    },
+    command::{Command, CommandType},
+    connection::Connection,
     flasher::ProgressCallbacks,
     targets::FlashTarget,
 };

--- a/espflash/src/targets/mod.rs
+++ b/espflash/src/targets/mod.rs
@@ -4,7 +4,9 @@
 //! possible to write an application to and boot from RAM, where a bootloader is
 //! obviously not required either.
 
-use std::collections::HashMap;
+use alloc::boxed::Box;
+use alloc::collections::BTreeMap;
+use alloc::format;
 
 use serde::{Deserialize, Serialize};
 use strum::{Display, EnumIter, EnumString, VariantNames};
@@ -21,14 +23,8 @@ use crate::{
     flasher::{FlashData, FlashFrequency},
     image_format::IdfBootloaderFormat,
     targets::{
-        esp32::Esp32,
-        esp32c2::Esp32c2,
-        esp32c3::Esp32c3,
-        esp32c6::Esp32c6,
-        esp32h2::Esp32h2,
-        esp32p4::Esp32p4,
-        esp32s2::Esp32s2,
-        esp32s3::Esp32s3,
+        esp32::Esp32, esp32c2::Esp32c2, esp32c3::Esp32c3, esp32c6::Esp32c6, esp32h2::Esp32h2,
+        esp32p4::Esp32p4, esp32s2::Esp32s2, esp32s3::Esp32s3,
     },
     Error,
 };
@@ -337,12 +333,12 @@ pub trait Target: ReadEFuse {
     fn crystal_freq(&self, connection: &mut Connection) -> Result<XtalFrequency, Error>;
 
     /// Numeric encodings for the flash frequencies supported by a chip
-    fn flash_frequency_encodings(&self) -> HashMap<FlashFrequency, u8> {
+    fn flash_frequency_encodings(&self) -> BTreeMap<FlashFrequency, u8> {
         use FlashFrequency::*;
 
         let encodings = [(_20Mhz, 0x2), (_26Mhz, 0x1), (_40Mhz, 0x0), (_80Mhz, 0xf)];
 
-        HashMap::from(encodings)
+        BTreeMap::from(encodings)
     }
 
     #[cfg(feature = "serialport")]


### PR DESCRIPTION
This is a pull-request for those interested not necessarily for upstreaming (see https://github.com/esp-rs/espflash/issues/794#issuecomment-2781489369).

It uses a custom esp-idf-part which is `no_std` but `alloc` (https://github.com/i404788/esp-idf-part).

Main changes:
- Move `command` outside of `connection`
- Add embedded-io with adapters to keep existing functionality intact
- Replace HashMaps with BTreeMaps (adds Ord)
- Make all dependencies also available without std

Importantly it's not 'no-alloc` because that is very hard to maintain with the std counterpart.