### PR TITLE
Check monitor args

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `espflash` no longer allows flashing a too-big partition table (#830)
 - Allow specifying a partition label for `write-bin`, add `--partition-table`. (#828)
 - `--mmu-page-size` parameter for `flash` and `save-image` (#835)
+- Run some arguments checks for monitoring flags. (#842)
 
 ### Changed
 

--- a/espflash/src/cli/mod.rs
+++ b/espflash/src/cli/mod.rs
@@ -29,7 +29,7 @@ use serialport::{FlowControl, SerialPortInfo, SerialPortType, UsbPortInfo};
 
 use self::{
     config::Config,
-    monitor::{monitor, LogFormat},
+    monitor::{check_monitor_args, monitor, LogFormat},
 };
 use crate::{
     connection::reset::{ResetAfterOperation, ResetBeforeOperation},
@@ -1036,6 +1036,9 @@ pub fn make_flash_data(
 
 /// Write a binary to the flash memory of a target device
 pub fn write_bin(args: WriteBinArgs, config: &Config) -> Result<()> {
+    // Check monitor arguments
+    check_monitor_args(&args.monitor, &args.monitor_args)?;
+
     // Load the file to be flashed
     let mut f = File::open(&args.file).into_diagnostic()?;
 

--- a/espflash/src/cli/monitor/mod.rs
+++ b/espflash/src/cli/monitor/mod.rs
@@ -263,18 +263,15 @@ fn handle_key_event(key_event: KeyEvent) -> Option<Vec<u8>> {
 pub fn check_monitor_args(monitor: &bool, monitor_args: &MonitorConfigArgs) -> Result<()> {
     // Check if any monitor args are provided but monitor flag isn't set
     if !monitor
-        && (
-            monitor_args.elf.is_some()
-                || monitor_args.log_format.is_some()
-                || monitor_args.output_format.is_some()
-                || monitor_args.processors.is_some()
-                || monitor_args.non_interactive
-                || monitor_args.no_reset
-                || monitor_args.monitor_baud != 115_200
-            // Check if baud was explicitly set
-        )
+        && (monitor_args.elf.is_some()
+            || monitor_args.log_format.is_some()
+            || monitor_args.output_format.is_some()
+            || monitor_args.processors.is_some()
+            || monitor_args.non_interactive
+            || monitor_args.no_reset
+            || monitor_args.monitor_baud != 115_200)
     {
-        warn!("Monitor options were provided, but '--monitor/-M' flag isn't set. These options will be ignored.");
+        warn!("Monitor options were provided, but `--monitor/-M` flag isn't set. These options will be ignored.");
     }
 
     // Check if log-format is used with serial but output-format is specified
@@ -287,7 +284,7 @@ pub fn check_monitor_args(monitor: &bool, monitor_args: &MonitorConfigArgs) -> R
     // Check if log-format is defmt but no ELF file is provided
     if let Some(LogFormat::Defmt) = monitor_args.log_format {
         if monitor_args.elf.is_none() {
-            warn!("Log format 'defmt' requires an ELF file. Please provide one with the --elf option.");
+            warn!("Log format `defmt` requires an ELF file. Please provide one with the `--elf` option.");
         }
     }
 

--- a/espflash/src/cli/monitor/mod.rs
+++ b/espflash/src/cli/monitor/mod.rs
@@ -259,3 +259,37 @@ fn handle_key_event(key_event: KeyEvent) -> Option<Vec<u8>> {
 
     key_str.map(|slice| slice.into())
 }
+
+pub fn check_monitor_args(monitor: &bool, monitor_args: &MonitorConfigArgs) -> Result<()> {
+    // Check if any monitor args are provided but monitor flag isn't set
+    if !monitor
+        && (
+            monitor_args.elf.is_some()
+                || monitor_args.log_format.is_some()
+                || monitor_args.output_format.is_some()
+                || monitor_args.processors.is_some()
+                || monitor_args.non_interactive
+                || monitor_args.no_reset
+                || monitor_args.monitor_baud != 115_200
+            // Check if baud was explicitly set
+        )
+    {
+        warn!("Monitor options were provided, but '--monitor/-M' flag isn't set. These options will be ignored.");
+    }
+
+    // Check if log-format is used with serial but output-format is specified
+    if let Some(LogFormat::Serial) = monitor_args.log_format {
+        if monitor_args.output_format.is_some() {
+            warn!("Output format specified but log format is serial. The output format option will be ignored.");
+        }
+    }
+
+    // Check if log-format is defmt but no ELF file is provided
+    if let Some(LogFormat::Defmt) = monitor_args.log_format {
+        if monitor_args.elf.is_none() {
+            warn!("Log format 'defmt' requires an ELF file. Please provide one with the --elf option.");
+        }
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
Still far from ideal, but I guess its better than what we currently have. We will print a warning if we set any monitor arg but we dont use the monitor flag.

Also, when using `flash` subcommand the elf file is not taken from the `--elf` arg as we already know the elf. The user could still use the `--elf` flag though...