### PR TITLE
Add `board-info` command support in Secure Download Mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -234,7 +234,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Make the default flashing frequency target specific (#389)
 - Add note about permissions on Linux (#391)
 - Add a diagnostic to tell the user about the partition table format (#397)
-- Add `board-info` command support in Secure Download Mode (#835)
+- Add `board-info` command support in Secure Download Mode (#838)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -234,6 +234,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Make the default flashing frequency target specific (#389)
 - Add note about permissions on Linux (#391)
 - Add a diagnostic to tell the user about the partition table format (#397)
+- Add (some level of) SDM support (#832)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -234,7 +234,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Make the default flashing frequency target specific (#389)
 - Add note about permissions on Linux (#391)
 - Add a diagnostic to tell the user about the partition table format (#397)
-- Add (some level of) SDM support (#832)
+- Add `board-info` command support in Secure Download Mode (#835)
 
 ### Fixed
 

--- a/espflash/src/cli/mod.rs
+++ b/espflash/src/cli/mod.rs
@@ -575,17 +575,21 @@ pub fn parse_chip_rev(chip_rev: &str) -> Result<u16> {
 /// Print information about a chip
 pub fn print_board_info(flasher: &mut Flasher) -> Result<()> {
     let info = flasher.device_info()?;
-
     print!("Chip type:         {}", info.chip);
+
     if let Some((major, minor)) = info.revision {
         println!(" (revision v{major}.{minor})");
     } else {
         println!();
     }
+
     println!("Crystal frequency: {}", info.crystal_frequency);
     println!("Flash size:        {}", info.flash_size);
     println!("Features:          {}", info.features.join(", "));
-    println!("MAC address:       {}", info.mac_address);
+
+    if let Some(mac) = info.mac_address {
+        println!("MAC address:       {}", mac);
+    }
 
     Ok(())
 }

--- a/espflash/src/connection/mod.rs
+++ b/espflash/src/connection/mod.rs
@@ -145,7 +145,7 @@ impl Connection {
     }
 
     /// Initialize a connection with a device
-    pub fn begin(&mut self) -> Result<bool, Error> {
+    pub fn begin(&mut self) -> Result<(), Error> {
         let port_name = self.serial.name().unwrap_or_default();
         let reset_sequence = construct_reset_strategy_sequence(
             &port_name,
@@ -156,14 +156,7 @@ impl Connection {
         for (_, reset_strategy) in zip(0..MAX_CONNECT_ATTEMPTS, reset_sequence.iter().cycle()) {
             match self.connect_attempt(reset_strategy) {
                 Ok(_) => {
-                    match self.read_reg(crate::flasher::stubs::CHIP_DETECT_MAGIC_REG_ADDR) {
-                        Ok(_) => return Ok(false),
-                        Err(_) => {
-                            log::warn!("Secure Download Mode is enabled on this chip");
-                            self.secure_download_mode = true;
-                            return Ok(true);
-                        }
-                    };
+                    return Ok(());
                 }
                 Err(e) => {
                     debug!("Failed to reset, error {:#?}, retrying", e);

--- a/espflash/src/flasher/mod.rs
+++ b/espflash/src/flasher/mod.rs
@@ -634,7 +634,7 @@ pub struct DeviceInfo {
     /// Device features
     pub features: Vec<String>,
     /// MAC address
-    pub mac_address: String,
+    pub mac_address: Option<String>,
 }
 
 /// Connect to and flash a target device
@@ -674,7 +674,7 @@ impl Flasher {
         // Establish a connection to the device using the default baud rate of 115,200
         // and timeout of 3 seconds.
         let mut connection = Connection::new(serial, port_info, after_operation, before_operation);
-        connection.begin()?;
+        let sdm = connection.begin()?;
         connection.set_timeout(DEFAULT_TIMEOUT)?;
 
         let detected_chip = if before_operation != ResetBeforeOperation::NoResetNoSync {
@@ -710,13 +710,18 @@ impl Flasher {
             return Ok(flasher);
         }
 
-        // Load flash stub if enabled
-        if use_stub {
-            info!("Using flash stub");
-            flasher.load_stub()?;
+        if !sdm {
+            // Load flash stub if enabled.
+            if use_stub {
+                info!("Using flash stub");
+                flasher.load_stub()?;
+            }
+            // Flash size autodetection doesn't work in Secure Download Mode.
+            flasher.spi_autodetect()?;
+        } else if use_stub {
+            warn!("Stub is not supported in Secure Download Mode, setting --no-stub");
+            flasher.use_stub = false;
         }
-
-        flasher.spi_autodetect()?;
 
         // Now that we have established a connection and detected the chip and flash
         // size, we can set the baud rate of the connection to the configured value.
@@ -985,14 +990,21 @@ impl Flasher {
         let chip = self.chip();
         let target = chip.into_target();
 
-        let revision = Some(target.chip_revision(self.connection())?);
+        // chip_revision reads from efuse, which is not possible in Secure Download Mode
+        let revision = (!self.connection.secure_download_mode)
+            .then(|| target.chip_revision(self.connection()))
+            .transpose()?;
+
         let crystal_frequency = target.crystal_freq(self.connection())?;
         let features = target
             .chip_features(self.connection())?
             .iter()
             .map(|s| s.to_string())
             .collect::<Vec<_>>();
-        let mac_address = target.mac_address(self.connection())?;
+
+        let mac_address = (!self.connection.secure_download_mode)
+            .then(|| target.mac_address(self.connection()))
+            .transpose()?;
 
         let info = DeviceInfo {
             chip,
@@ -1102,10 +1114,20 @@ impl Flasher {
         let mut target = self
             .chip
             .flash_target(self.spi_params, self.use_stub, false, false);
+
         target.begin(&mut self.connection).flashing()?;
+
         for segment in segments {
-            target.write_segment(&mut self.connection, segment.borrow(), &mut progress)?;
+            if self.connection.secure_download_mode {
+                return Err(Error::UnsupportedFeature {
+                    chip: self.chip,
+                    feature: "writing binaries in Secure Download Mode currently".into(),
+                });
+            } else {
+                target.write_segment(&mut self.connection, segment.borrow(), &mut progress)?;
+            }
         }
+
         target.finish(&mut self.connection, true).flashing()?;
 
         Ok(())

--- a/espflash/src/flasher/mod.rs
+++ b/espflash/src/flasher/mod.rs
@@ -674,7 +674,7 @@ impl Flasher {
         // Establish a connection to the device using the default baud rate of 115,200
         // and timeout of 3 seconds.
         let mut connection = Connection::new(serial, port_info, after_operation, before_operation);
-        let sdm = connection.begin()?;
+        connection.begin()?;
         connection.set_timeout(DEFAULT_TIMEOUT)?;
 
         let detected_chip = if before_operation != ResetBeforeOperation::NoResetNoSync {
@@ -695,6 +695,8 @@ impl Flasher {
         } else {
             return Err(Error::ChipNotProvided);
         };
+
+        let sdm = connection.secure_download_mode;
 
         let mut flasher = Flasher {
             connection,


### PR DESCRIPTION
Some progress towards https://github.com/esp-rs/espflash/issues/726

Initial issue contains just a little bit of lie: espflash didn't work with SDM almost at all 😅
After this is merged, at least board-info command will be supported. `write-bin` support will be added later in https://github.com/esp-rs/espflash/pull/832

No extra flags are needed, user will be able to just execute:
```bash
espflash board-info
```

Also, --no-stub is applied automatically when tool detects that connected chip is in SDM mode.