### PR TITLE
Fix CI error by installing newly required dependency

### DIFF
--- a/.github/actions/setup-target/action.yml
+++ b/.github/actions/setup-target/action.yml
@@ -50,8 +50,10 @@ runs:
           gcc-aarch64-linux-gnu \
           gcc-arm-linux-gnueabihf \
           git \
+          libc-dev \
           "libc6:${{ inputs.arch }}" \
           "libgcc-s1:${{ inputs.arch }}" \
+          linux-libc-dev \
           musl-tools \
           pkg-config
 


### PR DESCRIPTION
Not sure why this is suddenly required (CI worked fine yesterday), but easy fix at least 🤷🏻‍♂️ 