### PR TITLE
Fix MMU page size handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `espflash` can detect the chip from ESP-HAL metadata to prevent flashing firmware built for a different device. Reqires `esp-hal` 1.0.0-beta.0 (presumably, yet to be released) (#816)
 - `espflash` no longer allows flashing a too-big partition table (#830)
 - Allow specifying a partition label for `write-bin`, add `--partition-table`. (#828)
+- `--mmu-page-size` parameter for `flash` and `save-image` (#?)
 
 ### Changed
 
@@ -48,6 +49,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix `read-flash` which didn't work with some lengths (#804)
 - espflash can now flash an ESP32-S2 in download mode over USB (#813)
 - Fixed a case where esplash transformed the firmware elf in a way that made it unbootable (#831)
+- The app descriptor is now correctly placed in the front of the bianry (#?)
+- espflash now extracts the MMU page size from the app descriptor (#?)
 
 ### Removed
 

--- a/espflash/src/cli/mod.rs
+++ b/espflash/src/cli/mod.rs
@@ -249,6 +249,9 @@ pub struct ImageArgs {
     /// Minimum chip revision supported by image, in format: major.minor
     #[arg(long, default_value = "0.0", value_parser = parse_chip_rev)]
     pub min_chip_rev: u16,
+    /// MMU page size.
+    #[arg(long, value_name = "MMU_PAGE_SIZE", value_parser = parse_u32)]
+    pub mmu_page_size: Option<u32>,
 }
 
 #[derive(Debug, Args)]
@@ -1027,6 +1030,7 @@ pub fn make_flash_data(
         image_args.target_app_partition,
         flash_settings,
         image_args.min_chip_rev,
+        image_args.mmu_page_size,
     )
 }
 

--- a/espflash/src/flasher/mod.rs
+++ b/espflash/src/flasher/mod.rs
@@ -476,6 +476,7 @@ pub struct FlashData {
     pub target_app_partition: Option<String>,
     pub flash_settings: FlashSettings,
     pub min_chip_rev: u16,
+    pub mmu_page_size: Option<u32>,
 }
 
 impl FlashData {
@@ -486,6 +487,7 @@ impl FlashData {
         target_app_partition: Option<String>,
         flash_settings: FlashSettings,
         min_chip_rev: u16,
+        mmu_page_size: Option<u32>,
     ) -> Result<Self, Error> {
         // If the '--bootloader' option is provided, load the binary file at the
         // specified path.
@@ -517,6 +519,7 @@ impl FlashData {
             target_app_partition,
             flash_settings,
             min_chip_rev,
+            mmu_page_size,
         })
     }
 }
@@ -760,6 +763,7 @@ impl Flasher {
             .write_segment(
                 &mut self.connection,
                 Segment {
+                    name: Cow::Borrowed(""),
                     addr: text_addr,
                     data: Cow::Borrowed(&text),
                 },
@@ -774,6 +778,7 @@ impl Flasher {
             .write_segment(
                 &mut self.connection,
                 Segment {
+                    name: Cow::Borrowed(""),
                     addr: data_addr,
                     data: Cow::Borrowed(&data),
                 },
@@ -1080,6 +1085,7 @@ impl Flasher {
         progress: Option<&mut dyn ProgressCallbacks>,
     ) -> Result<(), Error> {
         let segment = Segment {
+            name: Cow::Borrowed(""),
             addr,
             data: Cow::from(data),
         };

--- a/espflash/src/image_format/mod.rs
+++ b/espflash/src/image_format/mod.rs
@@ -25,6 +25,7 @@ mod metadata;
 /// A segment of code from the source ELF
 #[derive(Default, Clone, Eq)]
 pub struct Segment<'a> {
+    pub name: Cow<'a, str>,
     /// Base address of the code segment
     pub addr: u32,
     /// Segment data
@@ -32,10 +33,11 @@ pub struct Segment<'a> {
 }
 
 impl<'a> Segment<'a> {
-    pub fn new(addr: u32, data: &'a [u8]) -> Self {
+    pub fn new(name: &'a str, addr: u32, data: &'a [u8]) -> Self {
         // Do not pad the data here, as it might result in overlapping segments
         // in the ELF file. The padding should be done after merging adjacent segments.
         Segment {
+            name: Cow::Borrowed(name),
             addr,
             data: Cow::Borrowed(data),
         }
@@ -56,6 +58,7 @@ impl<'a> Segment<'a> {
                 }
             };
             let new = Segment {
+                name: self.name.clone(),
                 addr: self.addr,
                 data: head,
             };
@@ -96,6 +99,7 @@ impl<'a> Segment<'a> {
         'a: 'b,
     {
         Segment {
+            name: self.name.clone(),
             addr: self.addr,
             data: Cow::Borrowed(self.data.as_ref()),
         }
@@ -176,7 +180,11 @@ fn segments<'a>(elf: &'a ElfFile<'a>) -> Box<dyn Iterator<Item = Segment<'a>> + 
                     && section.address() > 0
             })
             .flat_map(move |section| match section.data() {
-                Ok(data) => Some(Segment::new(section.address() as u32, data)),
+                Ok(data) => Some(Segment::new(
+                    section.name().unwrap_or_default(),
+                    section.address() as u32,
+                    data,
+                )),
                 _ => None,
             }),
     )

--- a/espflash/src/targets/esp32.rs
+++ b/espflash/src/targets/esp32.rs
@@ -182,6 +182,7 @@ impl Target for Esp32 {
             CHIP_ID,
             FlashFrequency::_40Mhz,
             bootloader,
+            None,
         );
 
         IdfBootloaderFormat::new(elf_data, Chip::Esp32, flash_data, params)

--- a/espflash/src/targets/esp32c2.rs
+++ b/espflash/src/targets/esp32c2.rs
@@ -120,6 +120,7 @@ impl Target for Esp32c2 {
             CHIP_ID,
             FlashFrequency::_30Mhz,
             bootloader,
+            Some(&[16 * 1024, 32 * 1024, 64 * 1024]),
         );
 
         IdfBootloaderFormat::new(elf_data, Chip::Esp32c2, flash_data, params)

--- a/espflash/src/targets/esp32c3.rs
+++ b/espflash/src/targets/esp32c3.rs
@@ -30,6 +30,7 @@ const PARAMS: Esp32Params = Esp32Params::new(
     CHIP_ID,
     FlashFrequency::_40Mhz,
     include_bytes!("../../resources/bootloaders/esp32c3-bootloader.bin"),
+    None,
 );
 
 /// ESP32-C3 Target

--- a/espflash/src/targets/esp32c6.rs
+++ b/espflash/src/targets/esp32c6.rs
@@ -25,6 +25,7 @@ const PARAMS: Esp32Params = Esp32Params::new(
     CHIP_ID,
     FlashFrequency::_40Mhz,
     include_bytes!("../../resources/bootloaders/esp32c6-bootloader.bin"),
+    Some(&[8 * 1024, 16 * 1024, 32 * 1024, 64 * 1024]),
 );
 
 /// ESP32-C6 Target

--- a/espflash/src/targets/esp32h2.rs
+++ b/espflash/src/targets/esp32h2.rs
@@ -25,6 +25,7 @@ const PARAMS: Esp32Params = Esp32Params::new(
     CHIP_ID,
     FlashFrequency::_24Mhz,
     include_bytes!("../../resources/bootloaders/esp32h2-bootloader.bin"),
+    Some(&[8 * 1024, 16 * 1024, 32 * 1024, 64 * 1024]),
 );
 
 /// ESP32-H2 Target

--- a/espflash/src/targets/esp32p4.rs
+++ b/espflash/src/targets/esp32p4.rs
@@ -25,6 +25,7 @@ const PARAMS: Esp32Params = Esp32Params::new(
     CHIP_ID,
     FlashFrequency::_40Mhz,
     include_bytes!("../../resources/bootloaders/esp32p4-bootloader.bin"),
+    None,
 );
 
 /// ESP32-P4 Target

--- a/espflash/src/targets/esp32s2.rs
+++ b/espflash/src/targets/esp32s2.rs
@@ -30,6 +30,7 @@ const PARAMS: Esp32Params = Esp32Params::new(
     CHIP_ID,
     FlashFrequency::_40Mhz,
     include_bytes!("../../resources/bootloaders/esp32s2-bootloader.bin"),
+    None,
 );
 
 /// ESP32-S2 Target

--- a/espflash/src/targets/esp32s3.rs
+++ b/espflash/src/targets/esp32s3.rs
@@ -25,6 +25,7 @@ const PARAMS: Esp32Params = Esp32Params::new(
     CHIP_ID,
     FlashFrequency::_40Mhz,
     include_bytes!("../../resources/bootloaders/esp32s3-bootloader.bin"),
+    None,
 );
 
 /// ESP32-S2 Target

--- a/espflash/src/targets/mod.rs
+++ b/espflash/src/targets/mod.rs
@@ -226,6 +226,8 @@ pub struct Esp32Params {
     pub chip_id: u16,
     pub flash_freq: FlashFrequency,
     pub default_bootloader: &'static [u8],
+    /// If the MMU page size is configurable, contains the supported page sizes.
+    pub mmu_page_sizes: Option<&'static [u32]>,
 }
 
 impl Esp32Params {
@@ -236,6 +238,7 @@ impl Esp32Params {
         chip_id: u16,
         flash_freq: FlashFrequency,
         bootloader: &'static [u8],
+        mmu_page_sizes: Option<&'static [u32]>,
     ) -> Self {
         Self {
             boot_addr,
@@ -249,6 +252,7 @@ impl Esp32Params {
             chip_id,
             flash_freq,
             default_bootloader: bootloader,
+            mmu_page_sizes,
         }
     }
 }


### PR DESCRIPTION
This PR:
- bubbles up the flash segment that contains the app descriptor to the first position
- reads AppDescriptor and extracts the MMU page size
- allows the user to specify an MMU page size
- defines the valid page sizes per chip to double-check the detection

Fixes #741