### PR TITLE
Implement new API for reading eFuse values

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[alias]
+xtask = "run --package xtask --"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -45,6 +45,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "android-tzdata"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
+
+[[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "anstream"
 version = "0.6.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -281,6 +296,20 @@ name = "cfg_aliases"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
+name = "chrono"
+version = "0.4.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a7964611d71df112cb1730f2ee67324fcf4d0fc6606acbbe9bfe06df124637c"
+dependencies = [
+ "android-tzdata",
+ "iana-time-zone",
+ "js-sys",
+ "num-traits",
+ "wasm-bindgen",
+ "windows-link",
+]
 
 [[package]]
 name = "clap"
@@ -1016,6 +1045,30 @@ dependencies = [
  "tokio",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "iana-time-zone"
+version = "0.1.63"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0c919e5debc312ad217002b8048a17b7d83f80703865bbfcfebb0458b0b27d8"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -1977,6 +2030,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_yaml"
+version = "0.9.34+deprecated"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
+dependencies = [
+ "indexmap",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
+]
+
+[[package]]
 name = "serialport"
 version = "4.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2507,6 +2573,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fc81956842c57dac11422a97c3b8195a1ff727f06e85c84ed2e8aa277c9a0fd"
 
 [[package]]
+name = "unsafe-libyaml"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
+
+[[package]]
 name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2713,13 +2785,54 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
+name = "windows-core"
+version = "0.61.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4763c1de310c86d75a878046489e2e5ba02c649d185f21c67d4cf8a56d098980"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result 0.3.2",
+ "windows-strings 0.4.0",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a47fddd13af08290e67f4acabf4b459f647552718f683a7b415d290ac744a836"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd9211b69f8dcdfa817bfd14bf1c97c9188afa36f4750130fcdf3f400eca9fa8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-link"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76840935b766e1b0a05c0066835fb9ec80071d4c09a16f6bd5f7e655e3c14c38"
+
+[[package]]
 name = "windows-registry"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e400001bb720a623c1c69032f8e3e4cf09984deec740f007dd2b03ec864804b0"
 dependencies = [
- "windows-result",
- "windows-strings",
+ "windows-result 0.2.0",
+ "windows-strings 0.1.0",
  "windows-targets 0.52.6",
 ]
 
@@ -2733,13 +2846,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-result"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c64fd11a4fd95df68efcfee5f44a294fe71b8bc6a91993e2791938abcc712252"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
 name = "windows-strings"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
 dependencies = [
- "windows-result",
+ "windows-result 0.2.0",
  "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a2ba9642430ee452d5a7aa78d72907ebe8cfda358e8cb7918a2050581322f97"
+dependencies = [
+ "windows-link",
 ]
 
 [[package]]
@@ -2924,9 +3055,12 @@ dependencies = [
 name = "xtask"
 version = "0.0.0"
 dependencies = [
+ "chrono",
  "clap",
  "env_logger",
  "log",
+ "serde",
+ "serde_yaml",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -284,9 +284,9 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "clap"
-version = "4.5.26"
+version = "4.5.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8eb5e908ef3a6efbe1ed62520fb7287959888c88485abe072543190ecc66783"
+checksum = "2df961d8c8a0d08aa9945718ccf584145eee3f3aa06cddbeac12933781102e04"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -294,9 +294,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.26"
+version = "4.5.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96b01801b5fc6a0a232407abc821660c9c6d25a1cafc0d4f85f29fb8d9afc121"
+checksum = "132dbda40fb6753878316a489d5a1242a8ef2f0d9e47ba01c951ea8aa7d013a5"
 dependencies = [
  "anstream",
  "anstyle",
@@ -316,9 +316,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.24"
+version = "4.5.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54b755194d6389280185988721fffba69495eed5ee9feeee9a599b53db80318c"
+checksum = "09176aae279615badda0765c0c0b3f6ed53f4709118af73cf4655d85d1530cd7"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -673,14 +673,14 @@ dependencies = [
 
 [[package]]
 name = "env_logger"
-version = "0.11.6"
+version = "0.11.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcaee3d8e3cfc3fd92428d477bc97fc29ec8716d180c0d74c643bb26166660e0"
+checksum = "13c863f0904021b108aa8b2f55046443e6b1ebde8fd4a15c399893aae4fa069f"
 dependencies = [
  "anstream",
  "anstyle",
  "env_filter",
- "humantime",
+ "jiff",
  "log",
 ]
 
@@ -963,12 +963,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d71d3574edd2771538b901e6549113b4006ece66150fb69c0fb6d9a2adae946"
 
 [[package]]
-name = "humantime"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
-
-[[package]]
 name = "hyper"
 version = "1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1227,6 +1221,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d75a2a4b1b190afb6f5425f10f6a8f959d2ea0b9c2b1d79553551850539e4674"
 
 [[package]]
+name = "jiff"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5ad87c89110f55e4cd4dc2893a9790820206729eaf221555f742d540b0724a0"
+dependencies = [
+ "jiff-static",
+ "log",
+ "portable-atomic",
+ "portable-atomic-util",
+ "serde",
+]
+
+[[package]]
+name = "jiff-static"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d076d5b64a7e2fe6f0743f02c43ca4a6725c0f904203bfe276a5b3e793103605"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1282,9 +1300,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.22"
+version = "0.4.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
+checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
 dependencies = [
  "serde",
 ]
@@ -1545,6 +1563,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "280dc24453071f1b63954171985a0b0d30058d287960968b9b2aca264c8d4ee6"
 
 [[package]]
+name = "portable-atomic-util"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8a2f0d8d040d7848a709caf78912debcc3f33ee4b3cac47d73d1e1069e83507"
+dependencies = [
+ "portable-atomic",
+]
+
+[[package]]
 name = "powerfmt"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1570,9 +1597,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.92"
+version = "1.0.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37d3544b3f2748c54e147655edb5025752e2303145b5aefb3c3ea2c78b973bb0"
+checksum = "a31971752e70b8b2686d7e46ec17fb38dad4051d94024c88df49b667caea9c84"
 dependencies = [
  "unicode-ident",
 ]
@@ -2148,9 +2175,9 @@ checksum = "b7401a30af6cb5818bb64852270bb722533397edcfc7344954a38f420819ece2"
 
 [[package]]
 name = "syn"
-version = "2.0.96"
+version = "2.0.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5d0adab1ae378d7f53bdebc67a39f1f151407ef230f0ce2883572f5d8985c80"
+checksum = "b09a44accad81e1ba1cd74a32461ba89dee89095ba17b32f5d03683b1b1fc2a0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2891,6 +2918,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
 dependencies = [
  "tap",
+]
+
+[[package]]
+name = "xtask"
+version = "0.0.0"
+dependencies = [
+ "clap",
+ "env_logger",
+ "log",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
 resolver = "2"
-members  = ["cargo-espflash", "espflash"]
+members  = ["cargo-espflash", "espflash", "xtask"]
 
 [profile.release]
 lto   = "thin"

--- a/espflash/src/connection/mod.rs
+++ b/espflash/src/connection/mod.rs
@@ -557,9 +557,9 @@ impl Connection {
     }
 
     /// Read a register command with a timeout
-    pub fn read_reg(&mut self, reg: u32) -> Result<u32, Error> {
+    pub fn read_reg(&mut self, addr: u32) -> Result<u32, Error> {
         let resp = self.with_timeout(CommandType::ReadReg.timeout(), |connection| {
-            connection.command(Command::ReadReg { address: reg })
+            connection.command(Command::ReadReg { address: addr })
         })?;
 
         resp.try_into()

--- a/espflash/src/targets/efuse/esp32.rs
+++ b/espflash/src/targets/efuse/esp32.rs
@@ -1,0 +1,145 @@
+//! This file was automatically generated, please do not edit it manually!
+//!
+//! Generated: 2025-04-15 12:51
+//! Version:   369d2d860d34e777c0f7d545a7dfc3c4
+
+#![allow(unused)]
+
+use super::EfuseField;
+
+/// Total size in bytes of each block
+pub(crate) const BLOCK_SIZES: &[u32] = &[28, 32, 32, 32];
+
+/// Efuse write disable mask
+pub(crate) const WR_DIS: EfuseField = EfuseField::new(0, 0, 0, 16);
+/// Disable reading from BlOCK1-3
+pub(crate) const RD_DIS: EfuseField = EfuseField::new(0, 0, 16, 4);
+/// Flash encryption is enabled if this field has an odd number of bits set
+pub(crate) const FLASH_CRYPT_CNT: EfuseField = EfuseField::new(0, 0, 20, 7);
+/// Disable UART download mode. Valid for ESP32 V3 and newer; only
+pub(crate) const UART_DOWNLOAD_DIS: EfuseField = EfuseField::new(0, 0, 27, 1);
+/// reserved
+pub(crate) const RESERVED_0_28: EfuseField = EfuseField::new(0, 0, 28, 4);
+/// MAC address
+pub(crate) const MAC0: EfuseField = EfuseField::new(0, 1, 0, 32);
+/// MAC address
+pub(crate) const MAC1: EfuseField = EfuseField::new(0, 2, 32, 16);
+/// CRC8 for MAC address
+pub(crate) const MAC_CRC: EfuseField = EfuseField::new(0, 2, 80, 8);
+/// Reserved; it was created by set_missed_fields_in_regs func
+pub(crate) const RESERVE_0_88: EfuseField = EfuseField::new(0, 2, 88, 8);
+/// Disables APP CPU
+pub(crate) const DISABLE_APP_CPU: EfuseField = EfuseField::new(0, 3, 96, 1);
+/// Disables Bluetooth
+pub(crate) const DISABLE_BT: EfuseField = EfuseField::new(0, 3, 97, 1);
+/// Chip package identifier #4bit
+pub(crate) const CHIP_PACKAGE_4BIT: EfuseField = EfuseField::new(0, 3, 98, 1);
+/// Disables cache
+pub(crate) const DIS_CACHE: EfuseField = EfuseField::new(0, 3, 99, 1);
+/// read for SPI_pad_config_hd
+pub(crate) const SPI_PAD_CONFIG_HD: EfuseField = EfuseField::new(0, 3, 100, 5);
+/// Chip package identifier
+pub(crate) const CHIP_PACKAGE: EfuseField = EfuseField::new(0, 3, 105, 3);
+/// If set alongside EFUSE_RD_CHIP_CPU_FREQ_RATED; the ESP32's max CPU frequency
+/// is rated for 160MHz. 240MHz otherwise
+pub(crate) const CHIP_CPU_FREQ_LOW: EfuseField = EfuseField::new(0, 3, 108, 1);
+/// If set; the ESP32's maximum CPU frequency has been rated
+pub(crate) const CHIP_CPU_FREQ_RATED: EfuseField = EfuseField::new(0, 3, 109, 1);
+/// BLOCK3 partially served for ADC calibration data
+pub(crate) const BLK3_PART_RESERVE: EfuseField = EfuseField::new(0, 3, 110, 1);
+/// bit is set to 1 for rev1 silicon
+pub(crate) const CHIP_VER_REV1: EfuseField = EfuseField::new(0, 3, 111, 1);
+/// Reserved; it was created by set_missed_fields_in_regs func
+pub(crate) const RESERVE_0_112: EfuseField = EfuseField::new(0, 3, 112, 16);
+/// 8MHz clock freq override
+pub(crate) const CLK8M_FREQ: EfuseField = EfuseField::new(0, 4, 128, 8);
+/// True ADC reference voltage
+pub(crate) const ADC_VREF: EfuseField = EfuseField::new(0, 4, 136, 5);
+/// Reserved; it was created by set_missed_fields_in_regs func
+pub(crate) const RESERVE_0_141: EfuseField = EfuseField::new(0, 4, 141, 1);
+/// read for XPD_SDIO_REG
+pub(crate) const XPD_SDIO_REG: EfuseField = EfuseField::new(0, 4, 142, 1);
+/// If XPD_SDIO_FORCE & XPD_SDIO_REG
+pub(crate) const XPD_SDIO_TIEH: EfuseField = EfuseField::new(0, 4, 143, 1);
+/// Ignore MTDI pin (GPIO12) for VDD_SDIO on reset
+pub(crate) const XPD_SDIO_FORCE: EfuseField = EfuseField::new(0, 4, 144, 1);
+/// Reserved; it was created by set_missed_fields_in_regs func
+pub(crate) const RESERVE_0_145: EfuseField = EfuseField::new(0, 4, 145, 15);
+/// Override SD_CLK pad (GPIO6/SPICLK)
+pub(crate) const SPI_PAD_CONFIG_CLK: EfuseField = EfuseField::new(0, 5, 160, 5);
+/// Override SD_DATA_0 pad (GPIO7/SPIQ)
+pub(crate) const SPI_PAD_CONFIG_Q: EfuseField = EfuseField::new(0, 5, 165, 5);
+/// Override SD_DATA_1 pad (GPIO8/SPID)
+pub(crate) const SPI_PAD_CONFIG_D: EfuseField = EfuseField::new(0, 5, 170, 5);
+/// Override SD_CMD pad (GPIO11/SPICS0)
+pub(crate) const SPI_PAD_CONFIG_CS0: EfuseField = EfuseField::new(0, 5, 175, 5);
+///
+pub(crate) const CHIP_VER_REV2: EfuseField = EfuseField::new(0, 5, 180, 1);
+/// Reserved; it was created by set_missed_fields_in_regs func
+pub(crate) const RESERVE_0_181: EfuseField = EfuseField::new(0, 5, 181, 1);
+/// This field stores the voltage level for CPU to run at 240 MHz; or for
+/// flash/PSRAM to run at 80 MHz.0x0: level 7; 0x1: level 6; 0x2: level 5; 0x3:
+/// level 4. (RO)
+pub(crate) const VOL_LEVEL_HP_INV: EfuseField = EfuseField::new(0, 5, 182, 2);
+///
+pub(crate) const WAFER_VERSION_MINOR: EfuseField = EfuseField::new(0, 5, 184, 2);
+/// Reserved; it was created by set_missed_fields_in_regs func
+pub(crate) const RESERVE_0_186: EfuseField = EfuseField::new(0, 5, 186, 2);
+/// Flash encryption config (key tweak bits)
+pub(crate) const FLASH_CRYPT_CONFIG: EfuseField = EfuseField::new(0, 5, 188, 4);
+/// Efuse variable block length scheme
+pub(crate) const CODING_SCHEME: EfuseField = EfuseField::new(0, 6, 192, 2);
+/// Disable ROM BASIC interpreter fallback
+pub(crate) const CONSOLE_DEBUG_DISABLE: EfuseField = EfuseField::new(0, 6, 194, 1);
+///
+pub(crate) const DISABLE_SDIO_HOST: EfuseField = EfuseField::new(0, 6, 195, 1);
+/// Secure boot V1 is enabled for bootloader image
+pub(crate) const ABS_DONE_0: EfuseField = EfuseField::new(0, 6, 196, 1);
+/// Secure boot V2 is enabled for bootloader image
+pub(crate) const ABS_DONE_1: EfuseField = EfuseField::new(0, 6, 197, 1);
+/// Disable JTAG
+pub(crate) const JTAG_DISABLE: EfuseField = EfuseField::new(0, 6, 198, 1);
+/// Disable flash encryption in UART bootloader
+pub(crate) const DISABLE_DL_ENCRYPT: EfuseField = EfuseField::new(0, 6, 199, 1);
+/// Disable flash decryption in UART bootloader
+pub(crate) const DISABLE_DL_DECRYPT: EfuseField = EfuseField::new(0, 6, 200, 1);
+/// Disable flash cache in UART bootloader
+pub(crate) const DISABLE_DL_CACHE: EfuseField = EfuseField::new(0, 6, 201, 1);
+/// Usage of efuse block 3 (reserved)
+pub(crate) const KEY_STATUS: EfuseField = EfuseField::new(0, 6, 202, 1);
+/// Reserved; it was created by set_missed_fields_in_regs func
+pub(crate) const RESERVE_0_203: EfuseField = EfuseField::new(0, 6, 203, 21);
+/// Flash encryption key
+pub(crate) const BLOCK1: EfuseField = EfuseField::new(1, 0, 0, 256);
+/// Security boot key
+pub(crate) const BLOCK2: EfuseField = EfuseField::new(2, 0, 0, 256);
+/// CRC8 for custom MAC address
+pub(crate) const CUSTOM_MAC_CRC: EfuseField = EfuseField::new(3, 0, 0, 8);
+/// Custom MAC address
+pub(crate) const CUSTOM_MAC: EfuseField = EfuseField::new(3, 0, 8, 48);
+/// reserved
+pub(crate) const RESERVED_3_56: EfuseField = EfuseField::new(3, 1, 56, 8);
+/// read for BLOCK3
+pub(crate) const BLK3_RESERVED_2: EfuseField = EfuseField::new(3, 2, 64, 32);
+/// ADC1 Two Point calibration low point. Only valid if
+/// EFUSE_RD_BLK3_PART_RESERVE
+pub(crate) const ADC1_TP_LOW: EfuseField = EfuseField::new(3, 3, 96, 7);
+/// ADC1 Two Point calibration high point. Only valid if
+/// EFUSE_RD_BLK3_PART_RESERVE
+pub(crate) const ADC1_TP_HIGH: EfuseField = EfuseField::new(3, 3, 103, 9);
+/// ADC2 Two Point calibration low point. Only valid if
+/// EFUSE_RD_BLK3_PART_RESERVE
+pub(crate) const ADC2_TP_LOW: EfuseField = EfuseField::new(3, 3, 112, 7);
+/// ADC2 Two Point calibration high point. Only valid if
+/// EFUSE_RD_BLK3_PART_RESERVE
+pub(crate) const ADC2_TP_HIGH: EfuseField = EfuseField::new(3, 3, 119, 9);
+/// Secure version for anti-rollback
+pub(crate) const SECURE_VERSION: EfuseField = EfuseField::new(3, 4, 128, 32);
+/// reserved
+pub(crate) const RESERVED_3_160: EfuseField = EfuseField::new(3, 5, 160, 24);
+/// Version of the MAC field
+pub(crate) const MAC_VERSION: EfuseField = EfuseField::new(3, 5, 184, 8);
+/// read for BLOCK3
+pub(crate) const BLK3_RESERVED_6: EfuseField = EfuseField::new(3, 6, 192, 32);
+/// read for BLOCK3
+pub(crate) const BLK3_RESERVED_7: EfuseField = EfuseField::new(3, 7, 224, 32);

--- a/espflash/src/targets/efuse/esp32c2.rs
+++ b/espflash/src/targets/efuse/esp32c2.rs
@@ -1,0 +1,118 @@
+//! This file was automatically generated, please do not edit it manually!
+//!
+//! Generated: 2025-04-15 12:51
+//! Version:   897499b0349a608b895d467abbcf006b
+
+#![allow(unused)]
+
+use super::EfuseField;
+
+/// Total size in bytes of each block
+pub(crate) const BLOCK_SIZES: &[u32] = &[8, 11, 32, 32];
+
+/// Disable programming of individual eFuses
+pub(crate) const WR_DIS: EfuseField = EfuseField::new(0, 0, 0, 8);
+///
+pub(crate) const RESERVED_0_8: EfuseField = EfuseField::new(0, 0, 8, 24);
+/// Disable reading from BlOCK3
+pub(crate) const RD_DIS: EfuseField = EfuseField::new(0, 1, 32, 2);
+/// RTC watchdog timeout threshold; in unit of slow clock cycle
+pub(crate) const WDT_DELAY_SEL: EfuseField = EfuseField::new(0, 1, 34, 2);
+/// Set this bit to disable pad jtag
+pub(crate) const DIS_PAD_JTAG: EfuseField = EfuseField::new(0, 1, 36, 1);
+/// The bit be set to disable icache in download mode
+pub(crate) const DIS_DOWNLOAD_ICACHE: EfuseField = EfuseField::new(0, 1, 37, 1);
+/// The bit be set to disable manual encryption
+pub(crate) const DIS_DOWNLOAD_MANUAL_ENCRYPT: EfuseField = EfuseField::new(0, 1, 38, 1);
+/// Enables flash encryption when 1 or 3 bits are set and disables otherwise
+pub(crate) const SPI_BOOT_CRYPT_CNT: EfuseField = EfuseField::new(0, 1, 39, 3);
+/// Flash encryption key length
+pub(crate) const XTS_KEY_LENGTH_256: EfuseField = EfuseField::new(0, 1, 42, 1);
+/// Set the default UARTboot message output mode
+pub(crate) const UART_PRINT_CONTROL: EfuseField = EfuseField::new(0, 1, 43, 2);
+/// Set this bit to force ROM code to send a resume command during SPI boot
+pub(crate) const FORCE_SEND_RESUME: EfuseField = EfuseField::new(0, 1, 45, 1);
+/// Set this bit to disable download mode (boot_mode[3:0] = 0; 1; 2; 4; 5; 6; 7)
+pub(crate) const DIS_DOWNLOAD_MODE: EfuseField = EfuseField::new(0, 1, 46, 1);
+/// This bit set means disable direct_boot mode
+pub(crate) const DIS_DIRECT_BOOT: EfuseField = EfuseField::new(0, 1, 47, 1);
+/// Set this bit to enable secure UART download mode
+pub(crate) const ENABLE_SECURITY_DOWNLOAD: EfuseField = EfuseField::new(0, 1, 48, 1);
+/// Configures flash waiting time after power-up; in unit of ms. If the value is
+/// less than 15; the waiting time is the configurable value.  Otherwise; the
+/// waiting time is twice the configurable value
+pub(crate) const FLASH_TPUW: EfuseField = EfuseField::new(0, 1, 49, 4);
+/// The bit be set to enable secure boot
+pub(crate) const SECURE_BOOT_EN: EfuseField = EfuseField::new(0, 1, 53, 1);
+/// Secure version for anti-rollback
+pub(crate) const SECURE_VERSION: EfuseField = EfuseField::new(0, 1, 54, 4);
+/// True if MAC_CUSTOM is burned
+pub(crate) const CUSTOM_MAC_USED: EfuseField = EfuseField::new(0, 1, 58, 1);
+/// Disables check of wafer version major
+pub(crate) const DISABLE_WAFER_VERSION_MAJOR: EfuseField = EfuseField::new(0, 1, 59, 1);
+/// Disables check of blk version major
+pub(crate) const DISABLE_BLK_VERSION_MAJOR: EfuseField = EfuseField::new(0, 1, 60, 1);
+/// reserved
+pub(crate) const RESERVED_0_61: EfuseField = EfuseField::new(0, 1, 61, 3);
+/// Custom MAC address
+pub(crate) const CUSTOM_MAC: EfuseField = EfuseField::new(1, 0, 0, 48);
+/// reserved
+pub(crate) const RESERVED_1_48: EfuseField = EfuseField::new(1, 1, 48, 16);
+/// Stores the bits [64:87] of system data
+pub(crate) const SYSTEM_DATA2: EfuseField = EfuseField::new(1, 2, 64, 24);
+/// MAC address
+pub(crate) const MAC0: EfuseField = EfuseField::new(2, 0, 0, 32);
+/// MAC address
+pub(crate) const MAC1: EfuseField = EfuseField::new(2, 1, 0, 16);
+/// WAFER_VERSION_MINOR
+pub(crate) const WAFER_VERSION_MINOR: EfuseField = EfuseField::new(2, 1, 48, 4);
+/// WAFER_VERSION_MAJOR
+pub(crate) const WAFER_VERSION_MAJOR: EfuseField = EfuseField::new(2, 1, 52, 2);
+/// EFUSE_PKG_VERSION
+pub(crate) const PKG_VERSION: EfuseField = EfuseField::new(2, 1, 54, 3);
+/// Minor version of BLOCK2
+pub(crate) const BLK_VERSION_MINOR: EfuseField = EfuseField::new(2, 1, 57, 3);
+/// Major version of BLOCK2
+pub(crate) const BLK_VERSION_MAJOR: EfuseField = EfuseField::new(2, 1, 60, 2);
+/// OCode
+pub(crate) const OCODE: EfuseField = EfuseField::new(2, 1, 62, 7);
+/// Temperature calibration data
+pub(crate) const TEMP_CALIB: EfuseField = EfuseField::new(2, 2, 69, 9);
+/// ADC1 init code at atten0
+pub(crate) const ADC1_INIT_CODE_ATTEN0: EfuseField = EfuseField::new(2, 2, 78, 8);
+/// ADC1 init code at atten3
+pub(crate) const ADC1_INIT_CODE_ATTEN3: EfuseField = EfuseField::new(2, 2, 86, 5);
+/// ADC1 calibration voltage at atten0
+pub(crate) const ADC1_CAL_VOL_ATTEN0: EfuseField = EfuseField::new(2, 2, 91, 8);
+/// ADC1 calibration voltage at atten3
+pub(crate) const ADC1_CAL_VOL_ATTEN3: EfuseField = EfuseField::new(2, 3, 99, 6);
+/// BLOCK2 digital dbias when hvt
+pub(crate) const DIG_DBIAS_HVT: EfuseField = EfuseField::new(2, 3, 105, 5);
+/// BLOCK2 DIG_LDO_DBG0_DBIAS2
+pub(crate) const DIG_LDO_SLP_DBIAS2: EfuseField = EfuseField::new(2, 3, 110, 7);
+/// BLOCK2 DIG_LDO_DBG0_DBIAS26
+pub(crate) const DIG_LDO_SLP_DBIAS26: EfuseField = EfuseField::new(2, 3, 117, 8);
+/// BLOCK2 DIG_LDO_ACT_DBIAS26
+pub(crate) const DIG_LDO_ACT_DBIAS26: EfuseField = EfuseField::new(2, 3, 125, 6);
+/// BLOCK2 DIG_LDO_ACT_STEPD10
+pub(crate) const DIG_LDO_ACT_STEPD10: EfuseField = EfuseField::new(2, 4, 131, 4);
+/// BLOCK2 DIG_LDO_SLP_DBIAS13
+pub(crate) const RTC_LDO_SLP_DBIAS13: EfuseField = EfuseField::new(2, 4, 135, 7);
+/// BLOCK2 DIG_LDO_SLP_DBIAS29
+pub(crate) const RTC_LDO_SLP_DBIAS29: EfuseField = EfuseField::new(2, 4, 142, 9);
+/// BLOCK2 DIG_LDO_SLP_DBIAS31
+pub(crate) const RTC_LDO_SLP_DBIAS31: EfuseField = EfuseField::new(2, 4, 151, 6);
+/// BLOCK2 DIG_LDO_ACT_DBIAS31
+pub(crate) const RTC_LDO_ACT_DBIAS31: EfuseField = EfuseField::new(2, 4, 157, 6);
+/// BLOCK2 DIG_LDO_ACT_DBIAS13
+pub(crate) const RTC_LDO_ACT_DBIAS13: EfuseField = EfuseField::new(2, 5, 163, 8);
+/// reserved
+pub(crate) const RESERVED_2_171: EfuseField = EfuseField::new(2, 5, 171, 21);
+/// Store the bit [86:96] of ADC calibration data
+pub(crate) const ADC_CALIBRATION_3: EfuseField = EfuseField::new(2, 6, 192, 11);
+/// Store the bit [0:20] of block2 reserved data
+pub(crate) const BLK2_RESERVED_DATA_0: EfuseField = EfuseField::new(2, 6, 203, 21);
+/// Store the bit [21:52] of block2 reserved data
+pub(crate) const BLK2_RESERVED_DATA_1: EfuseField = EfuseField::new(2, 7, 224, 32);
+/// BLOCK_KEY0 - 256-bits. 256-bit key of Flash Encryption
+pub(crate) const BLOCK_KEY0: EfuseField = EfuseField::new(3, 0, 0, 256);

--- a/espflash/src/targets/efuse/esp32c3.rs
+++ b/espflash/src/targets/efuse/esp32c3.rs
@@ -1,0 +1,243 @@
+//! This file was automatically generated, please do not edit it manually!
+//!
+//! Generated: 2025-04-15 12:51
+//! Version:   4622cf9245401eca0eb1df8122449a6d
+
+#![allow(unused)]
+
+use super::EfuseField;
+
+/// Total size in bytes of each block
+pub(crate) const BLOCK_SIZES: &[u32] = &[23, 24, 32, 32, 32, 32, 32, 32, 32, 32, 32];
+
+/// Disable programming of individual eFuses
+pub(crate) const WR_DIS: EfuseField = EfuseField::new(0, 0, 0, 32);
+/// Disable reading from BlOCK4-10
+pub(crate) const RD_DIS: EfuseField = EfuseField::new(0, 1, 32, 7);
+/// Set this bit to disable boot from RTC RAM
+pub(crate) const DIS_RTC_RAM_BOOT: EfuseField = EfuseField::new(0, 1, 39, 1);
+/// Set this bit to disable Icache
+pub(crate) const DIS_ICACHE: EfuseField = EfuseField::new(0, 1, 40, 1);
+/// Set this bit to disable function of usb switch to jtag in module of usb
+/// device
+pub(crate) const DIS_USB_JTAG: EfuseField = EfuseField::new(0, 1, 41, 1);
+/// Set this bit to disable Icache in download mode (boot_mode[3:0] is 0; 1; 2;
+/// 3; 6; 7)
+pub(crate) const DIS_DOWNLOAD_ICACHE: EfuseField = EfuseField::new(0, 1, 42, 1);
+/// USB-Serial-JTAG
+pub(crate) const DIS_USB_SERIAL_JTAG: EfuseField = EfuseField::new(0, 1, 43, 1);
+/// Set this bit to disable the function that forces chip into download mode
+pub(crate) const DIS_FORCE_DOWNLOAD: EfuseField = EfuseField::new(0, 1, 44, 1);
+/// Reserved (used for four backups method)
+pub(crate) const RPT4_RESERVED6: EfuseField = EfuseField::new(0, 1, 45, 1);
+/// Set this bit to disable CAN function
+pub(crate) const DIS_TWAI: EfuseField = EfuseField::new(0, 1, 46, 1);
+/// Set this bit to enable selection between usb_to_jtag and pad_to_jtag through
+/// strapping gpio10 when both reg_dis_usb_jtag and reg_dis_pad_jtag are equal
+/// to 0
+pub(crate) const JTAG_SEL_ENABLE: EfuseField = EfuseField::new(0, 1, 47, 1);
+/// Set these bits to disable JTAG in the soft way (odd number 1 means disable
+/// ). JTAG can be enabled in HMAC module
+pub(crate) const SOFT_DIS_JTAG: EfuseField = EfuseField::new(0, 1, 48, 3);
+/// Set this bit to disable JTAG in the hard way. JTAG is disabled permanently
+pub(crate) const DIS_PAD_JTAG: EfuseField = EfuseField::new(0, 1, 51, 1);
+/// Set this bit to disable flash encryption when in download boot modes
+pub(crate) const DIS_DOWNLOAD_MANUAL_ENCRYPT: EfuseField = EfuseField::new(0, 1, 52, 1);
+/// Controls single-end input threshold vrefh; 1.76 V to 2 V with step of 80 mV;
+/// stored in eFuse
+pub(crate) const USB_DREFH: EfuseField = EfuseField::new(0, 1, 53, 2);
+/// Controls single-end input threshold vrefl; 0.8 V to 1.04 V with step of 80
+/// mV; stored in eFuse
+pub(crate) const USB_DREFL: EfuseField = EfuseField::new(0, 1, 55, 2);
+/// Set this bit to exchange USB D+ and D- pins
+pub(crate) const USB_EXCHG_PINS: EfuseField = EfuseField::new(0, 1, 57, 1);
+/// Set this bit to vdd spi pin function as gpio
+pub(crate) const VDD_SPI_AS_GPIO: EfuseField = EfuseField::new(0, 1, 58, 1);
+/// Enable btlc gpio
+pub(crate) const BTLC_GPIO_ENABLE: EfuseField = EfuseField::new(0, 1, 59, 2);
+/// Set this bit to enable power glitch function
+pub(crate) const POWERGLITCH_EN: EfuseField = EfuseField::new(0, 1, 61, 1);
+/// Sample delay configuration of power glitch
+pub(crate) const POWER_GLITCH_DSENSE: EfuseField = EfuseField::new(0, 1, 62, 2);
+/// Reserved (used for four backups method)
+pub(crate) const RPT4_RESERVED2: EfuseField = EfuseField::new(0, 2, 64, 16);
+/// RTC watchdog timeout threshold; in unit of slow clock cycle
+pub(crate) const WDT_DELAY_SEL: EfuseField = EfuseField::new(0, 2, 80, 2);
+/// Enables flash encryption when 1 or 3 bits are set and disables otherwise
+pub(crate) const SPI_BOOT_CRYPT_CNT: EfuseField = EfuseField::new(0, 2, 82, 3);
+/// Revoke 1st secure boot key
+pub(crate) const SECURE_BOOT_KEY_REVOKE0: EfuseField = EfuseField::new(0, 2, 85, 1);
+/// Revoke 2nd secure boot key
+pub(crate) const SECURE_BOOT_KEY_REVOKE1: EfuseField = EfuseField::new(0, 2, 86, 1);
+/// Revoke 3rd secure boot key
+pub(crate) const SECURE_BOOT_KEY_REVOKE2: EfuseField = EfuseField::new(0, 2, 87, 1);
+/// Purpose of Key0
+pub(crate) const KEY_PURPOSE_0: EfuseField = EfuseField::new(0, 2, 88, 4);
+/// Purpose of Key1
+pub(crate) const KEY_PURPOSE_1: EfuseField = EfuseField::new(0, 2, 92, 4);
+/// Purpose of Key2
+pub(crate) const KEY_PURPOSE_2: EfuseField = EfuseField::new(0, 3, 96, 4);
+/// Purpose of Key3
+pub(crate) const KEY_PURPOSE_3: EfuseField = EfuseField::new(0, 3, 100, 4);
+/// Purpose of Key4
+pub(crate) const KEY_PURPOSE_4: EfuseField = EfuseField::new(0, 3, 104, 4);
+/// Purpose of Key5
+pub(crate) const KEY_PURPOSE_5: EfuseField = EfuseField::new(0, 3, 108, 4);
+/// Reserved (used for four backups method)
+pub(crate) const RPT4_RESERVED3: EfuseField = EfuseField::new(0, 3, 112, 4);
+/// Set this bit to enable secure boot
+pub(crate) const SECURE_BOOT_EN: EfuseField = EfuseField::new(0, 3, 116, 1);
+/// Set this bit to enable revoking aggressive secure boot
+pub(crate) const SECURE_BOOT_AGGRESSIVE_REVOKE: EfuseField = EfuseField::new(0, 3, 117, 1);
+/// Reserved (used for four backups method)
+pub(crate) const RPT4_RESERVED0: EfuseField = EfuseField::new(0, 3, 118, 6);
+/// Configures flash waiting time after power-up; in unit of ms. If the value is
+/// less than 15; the waiting time is the configurable value; Otherwise; the
+/// waiting time is twice the configurable value
+pub(crate) const FLASH_TPUW: EfuseField = EfuseField::new(0, 3, 124, 4);
+/// Set this bit to disable download mode (boot_mode[3:0] = 0; 1; 2; 3; 6; 7)
+pub(crate) const DIS_DOWNLOAD_MODE: EfuseField = EfuseField::new(0, 4, 128, 1);
+/// Disable direct boot mode
+pub(crate) const DIS_DIRECT_BOOT: EfuseField = EfuseField::new(0, 4, 129, 1);
+/// USB printing
+pub(crate) const DIS_USB_SERIAL_JTAG_ROM_PRINT: EfuseField = EfuseField::new(0, 4, 130, 1);
+/// ECC mode in ROM
+pub(crate) const FLASH_ECC_MODE: EfuseField = EfuseField::new(0, 4, 131, 1);
+/// Disable UART download mode through USB-Serial-JTAG
+pub(crate) const DIS_USB_SERIAL_JTAG_DOWNLOAD_MODE: EfuseField = EfuseField::new(0, 4, 132, 1);
+/// Set this bit to enable secure UART download mode
+pub(crate) const ENABLE_SECURITY_DOWNLOAD: EfuseField = EfuseField::new(0, 4, 133, 1);
+/// Set the default UARTboot message output mode
+pub(crate) const UART_PRINT_CONTROL: EfuseField = EfuseField::new(0, 4, 134, 2);
+/// GPIO33-GPIO37 power supply selection in ROM code
+pub(crate) const PIN_POWER_SELECTION: EfuseField = EfuseField::new(0, 4, 136, 1);
+/// Maximum lines of SPI flash
+pub(crate) const FLASH_TYPE: EfuseField = EfuseField::new(0, 4, 137, 1);
+/// Set Flash page size
+pub(crate) const FLASH_PAGE_SIZE: EfuseField = EfuseField::new(0, 4, 138, 2);
+/// Set 1 to enable ECC for flash boot
+pub(crate) const FLASH_ECC_EN: EfuseField = EfuseField::new(0, 4, 140, 1);
+/// Set this bit to force ROM code to send a resume command during SPI boot
+pub(crate) const FORCE_SEND_RESUME: EfuseField = EfuseField::new(0, 4, 141, 1);
+/// Secure version (used by ESP-IDF anti-rollback feature)
+pub(crate) const SECURE_VERSION: EfuseField = EfuseField::new(0, 4, 142, 16);
+/// reserved
+pub(crate) const RESERVED_0_158: EfuseField = EfuseField::new(0, 4, 158, 1);
+/// Use BLOCK0 to check error record registers
+pub(crate) const ERR_RST_ENABLE: EfuseField = EfuseField::new(0, 4, 159, 1);
+/// Disables check of wafer version major
+pub(crate) const DISABLE_WAFER_VERSION_MAJOR: EfuseField = EfuseField::new(0, 5, 160, 1);
+/// Disables check of blk version major
+pub(crate) const DISABLE_BLK_VERSION_MAJOR: EfuseField = EfuseField::new(0, 5, 161, 1);
+/// reserved
+pub(crate) const RESERVED_0_162: EfuseField = EfuseField::new(0, 5, 162, 22);
+/// MAC address
+pub(crate) const MAC0: EfuseField = EfuseField::new(1, 0, 0, 32);
+/// MAC address
+pub(crate) const MAC1: EfuseField = EfuseField::new(1, 1, 0, 16);
+/// SPI PAD CLK
+pub(crate) const SPI_PAD_CONFIG_CLK: EfuseField = EfuseField::new(1, 1, 48, 6);
+/// SPI PAD Q(D1)
+pub(crate) const SPI_PAD_CONFIG_Q: EfuseField = EfuseField::new(1, 1, 54, 6);
+/// SPI PAD D(D0)
+pub(crate) const SPI_PAD_CONFIG_D: EfuseField = EfuseField::new(1, 1, 60, 6);
+/// SPI PAD CS
+pub(crate) const SPI_PAD_CONFIG_CS: EfuseField = EfuseField::new(1, 2, 66, 6);
+/// SPI PAD HD(D3)
+pub(crate) const SPI_PAD_CONFIG_HD: EfuseField = EfuseField::new(1, 2, 72, 6);
+/// SPI PAD WP(D2)
+pub(crate) const SPI_PAD_CONFIG_WP: EfuseField = EfuseField::new(1, 2, 78, 6);
+/// SPI PAD DQS
+pub(crate) const SPI_PAD_CONFIG_DQS: EfuseField = EfuseField::new(1, 2, 84, 6);
+/// SPI PAD D4
+pub(crate) const SPI_PAD_CONFIG_D4: EfuseField = EfuseField::new(1, 2, 90, 6);
+/// SPI PAD D5
+pub(crate) const SPI_PAD_CONFIG_D5: EfuseField = EfuseField::new(1, 3, 96, 6);
+/// SPI PAD D6
+pub(crate) const SPI_PAD_CONFIG_D6: EfuseField = EfuseField::new(1, 3, 102, 6);
+/// SPI PAD D7
+pub(crate) const SPI_PAD_CONFIG_D7: EfuseField = EfuseField::new(1, 3, 108, 6);
+/// WAFER_VERSION_MINOR least significant bits
+pub(crate) const WAFER_VERSION_MINOR_LO: EfuseField = EfuseField::new(1, 3, 114, 3);
+/// Package version
+pub(crate) const PKG_VERSION: EfuseField = EfuseField::new(1, 3, 117, 3);
+/// BLK_VERSION_MINOR
+pub(crate) const BLK_VERSION_MINOR: EfuseField = EfuseField::new(1, 3, 120, 3);
+/// Flash capacity
+pub(crate) const FLASH_CAP: EfuseField = EfuseField::new(1, 3, 123, 3);
+/// Flash temperature
+pub(crate) const FLASH_TEMP: EfuseField = EfuseField::new(1, 3, 126, 2);
+/// Flash vendor
+pub(crate) const FLASH_VENDOR: EfuseField = EfuseField::new(1, 4, 128, 3);
+/// reserved
+pub(crate) const RESERVED_1_131: EfuseField = EfuseField::new(1, 4, 131, 4);
+/// BLOCK1 K_RTC_LDO
+pub(crate) const K_RTC_LDO: EfuseField = EfuseField::new(1, 4, 135, 7);
+/// BLOCK1 K_DIG_LDO
+pub(crate) const K_DIG_LDO: EfuseField = EfuseField::new(1, 4, 142, 7);
+/// BLOCK1 voltage of rtc dbias20
+pub(crate) const V_RTC_DBIAS20: EfuseField = EfuseField::new(1, 4, 149, 8);
+/// BLOCK1 voltage of digital dbias20
+pub(crate) const V_DIG_DBIAS20: EfuseField = EfuseField::new(1, 4, 157, 8);
+/// BLOCK1 digital dbias when hvt
+pub(crate) const DIG_DBIAS_HVT: EfuseField = EfuseField::new(1, 5, 165, 5);
+/// BLOCK1 pvt threshold when hvt
+pub(crate) const THRES_HVT: EfuseField = EfuseField::new(1, 5, 170, 10);
+/// reserved
+pub(crate) const RESERVED_1_180: EfuseField = EfuseField::new(1, 5, 180, 3);
+/// WAFER_VERSION_MINOR most significant bit
+pub(crate) const WAFER_VERSION_MINOR_HI: EfuseField = EfuseField::new(1, 5, 183, 1);
+/// WAFER_VERSION_MAJOR
+pub(crate) const WAFER_VERSION_MAJOR: EfuseField = EfuseField::new(1, 5, 184, 2);
+/// reserved
+pub(crate) const RESERVED_1_186: EfuseField = EfuseField::new(1, 5, 186, 6);
+/// Optional unique 128-bit ID
+pub(crate) const OPTIONAL_UNIQUE_ID: EfuseField = EfuseField::new(2, 0, 0, 128);
+/// BLK_VERSION_MAJOR of BLOCK2
+pub(crate) const BLK_VERSION_MAJOR: EfuseField = EfuseField::new(2, 4, 128, 2);
+/// reserved
+pub(crate) const RESERVED_2_130: EfuseField = EfuseField::new(2, 4, 130, 1);
+/// Temperature calibration data
+pub(crate) const TEMP_CALIB: EfuseField = EfuseField::new(2, 4, 131, 9);
+/// ADC OCode
+pub(crate) const OCODE: EfuseField = EfuseField::new(2, 4, 140, 8);
+/// ADC1 init code at atten0
+pub(crate) const ADC1_INIT_CODE_ATTEN0: EfuseField = EfuseField::new(2, 4, 148, 10);
+/// ADC1 init code at atten1
+pub(crate) const ADC1_INIT_CODE_ATTEN1: EfuseField = EfuseField::new(2, 4, 158, 10);
+/// ADC1 init code at atten2
+pub(crate) const ADC1_INIT_CODE_ATTEN2: EfuseField = EfuseField::new(2, 5, 168, 10);
+/// ADC1 init code at atten3
+pub(crate) const ADC1_INIT_CODE_ATTEN3: EfuseField = EfuseField::new(2, 5, 178, 10);
+/// ADC1 calibration voltage at atten0
+pub(crate) const ADC1_CAL_VOL_ATTEN0: EfuseField = EfuseField::new(2, 5, 188, 10);
+/// ADC1 calibration voltage at atten1
+pub(crate) const ADC1_CAL_VOL_ATTEN1: EfuseField = EfuseField::new(2, 6, 198, 10);
+/// ADC1 calibration voltage at atten2
+pub(crate) const ADC1_CAL_VOL_ATTEN2: EfuseField = EfuseField::new(2, 6, 208, 10);
+/// ADC1 calibration voltage at atten3
+pub(crate) const ADC1_CAL_VOL_ATTEN3: EfuseField = EfuseField::new(2, 6, 218, 10);
+/// reserved
+pub(crate) const RESERVED_2_228: EfuseField = EfuseField::new(2, 7, 228, 28);
+/// User data
+pub(crate) const BLOCK_USR_DATA: EfuseField = EfuseField::new(3, 0, 0, 192);
+/// reserved
+pub(crate) const RESERVED_3_192: EfuseField = EfuseField::new(3, 6, 192, 8);
+/// Custom MAC address
+pub(crate) const CUSTOM_MAC: EfuseField = EfuseField::new(3, 6, 200, 48);
+/// reserved
+pub(crate) const RESERVED_3_248: EfuseField = EfuseField::new(3, 7, 248, 8);
+/// Key0 or user data
+pub(crate) const BLOCK_KEY0: EfuseField = EfuseField::new(4, 0, 0, 256);
+/// Key1 or user data
+pub(crate) const BLOCK_KEY1: EfuseField = EfuseField::new(5, 0, 0, 256);
+/// Key2 or user data
+pub(crate) const BLOCK_KEY2: EfuseField = EfuseField::new(6, 0, 0, 256);
+/// Key3 or user data
+pub(crate) const BLOCK_KEY3: EfuseField = EfuseField::new(7, 0, 0, 256);
+/// Key4 or user data
+pub(crate) const BLOCK_KEY4: EfuseField = EfuseField::new(8, 0, 0, 256);
+/// Key5 or user data
+pub(crate) const BLOCK_KEY5: EfuseField = EfuseField::new(9, 0, 0, 256);
+/// System data part 2 (reserved)
+pub(crate) const BLOCK_SYS_DATA2: EfuseField = EfuseField::new(10, 0, 0, 256);

--- a/espflash/src/targets/efuse/esp32c6.rs
+++ b/espflash/src/targets/efuse/esp32c6.rs
@@ -1,0 +1,262 @@
+//! This file was automatically generated, please do not edit it manually!
+//!
+//! Generated: 2025-04-15 12:51
+//! Version:   df46b69f0ed3913114ba53d3a0b2b843
+
+#![allow(unused)]
+
+use super::EfuseField;
+
+/// Total size in bytes of each block
+pub(crate) const BLOCK_SIZES: &[u32] = &[24, 24, 32, 32, 32, 32, 32, 32, 32, 32, 32];
+
+/// Disable programming of individual eFuses
+pub(crate) const WR_DIS: EfuseField = EfuseField::new(0, 0, 0, 32);
+/// Disable reading from BlOCK4-10
+pub(crate) const RD_DIS: EfuseField = EfuseField::new(0, 1, 32, 7);
+/// Represents whether pad of uart and sdio is swapped or not. 1: swapped. 0:
+/// not swapped
+pub(crate) const SWAP_UART_SDIO_EN: EfuseField = EfuseField::new(0, 1, 39, 1);
+/// Represents whether icache is disabled or enabled. 1: disabled. 0: enabled
+pub(crate) const DIS_ICACHE: EfuseField = EfuseField::new(0, 1, 40, 1);
+/// Represents whether the function of usb switch to jtag is disabled or
+/// enabled. 1: disabled. 0: enabled
+pub(crate) const DIS_USB_JTAG: EfuseField = EfuseField::new(0, 1, 41, 1);
+/// Represents whether icache is disabled or enabled in Download mode. 1:
+/// disabled. 0: enabled
+pub(crate) const DIS_DOWNLOAD_ICACHE: EfuseField = EfuseField::new(0, 1, 42, 1);
+/// Represents whether USB-Serial-JTAG is disabled or enabled. 1: disabled. 0:
+/// enabled
+pub(crate) const DIS_USB_SERIAL_JTAG: EfuseField = EfuseField::new(0, 1, 43, 1);
+/// Represents whether the function that forces chip into download mode is
+/// disabled or enabled. 1: disabled. 0: enabled
+pub(crate) const DIS_FORCE_DOWNLOAD: EfuseField = EfuseField::new(0, 1, 44, 1);
+/// Represents whether SPI0 controller during boot_mode_download is disabled or
+/// enabled. 1: disabled. 0: enabled
+pub(crate) const SPI_DOWNLOAD_MSPI_DIS: EfuseField = EfuseField::new(0, 1, 45, 1);
+/// Represents whether TWAI function is disabled or enabled. 1: disabled. 0:
+/// enabled
+pub(crate) const DIS_TWAI: EfuseField = EfuseField::new(0, 1, 46, 1);
+/// Represents whether the selection between usb_to_jtag and pad_to_jtag through
+/// strapping gpio15 when both EFUSE_DIS_PAD_JTAG and EFUSE_DIS_USB_JTAG are
+/// equal to 0 is enabled or disabled. 1: enabled. 0: disabled
+pub(crate) const JTAG_SEL_ENABLE: EfuseField = EfuseField::new(0, 1, 47, 1);
+/// Represents whether JTAG is disabled in soft way. Odd number: disabled. Even
+/// number: enabled
+pub(crate) const SOFT_DIS_JTAG: EfuseField = EfuseField::new(0, 1, 48, 3);
+/// Represents whether JTAG is disabled in the hard way(permanently). 1:
+/// disabled. 0: enabled
+pub(crate) const DIS_PAD_JTAG: EfuseField = EfuseField::new(0, 1, 51, 1);
+/// Represents whether flash encrypt function is disabled or enabled(except in
+/// SPI boot mode). 1: disabled. 0: enabled
+pub(crate) const DIS_DOWNLOAD_MANUAL_ENCRYPT: EfuseField = EfuseField::new(0, 1, 52, 1);
+/// Represents the single-end input threshold vrefh; 1.76 V to 2 V with step of
+/// 80 mV
+pub(crate) const USB_DREFH: EfuseField = EfuseField::new(0, 1, 53, 2);
+/// Represents the single-end input threshold vrefl; 1.76 V to 2 V with step of
+/// 80 mV
+pub(crate) const USB_DREFL: EfuseField = EfuseField::new(0, 1, 55, 2);
+/// Represents whether the D+ and D- pins is exchanged. 1: exchanged. 0: not
+/// exchanged
+pub(crate) const USB_EXCHG_PINS: EfuseField = EfuseField::new(0, 1, 57, 1);
+/// Represents whether vdd spi pin is functioned as gpio. 1: functioned. 0: not
+/// functioned
+pub(crate) const VDD_SPI_AS_GPIO: EfuseField = EfuseField::new(0, 1, 58, 1);
+/// Reserved
+pub(crate) const RPT4_RESERVED0_2: EfuseField = EfuseField::new(0, 1, 59, 2);
+/// Reserved
+pub(crate) const RPT4_RESERVED0_1: EfuseField = EfuseField::new(0, 1, 61, 1);
+/// Reserved
+pub(crate) const RPT4_RESERVED0_0: EfuseField = EfuseField::new(0, 1, 62, 2);
+/// Reserved
+pub(crate) const RPT4_RESERVED1_0: EfuseField = EfuseField::new(0, 2, 64, 16);
+/// Represents whether RTC watchdog timeout threshold is selected at startup. 1:
+/// selected. 0: not selected
+pub(crate) const WDT_DELAY_SEL: EfuseField = EfuseField::new(0, 2, 80, 2);
+/// Enables flash encryption when 1 or 3 bits are set and disables otherwise
+pub(crate) const SPI_BOOT_CRYPT_CNT: EfuseField = EfuseField::new(0, 2, 82, 3);
+/// Revoke 1st secure boot key
+pub(crate) const SECURE_BOOT_KEY_REVOKE0: EfuseField = EfuseField::new(0, 2, 85, 1);
+/// Revoke 2nd secure boot key
+pub(crate) const SECURE_BOOT_KEY_REVOKE1: EfuseField = EfuseField::new(0, 2, 86, 1);
+/// Revoke 3rd secure boot key
+pub(crate) const SECURE_BOOT_KEY_REVOKE2: EfuseField = EfuseField::new(0, 2, 87, 1);
+/// Represents the purpose of Key0
+pub(crate) const KEY_PURPOSE_0: EfuseField = EfuseField::new(0, 2, 88, 4);
+/// Represents the purpose of Key1
+pub(crate) const KEY_PURPOSE_1: EfuseField = EfuseField::new(0, 2, 92, 4);
+/// Represents the purpose of Key2
+pub(crate) const KEY_PURPOSE_2: EfuseField = EfuseField::new(0, 3, 96, 4);
+/// Represents the purpose of Key3
+pub(crate) const KEY_PURPOSE_3: EfuseField = EfuseField::new(0, 3, 100, 4);
+/// Represents the purpose of Key4
+pub(crate) const KEY_PURPOSE_4: EfuseField = EfuseField::new(0, 3, 104, 4);
+/// Represents the purpose of Key5
+pub(crate) const KEY_PURPOSE_5: EfuseField = EfuseField::new(0, 3, 108, 4);
+/// Represents the spa secure level by configuring the clock random divide mode
+pub(crate) const SEC_DPA_LEVEL: EfuseField = EfuseField::new(0, 3, 112, 2);
+/// Represents whether anti-dpa attack is enabled. 1:enabled. 0: disabled
+pub(crate) const CRYPT_DPA_ENABLE: EfuseField = EfuseField::new(0, 3, 114, 1);
+/// Reserved
+pub(crate) const RPT4_RESERVED2_1: EfuseField = EfuseField::new(0, 3, 115, 1);
+/// Represents whether secure boot is enabled or disabled. 1: enabled. 0:
+/// disabled
+pub(crate) const SECURE_BOOT_EN: EfuseField = EfuseField::new(0, 3, 116, 1);
+/// Represents whether revoking aggressive secure boot is enabled or disabled.
+/// 1: enabled. 0: disabled
+pub(crate) const SECURE_BOOT_AGGRESSIVE_REVOKE: EfuseField = EfuseField::new(0, 3, 117, 1);
+/// Reserved
+pub(crate) const RPT4_RESERVED2_0: EfuseField = EfuseField::new(0, 3, 118, 6);
+/// Represents the flash waiting time after power-up; in unit of ms. When the
+/// value less than 15; the waiting time is the programmed value. Otherwise; the
+/// waiting time is 2 times the programmed value
+pub(crate) const FLASH_TPUW: EfuseField = EfuseField::new(0, 3, 124, 4);
+/// Represents whether Download mode is disabled or enabled. 1: disabled. 0:
+/// enabled
+pub(crate) const DIS_DOWNLOAD_MODE: EfuseField = EfuseField::new(0, 4, 128, 1);
+/// Represents whether direct boot mode is disabled or enabled. 1: disabled. 0:
+/// enabled
+pub(crate) const DIS_DIRECT_BOOT: EfuseField = EfuseField::new(0, 4, 129, 1);
+/// Represents whether print from USB-Serial-JTAG is disabled or enabled. 1:
+/// disabled. 0: enabled
+pub(crate) const DIS_USB_SERIAL_JTAG_ROM_PRINT: EfuseField = EfuseField::new(0, 4, 130, 1);
+/// Reserved
+pub(crate) const RPT4_RESERVED3_5: EfuseField = EfuseField::new(0, 4, 131, 1);
+/// Represents whether the USB-Serial-JTAG download function is disabled or
+/// enabled. 1: disabled. 0: enabled
+pub(crate) const DIS_USB_SERIAL_JTAG_DOWNLOAD_MODE: EfuseField = EfuseField::new(0, 4, 132, 1);
+/// Represents whether security download is enabled or disabled. 1: enabled. 0:
+/// disabled
+pub(crate) const ENABLE_SECURITY_DOWNLOAD: EfuseField = EfuseField::new(0, 4, 133, 1);
+/// Set the default UARTboot message output mode
+pub(crate) const UART_PRINT_CONTROL: EfuseField = EfuseField::new(0, 4, 134, 2);
+/// Reserved
+pub(crate) const RPT4_RESERVED3_4: EfuseField = EfuseField::new(0, 4, 136, 1);
+/// Reserved
+pub(crate) const RPT4_RESERVED3_3: EfuseField = EfuseField::new(0, 4, 137, 1);
+/// Reserved
+pub(crate) const RPT4_RESERVED3_2: EfuseField = EfuseField::new(0, 4, 138, 2);
+/// Reserved
+pub(crate) const RPT4_RESERVED3_1: EfuseField = EfuseField::new(0, 4, 140, 1);
+/// Represents whether ROM code is forced to send a resume command during SPI
+/// boot. 1: forced. 0:not forced
+pub(crate) const FORCE_SEND_RESUME: EfuseField = EfuseField::new(0, 4, 141, 1);
+/// Represents the version used by ESP-IDF anti-rollback feature
+pub(crate) const SECURE_VERSION: EfuseField = EfuseField::new(0, 4, 142, 16);
+/// Represents whether FAST VERIFY ON WAKE is disabled or enabled when Secure
+/// Boot is enabled. 1: disabled. 0: enabled
+pub(crate) const SECURE_BOOT_DISABLE_FAST_WAKE: EfuseField = EfuseField::new(0, 4, 158, 1);
+/// Reserved
+pub(crate) const RPT4_RESERVED3_0: EfuseField = EfuseField::new(0, 4, 159, 1);
+/// Disables check of wafer version major
+pub(crate) const DISABLE_WAFER_VERSION_MAJOR: EfuseField = EfuseField::new(0, 5, 160, 1);
+/// Disables check of blk version major
+pub(crate) const DISABLE_BLK_VERSION_MAJOR: EfuseField = EfuseField::new(0, 5, 161, 1);
+/// reserved
+pub(crate) const RESERVED_0_162: EfuseField = EfuseField::new(0, 5, 162, 22);
+/// Reserved
+pub(crate) const RPT4_RESERVED4_0: EfuseField = EfuseField::new(0, 5, 184, 8);
+/// MAC address
+pub(crate) const MAC0: EfuseField = EfuseField::new(1, 0, 0, 32);
+/// MAC address
+pub(crate) const MAC1: EfuseField = EfuseField::new(1, 1, 0, 16);
+/// Stores the extended bits of MAC address
+pub(crate) const MAC_EXT: EfuseField = EfuseField::new(1, 1, 48, 16);
+/// Stores the active hp dbias
+pub(crate) const ACTIVE_HP_DBIAS: EfuseField = EfuseField::new(1, 2, 64, 5);
+/// Stores the active lp dbias
+pub(crate) const ACTIVE_LP_DBIAS: EfuseField = EfuseField::new(1, 2, 69, 5);
+/// Stores the lslp hp dbg
+pub(crate) const LSLP_HP_DBG: EfuseField = EfuseField::new(1, 2, 74, 2);
+/// Stores the lslp hp dbias
+pub(crate) const LSLP_HP_DBIAS: EfuseField = EfuseField::new(1, 2, 76, 4);
+/// Stores the dslp lp dbg
+pub(crate) const DSLP_LP_DBG: EfuseField = EfuseField::new(1, 2, 80, 3);
+/// Stores the dslp lp dbias
+pub(crate) const DSLP_LP_DBIAS: EfuseField = EfuseField::new(1, 2, 83, 4);
+/// Stores the hp and lp dbias vol gap
+pub(crate) const DBIAS_VOL_GAP: EfuseField = EfuseField::new(1, 2, 87, 5);
+/// Stores the first part of SPI_PAD_CONF
+pub(crate) const SPI_PAD_CONF_1: EfuseField = EfuseField::new(1, 2, 92, 4);
+/// Stores the second part of SPI_PAD_CONF
+pub(crate) const SPI_PAD_CONF_2: EfuseField = EfuseField::new(1, 3, 96, 18);
+///
+pub(crate) const WAFER_VERSION_MINOR: EfuseField = EfuseField::new(1, 3, 114, 4);
+///
+pub(crate) const WAFER_VERSION_MAJOR: EfuseField = EfuseField::new(1, 3, 118, 2);
+/// Package version
+pub(crate) const PKG_VERSION: EfuseField = EfuseField::new(1, 3, 120, 3);
+/// BLK_VERSION_MINOR of BLOCK2
+pub(crate) const BLK_VERSION_MINOR: EfuseField = EfuseField::new(1, 3, 123, 3);
+/// BLK_VERSION_MAJOR of BLOCK2
+pub(crate) const BLK_VERSION_MAJOR: EfuseField = EfuseField::new(1, 3, 126, 2);
+///
+pub(crate) const FLASH_CAP: EfuseField = EfuseField::new(1, 4, 128, 3);
+///
+pub(crate) const FLASH_TEMP: EfuseField = EfuseField::new(1, 4, 131, 2);
+///
+pub(crate) const FLASH_VENDOR: EfuseField = EfuseField::new(1, 4, 133, 3);
+/// reserved
+pub(crate) const RESERVED_1_136: EfuseField = EfuseField::new(1, 4, 136, 24);
+/// Stores the second 32 bits of the zeroth part of system data
+pub(crate) const SYS_DATA_PART0_2: EfuseField = EfuseField::new(1, 5, 160, 32);
+/// Optional unique 128-bit ID
+pub(crate) const OPTIONAL_UNIQUE_ID: EfuseField = EfuseField::new(2, 0, 0, 128);
+/// Temperature calibration data
+pub(crate) const TEMP_CALIB: EfuseField = EfuseField::new(2, 4, 128, 9);
+/// ADC OCode
+pub(crate) const OCODE: EfuseField = EfuseField::new(2, 4, 137, 8);
+/// ADC1 init code at atten0
+pub(crate) const ADC1_INIT_CODE_ATTEN0: EfuseField = EfuseField::new(2, 4, 145, 10);
+/// ADC1 init code at atten1
+pub(crate) const ADC1_INIT_CODE_ATTEN1: EfuseField = EfuseField::new(2, 4, 155, 10);
+/// ADC1 init code at atten2
+pub(crate) const ADC1_INIT_CODE_ATTEN2: EfuseField = EfuseField::new(2, 5, 165, 10);
+/// ADC1 init code at atten3
+pub(crate) const ADC1_INIT_CODE_ATTEN3: EfuseField = EfuseField::new(2, 5, 175, 10);
+/// ADC1 calibration voltage at atten0
+pub(crate) const ADC1_CAL_VOL_ATTEN0: EfuseField = EfuseField::new(2, 5, 185, 10);
+/// ADC1 calibration voltage at atten1
+pub(crate) const ADC1_CAL_VOL_ATTEN1: EfuseField = EfuseField::new(2, 6, 195, 10);
+/// ADC1 calibration voltage at atten2
+pub(crate) const ADC1_CAL_VOL_ATTEN2: EfuseField = EfuseField::new(2, 6, 205, 10);
+/// ADC1 calibration voltage at atten3
+pub(crate) const ADC1_CAL_VOL_ATTEN3: EfuseField = EfuseField::new(2, 6, 215, 10);
+/// ADC1 init code at atten0 ch0
+pub(crate) const ADC1_INIT_CODE_ATTEN0_CH0: EfuseField = EfuseField::new(2, 7, 225, 4);
+/// ADC1 init code at atten0 ch1
+pub(crate) const ADC1_INIT_CODE_ATTEN0_CH1: EfuseField = EfuseField::new(2, 7, 229, 4);
+/// ADC1 init code at atten0 ch2
+pub(crate) const ADC1_INIT_CODE_ATTEN0_CH2: EfuseField = EfuseField::new(2, 7, 233, 4);
+/// ADC1 init code at atten0 ch3
+pub(crate) const ADC1_INIT_CODE_ATTEN0_CH3: EfuseField = EfuseField::new(2, 7, 237, 4);
+/// ADC1 init code at atten0 ch4
+pub(crate) const ADC1_INIT_CODE_ATTEN0_CH4: EfuseField = EfuseField::new(2, 7, 241, 4);
+/// ADC1 init code at atten0 ch5
+pub(crate) const ADC1_INIT_CODE_ATTEN0_CH5: EfuseField = EfuseField::new(2, 7, 245, 4);
+/// ADC1 init code at atten0 ch6
+pub(crate) const ADC1_INIT_CODE_ATTEN0_CH6: EfuseField = EfuseField::new(2, 7, 249, 4);
+/// reserved
+pub(crate) const RESERVED_2_253: EfuseField = EfuseField::new(2, 7, 253, 3);
+/// User data
+pub(crate) const BLOCK_USR_DATA: EfuseField = EfuseField::new(3, 0, 0, 192);
+/// reserved
+pub(crate) const RESERVED_3_192: EfuseField = EfuseField::new(3, 6, 192, 8);
+/// Custom MAC
+pub(crate) const CUSTOM_MAC: EfuseField = EfuseField::new(3, 6, 200, 48);
+/// reserved
+pub(crate) const RESERVED_3_248: EfuseField = EfuseField::new(3, 7, 248, 8);
+/// Key0 or user data
+pub(crate) const BLOCK_KEY0: EfuseField = EfuseField::new(4, 0, 0, 256);
+/// Key1 or user data
+pub(crate) const BLOCK_KEY1: EfuseField = EfuseField::new(5, 0, 0, 256);
+/// Key2 or user data
+pub(crate) const BLOCK_KEY2: EfuseField = EfuseField::new(6, 0, 0, 256);
+/// Key3 or user data
+pub(crate) const BLOCK_KEY3: EfuseField = EfuseField::new(7, 0, 0, 256);
+/// Key4 or user data
+pub(crate) const BLOCK_KEY4: EfuseField = EfuseField::new(8, 0, 0, 256);
+/// Key5 or user data
+pub(crate) const BLOCK_KEY5: EfuseField = EfuseField::new(9, 0, 0, 256);
+/// System data part 2 (reserved)
+pub(crate) const BLOCK_SYS_DATA2: EfuseField = EfuseField::new(10, 0, 0, 256);

--- a/espflash/src/targets/efuse/esp32h2.rs
+++ b/espflash/src/targets/efuse/esp32h2.rs
@@ -1,0 +1,252 @@
+//! This file was automatically generated, please do not edit it manually!
+//!
+//! Generated: 2025-04-15 12:51
+//! Version:   44563d2af4ebdba4db6c0a34a50c94f9
+
+#![allow(unused)]
+
+use super::EfuseField;
+
+/// Total size in bytes of each block
+pub(crate) const BLOCK_SIZES: &[u32] = &[24, 24, 32, 32, 32, 32, 32, 32, 32, 32, 32];
+
+/// Disable programming of individual eFuses
+pub(crate) const WR_DIS: EfuseField = EfuseField::new(0, 0, 0, 32);
+/// Disable reading from BlOCK4-10
+pub(crate) const RD_DIS: EfuseField = EfuseField::new(0, 1, 32, 7);
+/// Reserved
+pub(crate) const RPT4_RESERVED0_4: EfuseField = EfuseField::new(0, 1, 39, 1);
+/// Represents whether icache is disabled or enabled. 1: disabled. 0: enabled
+pub(crate) const DIS_ICACHE: EfuseField = EfuseField::new(0, 1, 40, 1);
+/// Represents whether the function of usb switch to jtag is disabled or
+/// enabled. 1: disabled. 0: enabled
+pub(crate) const DIS_USB_JTAG: EfuseField = EfuseField::new(0, 1, 41, 1);
+/// Represents whether power glitch function is enabled. 1: enabled. 0: disabled
+pub(crate) const POWERGLITCH_EN: EfuseField = EfuseField::new(0, 1, 42, 1);
+/// Represents whether USB-Serial-JTAG is disabled or enabled. 1: disabled. 0:
+/// enabled
+pub(crate) const DIS_USB_SERIAL_JTAG: EfuseField = EfuseField::new(0, 1, 43, 1);
+/// Represents whether the function that forces chip into download mode is
+/// disabled or enabled. 1: disabled. 0: enabled
+pub(crate) const DIS_FORCE_DOWNLOAD: EfuseField = EfuseField::new(0, 1, 44, 1);
+/// Represents whether SPI0 controller during boot_mode_download is disabled or
+/// enabled. 1: disabled. 0: enabled
+pub(crate) const SPI_DOWNLOAD_MSPI_DIS: EfuseField = EfuseField::new(0, 1, 45, 1);
+/// Represents whether TWAI function is disabled or enabled. 1: disabled. 0:
+/// enabled
+pub(crate) const DIS_TWAI: EfuseField = EfuseField::new(0, 1, 46, 1);
+/// Set this bit to enable selection between usb_to_jtag and pad_to_jtag through
+/// strapping gpio25 when both EFUSE_DIS_PAD_JTAG and EFUSE_DIS_USB_JTAG are
+/// equal to 0
+pub(crate) const JTAG_SEL_ENABLE: EfuseField = EfuseField::new(0, 1, 47, 1);
+/// Represents whether JTAG is disabled in soft way. Odd number: disabled. Even
+/// number: enabled
+pub(crate) const SOFT_DIS_JTAG: EfuseField = EfuseField::new(0, 1, 48, 3);
+/// Represents whether JTAG is disabled in the hard way(permanently). 1:
+/// disabled. 0: enabled
+pub(crate) const DIS_PAD_JTAG: EfuseField = EfuseField::new(0, 1, 51, 1);
+/// Represents whether flash encrypt function is disabled or enabled(except in
+/// SPI boot mode). 1: disabled. 0: enabled
+pub(crate) const DIS_DOWNLOAD_MANUAL_ENCRYPT: EfuseField = EfuseField::new(0, 1, 52, 1);
+/// Represents the single-end input threshold vrefh; 1.76 V to 2 V with step of
+/// 80 mV
+pub(crate) const USB_DREFH: EfuseField = EfuseField::new(0, 1, 53, 2);
+/// Represents the single-end input threshold vrefl; 1.76 V to 2 V with step of
+/// 80 mV
+pub(crate) const USB_DREFL: EfuseField = EfuseField::new(0, 1, 55, 2);
+/// Represents whether the D+ and D- pins is exchanged. 1: exchanged. 0: not
+/// exchanged
+pub(crate) const USB_EXCHG_PINS: EfuseField = EfuseField::new(0, 1, 57, 1);
+/// Represents whether vdd spi pin is functioned as gpio. 1: functioned. 0: not
+/// functioned
+pub(crate) const VDD_SPI_AS_GPIO: EfuseField = EfuseField::new(0, 1, 58, 1);
+/// Configures the curve of ECDSA calculation: 0: only enable P256. 1: only
+/// enable P192. 2: both enable P256 and P192. 3: only enable P256
+pub(crate) const ECDSA_CURVE_MODE: EfuseField = EfuseField::new(0, 1, 59, 2);
+/// Set this bit to permanently turn on ECC const-time mode
+pub(crate) const ECC_FORCE_CONST_TIME: EfuseField = EfuseField::new(0, 1, 61, 1);
+/// Set this bit to control the xts pseudo-round anti-dpa attack function: 0:
+/// controlled by register. 1-3: the higher the value is; the more pseudo-rounds
+/// are inserted to the xts-aes calculation
+pub(crate) const XTS_DPA_PSEUDO_LEVEL: EfuseField = EfuseField::new(0, 1, 62, 2);
+/// Reserved
+pub(crate) const RPT4_RESERVED1_1: EfuseField = EfuseField::new(0, 2, 64, 16);
+/// Represents whether RTC watchdog timeout threshold is selected at startup. 1:
+/// selected. 0: not selected
+pub(crate) const WDT_DELAY_SEL: EfuseField = EfuseField::new(0, 2, 80, 2);
+/// Enables flash encryption when 1 or 3 bits are set and disables otherwise
+pub(crate) const SPI_BOOT_CRYPT_CNT: EfuseField = EfuseField::new(0, 2, 82, 3);
+/// Revoke 1st secure boot key
+pub(crate) const SECURE_BOOT_KEY_REVOKE0: EfuseField = EfuseField::new(0, 2, 85, 1);
+/// Revoke 2nd secure boot key
+pub(crate) const SECURE_BOOT_KEY_REVOKE1: EfuseField = EfuseField::new(0, 2, 86, 1);
+/// Revoke 3rd secure boot key
+pub(crate) const SECURE_BOOT_KEY_REVOKE2: EfuseField = EfuseField::new(0, 2, 87, 1);
+/// Represents the purpose of Key0
+pub(crate) const KEY_PURPOSE_0: EfuseField = EfuseField::new(0, 2, 88, 4);
+/// Represents the purpose of Key1
+pub(crate) const KEY_PURPOSE_1: EfuseField = EfuseField::new(0, 2, 92, 4);
+/// Represents the purpose of Key2
+pub(crate) const KEY_PURPOSE_2: EfuseField = EfuseField::new(0, 3, 96, 4);
+/// Represents the purpose of Key3
+pub(crate) const KEY_PURPOSE_3: EfuseField = EfuseField::new(0, 3, 100, 4);
+/// Represents the purpose of Key4
+pub(crate) const KEY_PURPOSE_4: EfuseField = EfuseField::new(0, 3, 104, 4);
+/// Represents the purpose of Key5
+pub(crate) const KEY_PURPOSE_5: EfuseField = EfuseField::new(0, 3, 108, 4);
+/// Represents the spa secure level by configuring the clock random divide mode
+pub(crate) const SEC_DPA_LEVEL: EfuseField = EfuseField::new(0, 3, 112, 2);
+/// Reserved
+pub(crate) const RESERVE_0_114: EfuseField = EfuseField::new(0, 3, 114, 1);
+/// Represents whether anti-dpa attack is enabled. 1:enabled. 0: disabled
+pub(crate) const CRYPT_DPA_ENABLE: EfuseField = EfuseField::new(0, 3, 115, 1);
+/// Represents whether secure boot is enabled or disabled. 1: enabled. 0:
+/// disabled
+pub(crate) const SECURE_BOOT_EN: EfuseField = EfuseField::new(0, 3, 116, 1);
+/// Represents whether revoking aggressive secure boot is enabled or disabled.
+/// 1: enabled. 0: disabled
+pub(crate) const SECURE_BOOT_AGGRESSIVE_REVOKE: EfuseField = EfuseField::new(0, 3, 117, 1);
+/// Set these bits to enable power glitch function when chip power on
+pub(crate) const POWERGLITCH_EN1: EfuseField = EfuseField::new(0, 3, 118, 5);
+/// reserved
+pub(crate) const RESERVED_0_123: EfuseField = EfuseField::new(0, 3, 123, 1);
+/// Represents the flash waiting time after power-up; in unit of ms. When the
+/// value less than 15; the waiting time is the programmed value. Otherwise; the
+/// waiting time is 2 times the programmed value
+pub(crate) const FLASH_TPUW: EfuseField = EfuseField::new(0, 3, 124, 4);
+/// Represents whether Download mode is disabled or enabled. 1: disabled. 0:
+/// enabled
+pub(crate) const DIS_DOWNLOAD_MODE: EfuseField = EfuseField::new(0, 4, 128, 1);
+/// Represents whether direct boot mode is disabled or enabled. 1: disabled. 0:
+/// enabled
+pub(crate) const DIS_DIRECT_BOOT: EfuseField = EfuseField::new(0, 4, 129, 1);
+/// Set this bit to disable USB-Serial-JTAG print during rom boot
+pub(crate) const DIS_USB_SERIAL_JTAG_ROM_PRINT: EfuseField = EfuseField::new(0, 4, 130, 1);
+/// Reserved
+pub(crate) const RPT4_RESERVED3_5: EfuseField = EfuseField::new(0, 4, 131, 1);
+/// Represents whether the USB-Serial-JTAG download function is disabled or
+/// enabled. 1: disabled. 0: enabled
+pub(crate) const DIS_USB_SERIAL_JTAG_DOWNLOAD_MODE: EfuseField = EfuseField::new(0, 4, 132, 1);
+/// Represents whether security download is enabled or disabled. 1: enabled. 0:
+/// disabled
+pub(crate) const ENABLE_SECURITY_DOWNLOAD: EfuseField = EfuseField::new(0, 4, 133, 1);
+/// Set the default UARTboot message output mode
+pub(crate) const UART_PRINT_CONTROL: EfuseField = EfuseField::new(0, 4, 134, 2);
+/// Represents whether ROM code is forced to send a resume command during SPI
+/// boot. 1: forced. 0:not forced
+pub(crate) const FORCE_SEND_RESUME: EfuseField = EfuseField::new(0, 4, 136, 1);
+/// Represents the version used by ESP-IDF anti-rollback feature
+pub(crate) const SECURE_VERSION: EfuseField = EfuseField::new(0, 4, 137, 16);
+/// Represents whether FAST VERIFY ON WAKE is disabled or enabled when Secure
+/// Boot is enabled. 1: disabled. 0: enabled
+pub(crate) const SECURE_BOOT_DISABLE_FAST_WAKE: EfuseField = EfuseField::new(0, 4, 153, 1);
+/// Set bits to enable hysteresis function of PAD0~5
+pub(crate) const HYS_EN_PAD0: EfuseField = EfuseField::new(0, 4, 154, 6);
+/// Set bits to enable hysteresis function of PAD6~27
+pub(crate) const HYS_EN_PAD1: EfuseField = EfuseField::new(0, 5, 160, 22);
+/// Reserved
+pub(crate) const RPT4_RESERVED4_1: EfuseField = EfuseField::new(0, 5, 182, 2);
+/// Reserved
+pub(crate) const RPT4_RESERVED4_0: EfuseField = EfuseField::new(0, 5, 184, 8);
+/// MAC address
+pub(crate) const MAC0: EfuseField = EfuseField::new(1, 0, 0, 32);
+/// MAC address
+pub(crate) const MAC1: EfuseField = EfuseField::new(1, 1, 0, 16);
+/// Stores the extended bits of MAC address
+pub(crate) const MAC_EXT: EfuseField = EfuseField::new(1, 1, 48, 16);
+/// Stores RF Calibration data. RXIQ version
+pub(crate) const RXIQ_VERSION: EfuseField = EfuseField::new(1, 2, 64, 3);
+/// Stores RF Calibration data. RXIQ data 0
+pub(crate) const RXIQ_0: EfuseField = EfuseField::new(1, 2, 67, 7);
+/// Stores RF Calibration data. RXIQ data 1
+pub(crate) const RXIQ_1: EfuseField = EfuseField::new(1, 2, 74, 7);
+/// Stores the PMU active hp dbias
+pub(crate) const ACTIVE_HP_DBIAS: EfuseField = EfuseField::new(1, 2, 81, 5);
+/// Stores the PMU active lp dbias
+pub(crate) const ACTIVE_LP_DBIAS: EfuseField = EfuseField::new(1, 2, 86, 5);
+/// Stores the PMU sleep dbias
+pub(crate) const DSLP_DBIAS: EfuseField = EfuseField::new(1, 2, 91, 4);
+/// Stores the low 1 bit of dbias_vol_gap
+pub(crate) const DBIAS_VOL_GAP: EfuseField = EfuseField::new(1, 2, 95, 5);
+/// Reserved
+pub(crate) const MAC_RESERVED_2: EfuseField = EfuseField::new(1, 3, 100, 14);
+/// Stores the wafer version minor
+pub(crate) const WAFER_VERSION_MINOR: EfuseField = EfuseField::new(1, 3, 114, 3);
+/// Stores the wafer version major
+pub(crate) const WAFER_VERSION_MAJOR: EfuseField = EfuseField::new(1, 3, 117, 2);
+/// Disables check of wafer version major
+pub(crate) const DISABLE_WAFER_VERSION_MAJOR: EfuseField = EfuseField::new(1, 3, 119, 1);
+/// Stores the flash cap
+pub(crate) const FLASH_CAP: EfuseField = EfuseField::new(1, 3, 120, 3);
+/// Stores the flash temp
+pub(crate) const FLASH_TEMP: EfuseField = EfuseField::new(1, 3, 123, 2);
+/// Stores the flash vendor
+pub(crate) const FLASH_VENDOR: EfuseField = EfuseField::new(1, 3, 125, 3);
+/// Package version
+pub(crate) const PKG_VERSION: EfuseField = EfuseField::new(1, 4, 128, 3);
+/// reserved
+pub(crate) const RESERVED_1_131: EfuseField = EfuseField::new(1, 4, 131, 29);
+/// Stores the second 32 bits of the zeroth part of system data
+pub(crate) const SYS_DATA_PART0_2: EfuseField = EfuseField::new(1, 5, 160, 32);
+/// Optional unique 128-bit ID
+pub(crate) const OPTIONAL_UNIQUE_ID: EfuseField = EfuseField::new(2, 0, 0, 128);
+/// reserved
+pub(crate) const RESERVED_2_128: EfuseField = EfuseField::new(2, 4, 128, 2);
+/// BLK_VERSION_MINOR of BLOCK2. 1: RF Calibration data in BLOCK1
+pub(crate) const BLK_VERSION_MINOR: EfuseField = EfuseField::new(2, 4, 130, 3);
+/// BLK_VERSION_MAJOR of BLOCK2
+pub(crate) const BLK_VERSION_MAJOR: EfuseField = EfuseField::new(2, 4, 133, 2);
+/// Disables check of blk version major
+pub(crate) const DISABLE_BLK_VERSION_MAJOR: EfuseField = EfuseField::new(2, 4, 135, 1);
+/// Temperature calibration data
+pub(crate) const TEMP_CALIB: EfuseField = EfuseField::new(2, 4, 136, 9);
+/// ADC1 calibration data
+pub(crate) const ADC1_AVE_INITCODE_ATTEN0: EfuseField = EfuseField::new(2, 4, 145, 10);
+/// ADC1 calibration data
+pub(crate) const ADC1_AVE_INITCODE_ATTEN1: EfuseField = EfuseField::new(2, 4, 155, 10);
+/// ADC1 calibration data
+pub(crate) const ADC1_AVE_INITCODE_ATTEN2: EfuseField = EfuseField::new(2, 5, 165, 10);
+/// ADC1 calibration data
+pub(crate) const ADC1_AVE_INITCODE_ATTEN3: EfuseField = EfuseField::new(2, 5, 175, 10);
+/// ADC1 calibration data
+pub(crate) const ADC1_HI_DOUT_ATTEN0: EfuseField = EfuseField::new(2, 5, 185, 10);
+/// ADC1 calibration data
+pub(crate) const ADC1_HI_DOUT_ATTEN1: EfuseField = EfuseField::new(2, 6, 195, 10);
+/// ADC1 calibration data
+pub(crate) const ADC1_HI_DOUT_ATTEN2: EfuseField = EfuseField::new(2, 6, 205, 10);
+/// ADC1 calibration data
+pub(crate) const ADC1_HI_DOUT_ATTEN3: EfuseField = EfuseField::new(2, 6, 215, 10);
+/// ADC1 calibration data
+pub(crate) const ADC1_CH0_ATTEN0_INITCODE_DIFF: EfuseField = EfuseField::new(2, 7, 225, 4);
+/// ADC1 calibration data
+pub(crate) const ADC1_CH1_ATTEN0_INITCODE_DIFF: EfuseField = EfuseField::new(2, 7, 229, 4);
+/// ADC1 calibration data
+pub(crate) const ADC1_CH2_ATTEN0_INITCODE_DIFF: EfuseField = EfuseField::new(2, 7, 233, 4);
+/// ADC1 calibration data
+pub(crate) const ADC1_CH3_ATTEN0_INITCODE_DIFF: EfuseField = EfuseField::new(2, 7, 237, 4);
+/// ADC1 calibration data
+pub(crate) const ADC1_CH4_ATTEN0_INITCODE_DIFF: EfuseField = EfuseField::new(2, 7, 241, 4);
+/// reserved
+pub(crate) const RESERVED_2_245: EfuseField = EfuseField::new(2, 7, 245, 11);
+/// User data
+pub(crate) const BLOCK_USR_DATA: EfuseField = EfuseField::new(3, 0, 0, 192);
+/// reserved
+pub(crate) const RESERVED_3_192: EfuseField = EfuseField::new(3, 6, 192, 8);
+/// Custom MAC
+pub(crate) const CUSTOM_MAC: EfuseField = EfuseField::new(3, 6, 200, 48);
+/// reserved
+pub(crate) const RESERVED_3_248: EfuseField = EfuseField::new(3, 7, 248, 8);
+/// Key0 or user data
+pub(crate) const BLOCK_KEY0: EfuseField = EfuseField::new(4, 0, 0, 256);
+/// Key1 or user data
+pub(crate) const BLOCK_KEY1: EfuseField = EfuseField::new(5, 0, 0, 256);
+/// Key2 or user data
+pub(crate) const BLOCK_KEY2: EfuseField = EfuseField::new(6, 0, 0, 256);
+/// Key3 or user data
+pub(crate) const BLOCK_KEY3: EfuseField = EfuseField::new(7, 0, 0, 256);
+/// Key4 or user data
+pub(crate) const BLOCK_KEY4: EfuseField = EfuseField::new(8, 0, 0, 256);
+/// Key5 or user data
+pub(crate) const BLOCK_KEY5: EfuseField = EfuseField::new(9, 0, 0, 256);
+/// System data part 2 (reserved)
+pub(crate) const BLOCK_SYS_DATA2: EfuseField = EfuseField::new(10, 0, 0, 256);

--- a/espflash/src/targets/efuse/esp32p4.rs
+++ b/espflash/src/targets/efuse/esp32p4.rs
@@ -1,0 +1,351 @@
+//! This file was automatically generated, please do not edit it manually!
+//!
+//! Generated: 2025-04-15 12:51
+//! Version:   73787d3f5ae45b80abca925a7562120b
+
+#![allow(unused)]
+
+use super::EfuseField;
+
+/// Total size in bytes of each block
+pub(crate) const BLOCK_SIZES: &[u32] = &[24, 24, 32, 32, 32, 32, 32, 32, 32, 32, 32];
+
+/// Disable programming of individual eFuses
+pub(crate) const WR_DIS: EfuseField = EfuseField::new(0, 0, 0, 32);
+/// Disable reading from BlOCK4-10
+pub(crate) const RD_DIS: EfuseField = EfuseField::new(0, 1, 32, 7);
+/// Enable usb device exchange pins of D+ and D-
+pub(crate) const USB_DEVICE_EXCHG_PINS: EfuseField = EfuseField::new(0, 1, 39, 1);
+/// Enable usb otg11 exchange pins of D+ and D-
+pub(crate) const USB_OTG11_EXCHG_PINS: EfuseField = EfuseField::new(0, 1, 40, 1);
+/// Represents whether the function of usb switch to jtag is disabled or
+/// enabled. 1: disabled. 0: enabled
+pub(crate) const DIS_USB_JTAG: EfuseField = EfuseField::new(0, 1, 41, 1);
+/// Represents whether power glitch function is enabled. 1: enabled. 0: disabled
+pub(crate) const POWERGLITCH_EN: EfuseField = EfuseField::new(0, 1, 42, 1);
+/// Represents whether USB-Serial-JTAG is disabled or enabled. 1: disabled. 0:
+/// enabled
+pub(crate) const DIS_USB_SERIAL_JTAG: EfuseField = EfuseField::new(0, 1, 43, 1);
+/// Represents whether the function that forces chip into download mode is
+/// disabled or enabled. 1: disabled. 0: enabled
+pub(crate) const DIS_FORCE_DOWNLOAD: EfuseField = EfuseField::new(0, 1, 44, 1);
+/// Set this bit to disable accessing MSPI flash/MSPI ram by SYS AXI matrix
+/// during boot_mode_download
+pub(crate) const SPI_DOWNLOAD_MSPI_DIS: EfuseField = EfuseField::new(0, 1, 45, 1);
+/// Represents whether TWAI function is disabled or enabled. 1: disabled. 0:
+/// enabled
+pub(crate) const DIS_TWAI: EfuseField = EfuseField::new(0, 1, 46, 1);
+/// Represents whether the selection between usb_to_jtag and pad_to_jtag through
+/// strapping gpio15 when both EFUSE_DIS_PAD_JTAG and EFUSE_DIS_USB_JTAG are
+/// equal to 0 is enabled or disabled. 1: enabled. 0: disabled
+pub(crate) const JTAG_SEL_ENABLE: EfuseField = EfuseField::new(0, 1, 47, 1);
+/// Represents whether JTAG is disabled in soft way. Odd number: disabled. Even
+/// number: enabled
+pub(crate) const SOFT_DIS_JTAG: EfuseField = EfuseField::new(0, 1, 48, 3);
+/// Represents whether JTAG is disabled in the hard way(permanently). 1:
+/// disabled. 0: enabled
+pub(crate) const DIS_PAD_JTAG: EfuseField = EfuseField::new(0, 1, 51, 1);
+/// Represents whether flash encrypt function is disabled or enabled(except in
+/// SPI boot mode). 1: disabled. 0: enabled
+pub(crate) const DIS_DOWNLOAD_MANUAL_ENCRYPT: EfuseField = EfuseField::new(0, 1, 52, 1);
+/// USB intphy of usb device signle-end input high threshold; 1.76V to 2V. Step
+/// by 80mV
+pub(crate) const USB_DEVICE_DREFH: EfuseField = EfuseField::new(0, 1, 53, 2);
+/// USB intphy of usb otg11 signle-end input high threshold; 1.76V to 2V. Step
+/// by 80mV
+pub(crate) const USB_OTG11_DREFH: EfuseField = EfuseField::new(0, 1, 55, 2);
+/// TBD
+pub(crate) const USB_PHY_SEL: EfuseField = EfuseField::new(0, 1, 57, 1);
+/// Set this bit to control validation of HUK generate mode. Odd of 1 is
+/// invalid; even of 1 is valid
+pub(crate) const KM_HUK_GEN_STATE: EfuseField = EfuseField::new(0, 1, 58, 9);
+/// Set bits to control key manager random number switch cycle. 0: control by
+/// register. 1: 8 km clk cycles. 2: 16 km cycles. 3: 32 km cycles
+pub(crate) const KM_RND_SWITCH_CYCLE: EfuseField = EfuseField::new(0, 2, 67, 2);
+/// Set each bit to control whether corresponding key can only be deployed once.
+/// 1 is true; 0 is false. Bit0: ecdsa. Bit1: xts. Bit2: hmac. Bit3: ds
+pub(crate) const KM_DEPLOY_ONLY_ONCE: EfuseField = EfuseField::new(0, 2, 69, 4);
+/// Set each bit to control whether corresponding key must come from key
+/// manager.. 1 is true; 0 is false. Bit0: ecdsa. Bit1: xts. Bit2: hmac. Bit3:
+/// ds
+pub(crate) const FORCE_USE_KEY_MANAGER_KEY: EfuseField = EfuseField::new(0, 2, 73, 4);
+/// Set this bit to disable software written init key; and force use
+/// efuse_init_key
+pub(crate) const FORCE_DISABLE_SW_INIT_KEY: EfuseField = EfuseField::new(0, 2, 77, 1);
+/// Set this bit to configure flash encryption use xts-128 key; else use xts-256
+/// key
+pub(crate) const XTS_KEY_LENGTH_256: EfuseField = EfuseField::new(0, 2, 78, 1);
+/// Reserved; it was created by set_missed_fields_in_regs func
+pub(crate) const RESERVE_0_79: EfuseField = EfuseField::new(0, 2, 79, 1);
+/// Represents whether RTC watchdog timeout threshold is selected at startup. 1:
+/// selected. 0: not selected
+pub(crate) const WDT_DELAY_SEL: EfuseField = EfuseField::new(0, 2, 80, 2);
+/// Enables flash encryption when 1 or 3 bits are set and disables otherwise
+pub(crate) const SPI_BOOT_CRYPT_CNT: EfuseField = EfuseField::new(0, 2, 82, 3);
+/// Revoke 1st secure boot key
+pub(crate) const SECURE_BOOT_KEY_REVOKE0: EfuseField = EfuseField::new(0, 2, 85, 1);
+/// Revoke 2nd secure boot key
+pub(crate) const SECURE_BOOT_KEY_REVOKE1: EfuseField = EfuseField::new(0, 2, 86, 1);
+/// Revoke 3rd secure boot key
+pub(crate) const SECURE_BOOT_KEY_REVOKE2: EfuseField = EfuseField::new(0, 2, 87, 1);
+/// Represents the purpose of Key0
+pub(crate) const KEY_PURPOSE_0: EfuseField = EfuseField::new(0, 2, 88, 4);
+/// Represents the purpose of Key1
+pub(crate) const KEY_PURPOSE_1: EfuseField = EfuseField::new(0, 2, 92, 4);
+/// Represents the purpose of Key2
+pub(crate) const KEY_PURPOSE_2: EfuseField = EfuseField::new(0, 3, 96, 4);
+/// Represents the purpose of Key3
+pub(crate) const KEY_PURPOSE_3: EfuseField = EfuseField::new(0, 3, 100, 4);
+/// Represents the purpose of Key4
+pub(crate) const KEY_PURPOSE_4: EfuseField = EfuseField::new(0, 3, 104, 4);
+/// Represents the purpose of Key5
+pub(crate) const KEY_PURPOSE_5: EfuseField = EfuseField::new(0, 3, 108, 4);
+/// Represents the spa secure level by configuring the clock random divide mode
+pub(crate) const SEC_DPA_LEVEL: EfuseField = EfuseField::new(0, 3, 112, 2);
+/// Represents whether hardware random number k is forced used in ESDCA. 1:
+/// force used. 0: not force used
+pub(crate) const ECDSA_ENABLE_SOFT_K: EfuseField = EfuseField::new(0, 3, 114, 1);
+/// Represents whether anti-dpa attack is enabled. 1:enabled. 0: disabled
+pub(crate) const CRYPT_DPA_ENABLE: EfuseField = EfuseField::new(0, 3, 115, 1);
+/// Represents whether secure boot is enabled or disabled. 1: enabled. 0:
+/// disabled
+pub(crate) const SECURE_BOOT_EN: EfuseField = EfuseField::new(0, 3, 116, 1);
+/// Represents whether revoking aggressive secure boot is enabled or disabled.
+/// 1: enabled. 0: disabled
+pub(crate) const SECURE_BOOT_AGGRESSIVE_REVOKE: EfuseField = EfuseField::new(0, 3, 117, 1);
+/// Reserved; it was created by set_missed_fields_in_regs func
+pub(crate) const RESERVE_0_118: EfuseField = EfuseField::new(0, 3, 118, 1);
+/// The type of interfaced flash. 0: four data lines; 1: eight data lines
+pub(crate) const FLASH_TYPE: EfuseField = EfuseField::new(0, 3, 119, 1);
+/// Set flash page size
+pub(crate) const FLASH_PAGE_SIZE: EfuseField = EfuseField::new(0, 3, 120, 2);
+/// Set this bit to enable ecc for flash boot
+pub(crate) const FLASH_ECC_EN: EfuseField = EfuseField::new(0, 3, 122, 1);
+/// Set this bit to disable download via USB-OTG
+pub(crate) const DIS_USB_OTG_DOWNLOAD_MODE: EfuseField = EfuseField::new(0, 3, 123, 1);
+/// Represents the flash waiting time after power-up; in unit of ms. When the
+/// value less than 15; the waiting time is the programmed value. Otherwise; the
+/// waiting time is 2 times the programmed value
+pub(crate) const FLASH_TPUW: EfuseField = EfuseField::new(0, 3, 124, 4);
+/// Represents whether Download mode is disabled or enabled. 1: disabled. 0:
+/// enabled
+pub(crate) const DIS_DOWNLOAD_MODE: EfuseField = EfuseField::new(0, 4, 128, 1);
+/// Represents whether direct boot mode is disabled or enabled. 1: disabled. 0:
+/// enabled
+pub(crate) const DIS_DIRECT_BOOT: EfuseField = EfuseField::new(0, 4, 129, 1);
+/// Represents whether print from USB-Serial-JTAG is disabled or enabled. 1:
+/// disabled. 0: enabled
+pub(crate) const DIS_USB_SERIAL_JTAG_ROM_PRINT: EfuseField = EfuseField::new(0, 4, 130, 1);
+/// TBD
+pub(crate) const LOCK_KM_KEY: EfuseField = EfuseField::new(0, 4, 131, 1);
+/// Represents whether the USB-Serial-JTAG download function is disabled or
+/// enabled. 1: disabled. 0: enabled
+pub(crate) const DIS_USB_SERIAL_JTAG_DOWNLOAD_MODE: EfuseField = EfuseField::new(0, 4, 132, 1);
+/// Represents whether security download is enabled or disabled. 1: enabled. 0:
+/// disabled
+pub(crate) const ENABLE_SECURITY_DOWNLOAD: EfuseField = EfuseField::new(0, 4, 133, 1);
+/// Represents the type of UART printing. 00: force enable printing. 01: enable
+/// printing when GPIO8 is reset at low level. 10: enable printing when GPIO8 is
+/// reset at high level. 11: force disable printing
+pub(crate) const UART_PRINT_CONTROL: EfuseField = EfuseField::new(0, 4, 134, 2);
+/// Represents whether ROM code is forced to send a resume command during SPI
+/// boot. 1: forced. 0:not forced
+pub(crate) const FORCE_SEND_RESUME: EfuseField = EfuseField::new(0, 4, 136, 1);
+/// Represents the version used by ESP-IDF anti-rollback feature
+pub(crate) const SECURE_VERSION: EfuseField = EfuseField::new(0, 4, 137, 16);
+/// Represents whether FAST VERIFY ON WAKE is disabled or enabled when Secure
+/// Boot is enabled. 1: disabled. 0: enabled
+pub(crate) const SECURE_BOOT_DISABLE_FAST_WAKE: EfuseField = EfuseField::new(0, 4, 153, 1);
+/// Represents whether the hysteresis function of corresponding PAD is enabled.
+/// 1: enabled. 0:disabled
+pub(crate) const HYS_EN_PAD: EfuseField = EfuseField::new(0, 4, 154, 1);
+/// Set the dcdc voltage default
+pub(crate) const DCDC_VSET: EfuseField = EfuseField::new(0, 4, 155, 5);
+/// TBD
+pub(crate) const PXA0_TIEH_SEL_0: EfuseField = EfuseField::new(0, 5, 160, 2);
+/// TBD
+pub(crate) const PXA0_TIEH_SEL_1: EfuseField = EfuseField::new(0, 5, 162, 2);
+/// TBD
+pub(crate) const PXA0_TIEH_SEL_2: EfuseField = EfuseField::new(0, 5, 164, 2);
+/// TBD
+pub(crate) const PXA0_TIEH_SEL_3: EfuseField = EfuseField::new(0, 5, 166, 2);
+/// TBD
+pub(crate) const KM_DISABLE_DEPLOY_MODE: EfuseField = EfuseField::new(0, 5, 168, 4);
+/// Represents the usb device single-end input low threshold; 0.8 V to 1.04 V
+/// with step of 80 mV
+pub(crate) const USB_DEVICE_DREFL: EfuseField = EfuseField::new(0, 5, 172, 2);
+/// Represents the usb otg11 single-end input low threshold; 0.8 V to 1.04 V
+/// with step of 80 mV
+pub(crate) const USB_OTG11_DREFL: EfuseField = EfuseField::new(0, 5, 174, 2);
+/// Reserved; it was created by set_missed_fields_in_regs func
+pub(crate) const RESERVE_0_176: EfuseField = EfuseField::new(0, 5, 176, 2);
+/// HP system power source select. 0:LDO. 1: DCDC
+pub(crate) const HP_PWR_SRC_SEL: EfuseField = EfuseField::new(0, 5, 178, 1);
+/// Select dcdc vset use efuse_dcdc_vset
+pub(crate) const DCDC_VSET_EN: EfuseField = EfuseField::new(0, 5, 179, 1);
+/// Set this bit to disable watch dog
+pub(crate) const DIS_WDT: EfuseField = EfuseField::new(0, 5, 180, 1);
+/// Set this bit to disable super-watchdog
+pub(crate) const DIS_SWD: EfuseField = EfuseField::new(0, 5, 181, 1);
+/// Reserved; it was created by set_missed_fields_in_regs func
+pub(crate) const RESERVE_0_182: EfuseField = EfuseField::new(0, 5, 182, 10);
+/// MAC address
+pub(crate) const MAC0: EfuseField = EfuseField::new(1, 0, 0, 32);
+/// MAC address
+pub(crate) const MAC1: EfuseField = EfuseField::new(1, 1, 0, 16);
+/// Stores the extended bits of MAC address
+pub(crate) const RESERVED_1_16: EfuseField = EfuseField::new(1, 1, 48, 16);
+/// Minor chip version
+pub(crate) const WAFER_VERSION_MINOR: EfuseField = EfuseField::new(1, 2, 64, 4);
+/// Major chip version
+pub(crate) const WAFER_VERSION_MAJOR: EfuseField = EfuseField::new(1, 2, 68, 2);
+/// Disables check of wafer version major
+pub(crate) const DISABLE_WAFER_VERSION_MAJOR: EfuseField = EfuseField::new(1, 2, 70, 1);
+/// Disables check of blk version major
+pub(crate) const DISABLE_BLK_VERSION_MAJOR: EfuseField = EfuseField::new(1, 2, 71, 1);
+/// BLK_VERSION_MINOR of BLOCK2
+pub(crate) const BLK_VERSION_MINOR: EfuseField = EfuseField::new(1, 2, 72, 3);
+/// BLK_VERSION_MAJOR of BLOCK2
+pub(crate) const BLK_VERSION_MAJOR: EfuseField = EfuseField::new(1, 2, 75, 2);
+/// PSRAM capacity
+pub(crate) const PSRAM_CAP: EfuseField = EfuseField::new(1, 2, 77, 3);
+/// Operating temperature of the ESP chip
+pub(crate) const TEMP: EfuseField = EfuseField::new(1, 2, 80, 2);
+/// PSRAM vendor
+pub(crate) const PSRAM_VENDOR: EfuseField = EfuseField::new(1, 2, 82, 2);
+/// Package version
+pub(crate) const PKG_VERSION: EfuseField = EfuseField::new(1, 2, 84, 3);
+/// reserved
+pub(crate) const RESERVED_1_87: EfuseField = EfuseField::new(1, 2, 87, 1);
+/// Output VO1 parameter
+pub(crate) const LDO_VO1_DREF: EfuseField = EfuseField::new(1, 2, 88, 4);
+/// Output VO2 parameter
+pub(crate) const LDO_VO2_DREF: EfuseField = EfuseField::new(1, 2, 92, 4);
+/// Output VO1 parameter
+pub(crate) const LDO_VO1_MUL: EfuseField = EfuseField::new(1, 3, 96, 3);
+/// Output VO2 parameter
+pub(crate) const LDO_VO2_MUL: EfuseField = EfuseField::new(1, 3, 99, 3);
+/// Output VO3 calibration parameter
+pub(crate) const LDO_VO3_K: EfuseField = EfuseField::new(1, 3, 102, 8);
+/// Output VO3 calibration parameter
+pub(crate) const LDO_VO3_VOS: EfuseField = EfuseField::new(1, 3, 110, 6);
+/// Output VO3 calibration parameter
+pub(crate) const LDO_VO3_C: EfuseField = EfuseField::new(1, 3, 116, 6);
+/// Output VO4 calibration parameter
+pub(crate) const LDO_VO4_K: EfuseField = EfuseField::new(1, 3, 122, 8);
+/// Output VO4 calibration parameter
+pub(crate) const LDO_VO4_VOS: EfuseField = EfuseField::new(1, 4, 130, 6);
+/// Output VO4 calibration parameter
+pub(crate) const LDO_VO4_C: EfuseField = EfuseField::new(1, 4, 136, 6);
+/// reserved
+pub(crate) const RESERVED_1_142: EfuseField = EfuseField::new(1, 4, 142, 2);
+/// Active HP DBIAS of fixed voltage
+pub(crate) const ACTIVE_HP_DBIAS: EfuseField = EfuseField::new(1, 4, 144, 4);
+/// Active LP DBIAS of fixed voltage
+pub(crate) const ACTIVE_LP_DBIAS: EfuseField = EfuseField::new(1, 4, 148, 4);
+/// LSLP HP DBIAS of fixed voltage
+pub(crate) const LSLP_HP_DBIAS: EfuseField = EfuseField::new(1, 4, 152, 4);
+/// DSLP BDG of fixed voltage
+pub(crate) const DSLP_DBG: EfuseField = EfuseField::new(1, 4, 156, 4);
+/// DSLP LP DBIAS of fixed voltage
+pub(crate) const DSLP_LP_DBIAS: EfuseField = EfuseField::new(1, 5, 160, 5);
+/// DBIAS gap between LP and DCDC
+pub(crate) const LP_DCDC_DBIAS_VOL_GAP: EfuseField = EfuseField::new(1, 5, 165, 5);
+/// reserved
+pub(crate) const RESERVED_1_170: EfuseField = EfuseField::new(1, 5, 170, 22);
+/// Optional unique 128-bit ID
+pub(crate) const OPTIONAL_UNIQUE_ID: EfuseField = EfuseField::new(2, 0, 0, 128);
+/// Average initcode of ADC1 atten0
+pub(crate) const ADC1_AVE_INITCODE_ATTEN0: EfuseField = EfuseField::new(2, 4, 128, 10);
+/// Average initcode of ADC1 atten1
+pub(crate) const ADC1_AVE_INITCODE_ATTEN1: EfuseField = EfuseField::new(2, 4, 138, 10);
+/// Average initcode of ADC1 atten2
+pub(crate) const ADC1_AVE_INITCODE_ATTEN2: EfuseField = EfuseField::new(2, 4, 148, 10);
+/// Average initcode of ADC1 atten3
+pub(crate) const ADC1_AVE_INITCODE_ATTEN3: EfuseField = EfuseField::new(2, 4, 158, 10);
+/// Average initcode of ADC2 atten0
+pub(crate) const ADC2_AVE_INITCODE_ATTEN0: EfuseField = EfuseField::new(2, 5, 168, 10);
+/// Average initcode of ADC2 atten1
+pub(crate) const ADC2_AVE_INITCODE_ATTEN1: EfuseField = EfuseField::new(2, 5, 178, 10);
+/// Average initcode of ADC2 atten2
+pub(crate) const ADC2_AVE_INITCODE_ATTEN2: EfuseField = EfuseField::new(2, 5, 188, 10);
+/// Average initcode of ADC2 atten3
+pub(crate) const ADC2_AVE_INITCODE_ATTEN3: EfuseField = EfuseField::new(2, 6, 198, 10);
+/// HI_DOUT of ADC1 atten0
+pub(crate) const ADC1_HI_DOUT_ATTEN0: EfuseField = EfuseField::new(2, 6, 208, 10);
+/// HI_DOUT of ADC1 atten1
+pub(crate) const ADC1_HI_DOUT_ATTEN1: EfuseField = EfuseField::new(2, 6, 218, 10);
+/// HI_DOUT of ADC1 atten2
+pub(crate) const ADC1_HI_DOUT_ATTEN2: EfuseField = EfuseField::new(2, 7, 228, 10);
+/// HI_DOUT of ADC1 atten3
+pub(crate) const ADC1_HI_DOUT_ATTEN3: EfuseField = EfuseField::new(2, 7, 238, 10);
+/// reserved
+pub(crate) const RESERVED_2_248: EfuseField = EfuseField::new(2, 7, 248, 8);
+/// User data
+pub(crate) const BLOCK_USR_DATA: EfuseField = EfuseField::new(3, 0, 0, 192);
+/// reserved
+pub(crate) const RESERVED_3_192: EfuseField = EfuseField::new(3, 6, 192, 8);
+/// Custom MAC
+pub(crate) const CUSTOM_MAC: EfuseField = EfuseField::new(3, 6, 200, 48);
+/// reserved
+pub(crate) const RESERVED_3_248: EfuseField = EfuseField::new(3, 7, 248, 8);
+/// Key0 or user data
+pub(crate) const BLOCK_KEY0: EfuseField = EfuseField::new(4, 0, 0, 256);
+/// Key1 or user data
+pub(crate) const BLOCK_KEY1: EfuseField = EfuseField::new(5, 0, 0, 256);
+/// Key2 or user data
+pub(crate) const BLOCK_KEY2: EfuseField = EfuseField::new(6, 0, 0, 256);
+/// Key3 or user data
+pub(crate) const BLOCK_KEY3: EfuseField = EfuseField::new(7, 0, 0, 256);
+/// Key4 or user data
+pub(crate) const BLOCK_KEY4: EfuseField = EfuseField::new(8, 0, 0, 256);
+/// Key5 or user data
+pub(crate) const BLOCK_KEY5: EfuseField = EfuseField::new(9, 0, 0, 256);
+/// HI_DOUT of ADC2 atten0
+pub(crate) const ADC2_HI_DOUT_ATTEN0: EfuseField = EfuseField::new(10, 0, 0, 10);
+/// HI_DOUT of ADC2 atten1
+pub(crate) const ADC2_HI_DOUT_ATTEN1: EfuseField = EfuseField::new(10, 0, 10, 10);
+/// HI_DOUT of ADC2 atten2
+pub(crate) const ADC2_HI_DOUT_ATTEN2: EfuseField = EfuseField::new(10, 0, 20, 10);
+/// HI_DOUT of ADC2 atten3
+pub(crate) const ADC2_HI_DOUT_ATTEN3: EfuseField = EfuseField::new(10, 0, 30, 10);
+/// Gap between ADC1_ch0 and average initcode
+pub(crate) const ADC1_CH0_ATTEN0_INITCODE_DIFF: EfuseField = EfuseField::new(10, 1, 40, 4);
+/// Gap between ADC1_ch1 and average initcode
+pub(crate) const ADC1_CH1_ATTEN0_INITCODE_DIFF: EfuseField = EfuseField::new(10, 1, 44, 4);
+/// Gap between ADC1_ch2 and average initcode
+pub(crate) const ADC1_CH2_ATTEN0_INITCODE_DIFF: EfuseField = EfuseField::new(10, 1, 48, 4);
+/// Gap between ADC1_ch3 and average initcode
+pub(crate) const ADC1_CH3_ATTEN0_INITCODE_DIFF: EfuseField = EfuseField::new(10, 1, 52, 4);
+/// Gap between ADC1_ch4 and average initcode
+pub(crate) const ADC1_CH4_ATTEN0_INITCODE_DIFF: EfuseField = EfuseField::new(10, 1, 56, 4);
+/// Gap between ADC1_ch5 and average initcode
+pub(crate) const ADC1_CH5_ATTEN0_INITCODE_DIFF: EfuseField = EfuseField::new(10, 1, 60, 4);
+/// Gap between ADC1_ch6 and average initcode
+pub(crate) const ADC1_CH6_ATTEN0_INITCODE_DIFF: EfuseField = EfuseField::new(10, 2, 64, 4);
+/// Gap between ADC1_ch7 and average initcode
+pub(crate) const ADC1_CH7_ATTEN0_INITCODE_DIFF: EfuseField = EfuseField::new(10, 2, 68, 4);
+/// Gap between ADC2_ch0 and average initcode
+pub(crate) const ADC2_CH0_ATTEN0_INITCODE_DIFF: EfuseField = EfuseField::new(10, 2, 72, 4);
+/// Gap between ADC2_ch1 and average initcode
+pub(crate) const ADC2_CH1_ATTEN0_INITCODE_DIFF: EfuseField = EfuseField::new(10, 2, 76, 4);
+/// Gap between ADC2_ch2 and average initcode
+pub(crate) const ADC2_CH2_ATTEN0_INITCODE_DIFF: EfuseField = EfuseField::new(10, 2, 80, 4);
+/// Gap between ADC2_ch3 and average initcode
+pub(crate) const ADC2_CH3_ATTEN0_INITCODE_DIFF: EfuseField = EfuseField::new(10, 2, 84, 4);
+/// Gap between ADC2_ch4 and average initcode
+pub(crate) const ADC2_CH4_ATTEN0_INITCODE_DIFF: EfuseField = EfuseField::new(10, 2, 88, 4);
+/// Gap between ADC2_ch5 and average initcode
+pub(crate) const ADC2_CH5_ATTEN0_INITCODE_DIFF: EfuseField = EfuseField::new(10, 2, 92, 4);
+/// Temperature calibration data
+pub(crate) const TEMPERATURE_SENSOR: EfuseField = EfuseField::new(10, 3, 96, 9);
+/// reserved
+pub(crate) const RESERVED_10_105: EfuseField = EfuseField::new(10, 3, 105, 23);
+/// Stores the $nth 32 bits of the 2nd part of system data
+pub(crate) const SYS_DATA_PART2_4: EfuseField = EfuseField::new(10, 4, 128, 32);
+/// Stores the $nth 32 bits of the 2nd part of system data
+pub(crate) const SYS_DATA_PART2_5: EfuseField = EfuseField::new(10, 5, 160, 32);
+/// Stores the $nth 32 bits of the 2nd part of system data
+pub(crate) const SYS_DATA_PART2_6: EfuseField = EfuseField::new(10, 6, 192, 32);
+/// Stores the $nth 32 bits of the 2nd part of system data
+pub(crate) const SYS_DATA_PART2_7: EfuseField = EfuseField::new(10, 7, 224, 32);

--- a/espflash/src/targets/efuse/esp32s2.rs
+++ b/espflash/src/targets/efuse/esp32s2.rs
@@ -1,0 +1,256 @@
+//! This file was automatically generated, please do not edit it manually!
+//!
+//! Generated: 2025-04-15 12:51
+//! Version:   888a61f6f500d9c7ee0aa32016b0bee7
+
+#![allow(unused)]
+
+use super::EfuseField;
+
+/// Total size in bytes of each block
+pub(crate) const BLOCK_SIZES: &[u32] = &[23, 24, 32, 32, 32, 32, 32, 32, 32, 32, 32];
+
+/// Disable programming of individual eFuses
+pub(crate) const WR_DIS: EfuseField = EfuseField::new(0, 0, 0, 32);
+/// Disable reading from BlOCK4-10
+pub(crate) const RD_DIS: EfuseField = EfuseField::new(0, 1, 32, 7);
+/// Reserved
+pub(crate) const DIS_RTC_RAM_BOOT: EfuseField = EfuseField::new(0, 1, 39, 1);
+/// Set this bit to disable Icache
+pub(crate) const DIS_ICACHE: EfuseField = EfuseField::new(0, 1, 40, 1);
+/// Set this bit to disable Dcache
+pub(crate) const DIS_DCACHE: EfuseField = EfuseField::new(0, 1, 41, 1);
+/// Disables Icache when SoC is in Download mode
+pub(crate) const DIS_DOWNLOAD_ICACHE: EfuseField = EfuseField::new(0, 1, 42, 1);
+/// Disables Dcache when SoC is in Download mode
+pub(crate) const DIS_DOWNLOAD_DCACHE: EfuseField = EfuseField::new(0, 1, 43, 1);
+/// Set this bit to disable the function that forces chip into download mode
+pub(crate) const DIS_FORCE_DOWNLOAD: EfuseField = EfuseField::new(0, 1, 44, 1);
+/// Set this bit to disable USB OTG function
+pub(crate) const DIS_USB: EfuseField = EfuseField::new(0, 1, 45, 1);
+/// Set this bit to disable the TWAI Controller function
+pub(crate) const DIS_TWAI: EfuseField = EfuseField::new(0, 1, 46, 1);
+/// Disables capability to Remap RAM to ROM address space
+pub(crate) const DIS_BOOT_REMAP: EfuseField = EfuseField::new(0, 1, 47, 1);
+/// Reserved (used for four backups method)
+pub(crate) const RPT4_RESERVED5: EfuseField = EfuseField::new(0, 1, 48, 1);
+/// Software disables JTAG. When software disabled; JTAG can be activated
+/// temporarily by HMAC peripheral
+pub(crate) const SOFT_DIS_JTAG: EfuseField = EfuseField::new(0, 1, 49, 1);
+/// Hardware disables JTAG permanently
+pub(crate) const HARD_DIS_JTAG: EfuseField = EfuseField::new(0, 1, 50, 1);
+/// Disables flash encryption when in download boot modes
+pub(crate) const DIS_DOWNLOAD_MANUAL_ENCRYPT: EfuseField = EfuseField::new(0, 1, 51, 1);
+/// Controls single-end input threshold vrefh; 1.76 V to 2 V with step of 80 mV;
+/// stored in eFuse
+pub(crate) const USB_DREFH: EfuseField = EfuseField::new(0, 1, 52, 2);
+/// Controls single-end input threshold vrefl; 0.8 V to 1.04 V with step of 80
+/// mV; stored in eFuse
+pub(crate) const USB_DREFL: EfuseField = EfuseField::new(0, 1, 54, 2);
+/// Set this bit to exchange USB D+ and D- pins
+pub(crate) const USB_EXCHG_PINS: EfuseField = EfuseField::new(0, 1, 56, 1);
+/// Set this bit to enable external USB PHY
+pub(crate) const USB_EXT_PHY_ENABLE: EfuseField = EfuseField::new(0, 1, 57, 1);
+/// If set; forces USB BVALID to 1
+pub(crate) const USB_FORCE_NOPERSIST: EfuseField = EfuseField::new(0, 1, 58, 1);
+/// BLOCK0 efuse version
+pub(crate) const BLOCK0_VERSION: EfuseField = EfuseField::new(0, 1, 59, 2);
+/// SPI regulator switches current limit mode
+pub(crate) const VDD_SPI_MODECURLIM: EfuseField = EfuseField::new(0, 1, 61, 1);
+/// SPI regulator high voltage reference
+pub(crate) const VDD_SPI_DREFH: EfuseField = EfuseField::new(0, 1, 62, 2);
+/// SPI regulator medium voltage reference
+pub(crate) const VDD_SPI_DREFM: EfuseField = EfuseField::new(0, 2, 64, 2);
+/// SPI regulator low voltage reference
+pub(crate) const VDD_SPI_DREFL: EfuseField = EfuseField::new(0, 2, 66, 2);
+/// If VDD_SPI_FORCE is 1; this value determines if the VDD_SPI regulator is
+/// powered on
+pub(crate) const VDD_SPI_XPD: EfuseField = EfuseField::new(0, 2, 68, 1);
+/// If VDD_SPI_FORCE is 1; determines VDD_SPI voltage
+pub(crate) const VDD_SPI_TIEH: EfuseField = EfuseField::new(0, 2, 69, 1);
+/// Set this bit to use XPD_VDD_PSI_REG and VDD_SPI_TIEH to configure VDD_SPI
+/// LDO
+pub(crate) const VDD_SPI_FORCE: EfuseField = EfuseField::new(0, 2, 70, 1);
+/// Set SPI regulator to 0 to configure init[1:0]=0
+pub(crate) const VDD_SPI_EN_INIT: EfuseField = EfuseField::new(0, 2, 71, 1);
+/// Set SPI regulator to 1 to enable output current limit
+pub(crate) const VDD_SPI_ENCURLIM: EfuseField = EfuseField::new(0, 2, 72, 1);
+/// Tunes the current limit threshold of SPI regulator when tieh=0; about 800
+/// mA/(8+d)
+pub(crate) const VDD_SPI_DCURLIM: EfuseField = EfuseField::new(0, 2, 73, 3);
+/// Adds resistor from LDO output to ground
+pub(crate) const VDD_SPI_INIT: EfuseField = EfuseField::new(0, 2, 76, 2);
+/// Prevents SPI regulator from overshoot
+pub(crate) const VDD_SPI_DCAP: EfuseField = EfuseField::new(0, 2, 78, 2);
+/// RTC watchdog timeout threshold; in unit of slow clock cycle
+pub(crate) const WDT_DELAY_SEL: EfuseField = EfuseField::new(0, 2, 80, 2);
+/// Enables flash encryption when 1 or 3 bits are set and disabled otherwise
+pub(crate) const SPI_BOOT_CRYPT_CNT: EfuseField = EfuseField::new(0, 2, 82, 3);
+/// Revoke 1st secure boot key
+pub(crate) const SECURE_BOOT_KEY_REVOKE0: EfuseField = EfuseField::new(0, 2, 85, 1);
+/// Revoke 2nd secure boot key
+pub(crate) const SECURE_BOOT_KEY_REVOKE1: EfuseField = EfuseField::new(0, 2, 86, 1);
+/// Revoke 3rd secure boot key
+pub(crate) const SECURE_BOOT_KEY_REVOKE2: EfuseField = EfuseField::new(0, 2, 87, 1);
+/// Purpose of KEY0
+pub(crate) const KEY_PURPOSE_0: EfuseField = EfuseField::new(0, 2, 88, 4);
+/// Purpose of KEY1
+pub(crate) const KEY_PURPOSE_1: EfuseField = EfuseField::new(0, 2, 92, 4);
+/// Purpose of KEY2
+pub(crate) const KEY_PURPOSE_2: EfuseField = EfuseField::new(0, 3, 96, 4);
+/// Purpose of KEY3
+pub(crate) const KEY_PURPOSE_3: EfuseField = EfuseField::new(0, 3, 100, 4);
+/// Purpose of KEY4
+pub(crate) const KEY_PURPOSE_4: EfuseField = EfuseField::new(0, 3, 104, 4);
+/// Purpose of KEY5
+pub(crate) const KEY_PURPOSE_5: EfuseField = EfuseField::new(0, 3, 108, 4);
+/// Purpose of KEY6
+pub(crate) const KEY_PURPOSE_6: EfuseField = EfuseField::new(0, 3, 112, 4);
+/// Set this bit to enable secure boot
+pub(crate) const SECURE_BOOT_EN: EfuseField = EfuseField::new(0, 3, 116, 1);
+/// Set this bit to enable aggressive secure boot key revocation mode
+pub(crate) const SECURE_BOOT_AGGRESSIVE_REVOKE: EfuseField = EfuseField::new(0, 3, 117, 1);
+/// Reserved (used for four backups method)
+pub(crate) const RPT4_RESERVED1: EfuseField = EfuseField::new(0, 3, 118, 6);
+/// Configures flash startup delay after SoC power-up; in unit of (ms/2). When
+/// the value is 15; delay is 7.5 ms
+pub(crate) const FLASH_TPUW: EfuseField = EfuseField::new(0, 3, 124, 4);
+/// Set this bit to disable all download boot modes
+pub(crate) const DIS_DOWNLOAD_MODE: EfuseField = EfuseField::new(0, 4, 128, 1);
+/// Set this bit to disable Legacy SPI boot mode
+pub(crate) const DIS_LEGACY_SPI_BOOT: EfuseField = EfuseField::new(0, 4, 129, 1);
+/// Selects the default UART for printing boot messages
+pub(crate) const UART_PRINT_CHANNEL: EfuseField = EfuseField::new(0, 4, 130, 1);
+/// Reserved (used for four backups method)
+pub(crate) const RPT4_RESERVED3: EfuseField = EfuseField::new(0, 4, 131, 1);
+/// Set this bit to disable use of USB OTG in UART download boot mode
+pub(crate) const DIS_USB_DOWNLOAD_MODE: EfuseField = EfuseField::new(0, 4, 132, 1);
+/// Set this bit to enable secure UART download mode (read/write flash only)
+pub(crate) const ENABLE_SECURITY_DOWNLOAD: EfuseField = EfuseField::new(0, 4, 133, 1);
+/// Set the default UART boot message output mode
+pub(crate) const UART_PRINT_CONTROL: EfuseField = EfuseField::new(0, 4, 134, 2);
+/// Set default power supply for GPIO33-GPIO37; set when SPI flash is
+/// initialized
+pub(crate) const PIN_POWER_SELECTION: EfuseField = EfuseField::new(0, 4, 136, 1);
+/// SPI flash type
+pub(crate) const FLASH_TYPE: EfuseField = EfuseField::new(0, 4, 137, 1);
+/// If set; forces ROM code to send an SPI flash resume command during SPI boot
+pub(crate) const FORCE_SEND_RESUME: EfuseField = EfuseField::new(0, 4, 138, 1);
+/// Secure version (used by ESP-IDF anti-rollback feature)
+pub(crate) const SECURE_VERSION: EfuseField = EfuseField::new(0, 4, 139, 16);
+/// Reserved (used for four backups method)
+pub(crate) const RPT4_RESERVED2: EfuseField = EfuseField::new(0, 4, 155, 5);
+/// Disables check of wafer version major
+pub(crate) const DISABLE_WAFER_VERSION_MAJOR: EfuseField = EfuseField::new(0, 5, 160, 1);
+/// Disables check of blk version major
+pub(crate) const DISABLE_BLK_VERSION_MAJOR: EfuseField = EfuseField::new(0, 5, 161, 1);
+/// reserved
+pub(crate) const RESERVED_0_162: EfuseField = EfuseField::new(0, 5, 162, 22);
+/// MAC address
+pub(crate) const MAC0: EfuseField = EfuseField::new(1, 0, 0, 32);
+/// MAC address
+pub(crate) const MAC1: EfuseField = EfuseField::new(1, 1, 0, 16);
+/// SPI_PAD_configure CLK
+pub(crate) const SPI_PAD_CONFIG_CLK: EfuseField = EfuseField::new(1, 1, 48, 6);
+/// SPI_PAD_configure Q(D1)
+pub(crate) const SPI_PAD_CONFIG_Q: EfuseField = EfuseField::new(1, 1, 54, 6);
+/// SPI_PAD_configure D(D0)
+pub(crate) const SPI_PAD_CONFIG_D: EfuseField = EfuseField::new(1, 1, 60, 6);
+/// SPI_PAD_configure CS
+pub(crate) const SPI_PAD_CONFIG_CS: EfuseField = EfuseField::new(1, 2, 66, 6);
+/// SPI_PAD_configure HD(D3)
+pub(crate) const SPI_PAD_CONFIG_HD: EfuseField = EfuseField::new(1, 2, 72, 6);
+/// SPI_PAD_configure WP(D2)
+pub(crate) const SPI_PAD_CONFIG_WP: EfuseField = EfuseField::new(1, 2, 78, 6);
+/// SPI_PAD_configure DQS
+pub(crate) const SPI_PAD_CONFIG_DQS: EfuseField = EfuseField::new(1, 2, 84, 6);
+/// SPI_PAD_configure D4
+pub(crate) const SPI_PAD_CONFIG_D4: EfuseField = EfuseField::new(1, 2, 90, 6);
+/// SPI_PAD_configure D5
+pub(crate) const SPI_PAD_CONFIG_D5: EfuseField = EfuseField::new(1, 3, 96, 6);
+/// SPI_PAD_configure D6
+pub(crate) const SPI_PAD_CONFIG_D6: EfuseField = EfuseField::new(1, 3, 102, 6);
+/// SPI_PAD_configure D7
+pub(crate) const SPI_PAD_CONFIG_D7: EfuseField = EfuseField::new(1, 3, 108, 6);
+/// WAFER_VERSION_MAJOR
+pub(crate) const WAFER_VERSION_MAJOR: EfuseField = EfuseField::new(1, 3, 114, 2);
+/// WAFER_VERSION_MINOR most significant bit
+pub(crate) const WAFER_VERSION_MINOR_HI: EfuseField = EfuseField::new(1, 3, 116, 1);
+/// Flash version
+pub(crate) const FLASH_VERSION: EfuseField = EfuseField::new(1, 3, 117, 4);
+/// BLK_VERSION_MAJOR
+pub(crate) const BLK_VERSION_MAJOR: EfuseField = EfuseField::new(1, 3, 121, 2);
+/// reserved
+pub(crate) const RESERVED_1_123: EfuseField = EfuseField::new(1, 3, 123, 1);
+/// PSRAM version
+pub(crate) const PSRAM_VERSION: EfuseField = EfuseField::new(1, 3, 124, 4);
+/// Package version
+pub(crate) const PKG_VERSION: EfuseField = EfuseField::new(1, 4, 128, 4);
+/// WAFER_VERSION_MINOR least significant bits
+pub(crate) const WAFER_VERSION_MINOR_LO: EfuseField = EfuseField::new(1, 4, 132, 3);
+/// reserved
+pub(crate) const RESERVED_1_135: EfuseField = EfuseField::new(1, 4, 135, 25);
+/// Stores the second part of the zeroth part of system data
+pub(crate) const SYS_DATA_PART0_2: EfuseField = EfuseField::new(1, 5, 160, 32);
+/// Optional unique 128-bit ID
+pub(crate) const OPTIONAL_UNIQUE_ID: EfuseField = EfuseField::new(2, 0, 0, 128);
+/// 4 bit of ADC calibration
+pub(crate) const ADC_CALIB: EfuseField = EfuseField::new(2, 4, 128, 4);
+/// BLK_VERSION_MINOR of BLOCK2
+pub(crate) const BLK_VERSION_MINOR: EfuseField = EfuseField::new(2, 4, 132, 3);
+/// Temperature calibration data
+pub(crate) const TEMP_CALIB: EfuseField = EfuseField::new(2, 4, 135, 9);
+///
+pub(crate) const RTCCALIB_V1IDX_A10H: EfuseField = EfuseField::new(2, 4, 144, 8);
+///
+pub(crate) const RTCCALIB_V1IDX_A11H: EfuseField = EfuseField::new(2, 4, 152, 8);
+///
+pub(crate) const RTCCALIB_V1IDX_A12H: EfuseField = EfuseField::new(2, 5, 160, 8);
+///
+pub(crate) const RTCCALIB_V1IDX_A13H: EfuseField = EfuseField::new(2, 5, 168, 8);
+///
+pub(crate) const RTCCALIB_V1IDX_A20H: EfuseField = EfuseField::new(2, 5, 176, 8);
+///
+pub(crate) const RTCCALIB_V1IDX_A21H: EfuseField = EfuseField::new(2, 5, 184, 8);
+///
+pub(crate) const RTCCALIB_V1IDX_A22H: EfuseField = EfuseField::new(2, 6, 192, 8);
+///
+pub(crate) const RTCCALIB_V1IDX_A23H: EfuseField = EfuseField::new(2, 6, 200, 8);
+///
+pub(crate) const RTCCALIB_V1IDX_A10L: EfuseField = EfuseField::new(2, 6, 208, 6);
+///
+pub(crate) const RTCCALIB_V1IDX_A11L: EfuseField = EfuseField::new(2, 6, 214, 6);
+///
+pub(crate) const RTCCALIB_V1IDX_A12L: EfuseField = EfuseField::new(2, 6, 220, 6);
+///
+pub(crate) const RTCCALIB_V1IDX_A13L: EfuseField = EfuseField::new(2, 7, 226, 6);
+///
+pub(crate) const RTCCALIB_V1IDX_A20L: EfuseField = EfuseField::new(2, 7, 232, 6);
+///
+pub(crate) const RTCCALIB_V1IDX_A21L: EfuseField = EfuseField::new(2, 7, 238, 6);
+///
+pub(crate) const RTCCALIB_V1IDX_A22L: EfuseField = EfuseField::new(2, 7, 244, 6);
+///
+pub(crate) const RTCCALIB_V1IDX_A23L: EfuseField = EfuseField::new(2, 7, 250, 6);
+/// User data
+pub(crate) const BLOCK_USR_DATA: EfuseField = EfuseField::new(3, 0, 0, 192);
+/// reserved
+pub(crate) const RESERVED_3_192: EfuseField = EfuseField::new(3, 6, 192, 8);
+/// Custom MAC
+pub(crate) const CUSTOM_MAC: EfuseField = EfuseField::new(3, 6, 200, 48);
+/// reserved
+pub(crate) const RESERVED_3_248: EfuseField = EfuseField::new(3, 7, 248, 8);
+/// Key0 or user data
+pub(crate) const BLOCK_KEY0: EfuseField = EfuseField::new(4, 0, 0, 256);
+/// Key1 or user data
+pub(crate) const BLOCK_KEY1: EfuseField = EfuseField::new(5, 0, 0, 256);
+/// Key2 or user data
+pub(crate) const BLOCK_KEY2: EfuseField = EfuseField::new(6, 0, 0, 256);
+/// Key3 or user data
+pub(crate) const BLOCK_KEY3: EfuseField = EfuseField::new(7, 0, 0, 256);
+/// Key4 or user data
+pub(crate) const BLOCK_KEY4: EfuseField = EfuseField::new(8, 0, 0, 256);
+/// Key5 or user data
+pub(crate) const BLOCK_KEY5: EfuseField = EfuseField::new(9, 0, 0, 256);
+/// System data part 2 (reserved)
+pub(crate) const BLOCK_SYS_DATA2: EfuseField = EfuseField::new(10, 0, 0, 256);

--- a/espflash/src/targets/efuse/esp32s2.rs
+++ b/espflash/src/targets/efuse/esp32s2.rs
@@ -8,7 +8,7 @@
 use super::EfuseField;
 
 /// Total size in bytes of each block
-pub(crate) const BLOCK_SIZES: &[u32] = &[23, 24, 32, 32, 32, 32, 32, 32, 32, 32, 32];
+pub(crate) const BLOCK_SIZES: &[u32] = &[24, 24, 32, 32, 32, 32, 32, 32, 32, 32, 32];
 
 /// Disable programming of individual eFuses
 pub(crate) const WR_DIS: EfuseField = EfuseField::new(0, 0, 0, 32);
@@ -145,7 +145,7 @@ pub(crate) const DISABLE_WAFER_VERSION_MAJOR: EfuseField = EfuseField::new(0, 5,
 /// Disables check of blk version major
 pub(crate) const DISABLE_BLK_VERSION_MAJOR: EfuseField = EfuseField::new(0, 5, 161, 1);
 /// reserved
-pub(crate) const RESERVED_0_162: EfuseField = EfuseField::new(0, 5, 162, 22);
+pub(crate) const RESERVED_0_162: EfuseField = EfuseField::new(0, 5, 162, 30);
 /// MAC address
 pub(crate) const MAC0: EfuseField = EfuseField::new(1, 0, 0, 32);
 /// MAC address

--- a/espflash/src/targets/efuse/esp32s3.rs
+++ b/espflash/src/targets/efuse/esp32s3.rs
@@ -1,0 +1,296 @@
+//! This file was automatically generated, please do not edit it manually!
+//!
+//! Generated: 2025-04-15 12:51
+//! Version:   7127dd097e72bb90d0b790d460993126
+
+#![allow(unused)]
+
+use super::EfuseField;
+
+/// Total size in bytes of each block
+pub(crate) const BLOCK_SIZES: &[u32] = &[23, 24, 32, 32, 32, 32, 32, 32, 32, 32, 32];
+
+/// Disable programming of individual eFuses
+pub(crate) const WR_DIS: EfuseField = EfuseField::new(0, 0, 0, 32);
+/// Disable reading from BlOCK4-10
+pub(crate) const RD_DIS: EfuseField = EfuseField::new(0, 1, 32, 7);
+/// Set this bit to disable boot from RTC RAM
+pub(crate) const DIS_RTC_RAM_BOOT: EfuseField = EfuseField::new(0, 1, 39, 1);
+/// Set this bit to disable Icache
+pub(crate) const DIS_ICACHE: EfuseField = EfuseField::new(0, 1, 40, 1);
+/// Set this bit to disable Dcache
+pub(crate) const DIS_DCACHE: EfuseField = EfuseField::new(0, 1, 41, 1);
+/// Set this bit to disable Icache in download mode (boot_mode[3:0] is 0; 1; 2;
+/// 3; 6; 7)
+pub(crate) const DIS_DOWNLOAD_ICACHE: EfuseField = EfuseField::new(0, 1, 42, 1);
+/// Set this bit to disable Dcache in download mode ( boot_mode[3:0] is 0; 1; 2;
+/// 3; 6; 7)
+pub(crate) const DIS_DOWNLOAD_DCACHE: EfuseField = EfuseField::new(0, 1, 43, 1);
+/// Set this bit to disable the function that forces chip into download mode
+pub(crate) const DIS_FORCE_DOWNLOAD: EfuseField = EfuseField::new(0, 1, 44, 1);
+/// Set this bit to disable USB function
+pub(crate) const DIS_USB_OTG: EfuseField = EfuseField::new(0, 1, 45, 1);
+/// Set this bit to disable CAN function
+pub(crate) const DIS_TWAI: EfuseField = EfuseField::new(0, 1, 46, 1);
+/// Disable app cpu
+pub(crate) const DIS_APP_CPU: EfuseField = EfuseField::new(0, 1, 47, 1);
+/// Set these bits to disable JTAG in the soft way (odd number 1 means disable
+/// ). JTAG can be enabled in HMAC module
+pub(crate) const SOFT_DIS_JTAG: EfuseField = EfuseField::new(0, 1, 48, 3);
+/// Set this bit to disable JTAG in the hard way. JTAG is disabled permanently
+pub(crate) const DIS_PAD_JTAG: EfuseField = EfuseField::new(0, 1, 51, 1);
+/// Set this bit to disable flash encryption when in download boot modes
+pub(crate) const DIS_DOWNLOAD_MANUAL_ENCRYPT: EfuseField = EfuseField::new(0, 1, 52, 1);
+/// Controls single-end input threshold vrefh; 1.76 V to 2 V with step of 80 mV;
+/// stored in eFuse
+pub(crate) const USB_DREFH: EfuseField = EfuseField::new(0, 1, 53, 2);
+/// Controls single-end input threshold vrefl; 0.8 V to 1.04 V with step of 80
+/// mV; stored in eFuse
+pub(crate) const USB_DREFL: EfuseField = EfuseField::new(0, 1, 55, 2);
+/// Set this bit to exchange USB D+ and D- pins
+pub(crate) const USB_EXCHG_PINS: EfuseField = EfuseField::new(0, 1, 57, 1);
+/// Set this bit to enable external PHY
+pub(crate) const USB_EXT_PHY_ENABLE: EfuseField = EfuseField::new(0, 1, 58, 1);
+/// Bluetooth GPIO signal output security level control
+pub(crate) const BTLC_GPIO_ENABLE: EfuseField = EfuseField::new(0, 1, 59, 2);
+/// SPI regulator switches current limit mode
+pub(crate) const VDD_SPI_MODECURLIM: EfuseField = EfuseField::new(0, 1, 61, 1);
+/// SPI regulator high voltage reference
+pub(crate) const VDD_SPI_DREFH: EfuseField = EfuseField::new(0, 1, 62, 2);
+/// SPI regulator medium voltage reference
+pub(crate) const VDD_SPI_DREFM: EfuseField = EfuseField::new(0, 2, 64, 2);
+/// SPI regulator low voltage reference
+pub(crate) const VDD_SPI_DREFL: EfuseField = EfuseField::new(0, 2, 66, 2);
+/// SPI regulator power up signal
+pub(crate) const VDD_SPI_XPD: EfuseField = EfuseField::new(0, 2, 68, 1);
+/// If VDD_SPI_FORCE is 1; determines VDD_SPI voltage
+pub(crate) const VDD_SPI_TIEH: EfuseField = EfuseField::new(0, 2, 69, 1);
+/// Set this bit and force to use the configuration of eFuse to configure
+/// VDD_SPI
+pub(crate) const VDD_SPI_FORCE: EfuseField = EfuseField::new(0, 2, 70, 1);
+/// Set SPI regulator to 0 to configure init[1:0]=0
+pub(crate) const VDD_SPI_EN_INIT: EfuseField = EfuseField::new(0, 2, 71, 1);
+/// Set SPI regulator to 1 to enable output current limit
+pub(crate) const VDD_SPI_ENCURLIM: EfuseField = EfuseField::new(0, 2, 72, 1);
+/// Tunes the current limit threshold of SPI regulator when tieh=0; about 800
+/// mA/(8+d)
+pub(crate) const VDD_SPI_DCURLIM: EfuseField = EfuseField::new(0, 2, 73, 3);
+/// Adds resistor from LDO output to ground
+pub(crate) const VDD_SPI_INIT: EfuseField = EfuseField::new(0, 2, 76, 2);
+/// Prevents SPI regulator from overshoot
+pub(crate) const VDD_SPI_DCAP: EfuseField = EfuseField::new(0, 2, 78, 2);
+/// RTC watchdog timeout threshold; in unit of slow clock cycle
+pub(crate) const WDT_DELAY_SEL: EfuseField = EfuseField::new(0, 2, 80, 2);
+/// Enables flash encryption when 1 or 3 bits are set and disabled otherwise
+pub(crate) const SPI_BOOT_CRYPT_CNT: EfuseField = EfuseField::new(0, 2, 82, 3);
+/// Revoke 1st secure boot key
+pub(crate) const SECURE_BOOT_KEY_REVOKE0: EfuseField = EfuseField::new(0, 2, 85, 1);
+/// Revoke 2nd secure boot key
+pub(crate) const SECURE_BOOT_KEY_REVOKE1: EfuseField = EfuseField::new(0, 2, 86, 1);
+/// Revoke 3rd secure boot key
+pub(crate) const SECURE_BOOT_KEY_REVOKE2: EfuseField = EfuseField::new(0, 2, 87, 1);
+/// Purpose of Key0
+pub(crate) const KEY_PURPOSE_0: EfuseField = EfuseField::new(0, 2, 88, 4);
+/// Purpose of Key1
+pub(crate) const KEY_PURPOSE_1: EfuseField = EfuseField::new(0, 2, 92, 4);
+/// Purpose of Key2
+pub(crate) const KEY_PURPOSE_2: EfuseField = EfuseField::new(0, 3, 96, 4);
+/// Purpose of Key3
+pub(crate) const KEY_PURPOSE_3: EfuseField = EfuseField::new(0, 3, 100, 4);
+/// Purpose of Key4
+pub(crate) const KEY_PURPOSE_4: EfuseField = EfuseField::new(0, 3, 104, 4);
+/// Purpose of Key5
+pub(crate) const KEY_PURPOSE_5: EfuseField = EfuseField::new(0, 3, 108, 4);
+/// Reserved (used for four backups method)
+pub(crate) const RPT4_RESERVED0: EfuseField = EfuseField::new(0, 3, 112, 4);
+/// Set this bit to enable secure boot
+pub(crate) const SECURE_BOOT_EN: EfuseField = EfuseField::new(0, 3, 116, 1);
+/// Set this bit to enable revoking aggressive secure boot
+pub(crate) const SECURE_BOOT_AGGRESSIVE_REVOKE: EfuseField = EfuseField::new(0, 3, 117, 1);
+/// Set this bit to disable function of usb switch to jtag in module of usb
+/// device
+pub(crate) const DIS_USB_JTAG: EfuseField = EfuseField::new(0, 3, 118, 1);
+/// Set this bit to disable usb device
+pub(crate) const DIS_USB_SERIAL_JTAG: EfuseField = EfuseField::new(0, 3, 119, 1);
+/// Set this bit to enable selection between usb_to_jtag and pad_to_jtag through
+/// strapping gpio3 when both reg_dis_usb_jtag and reg_dis_pad_jtag are equal to
+/// 0
+pub(crate) const STRAP_JTAG_SEL: EfuseField = EfuseField::new(0, 3, 120, 1);
+/// This bit is used to switch internal PHY and external PHY for USB OTG and USB
+/// Device
+pub(crate) const USB_PHY_SEL: EfuseField = EfuseField::new(0, 3, 121, 1);
+/// Sample delay configuration of power glitch
+pub(crate) const POWER_GLITCH_DSENSE: EfuseField = EfuseField::new(0, 3, 122, 2);
+/// Configures flash waiting time after power-up; in unit of ms. If the value is
+/// less than 15; the waiting time is the configurable value.  Otherwise; the
+/// waiting time is twice the configurable value
+pub(crate) const FLASH_TPUW: EfuseField = EfuseField::new(0, 3, 124, 4);
+/// Set this bit to disable download mode (boot_mode[3:0] = 0; 1; 2; 3; 6; 7)
+pub(crate) const DIS_DOWNLOAD_MODE: EfuseField = EfuseField::new(0, 4, 128, 1);
+/// Disable direct boot mode
+pub(crate) const DIS_DIRECT_BOOT: EfuseField = EfuseField::new(0, 4, 129, 1);
+/// USB printing
+pub(crate) const DIS_USB_SERIAL_JTAG_ROM_PRINT: EfuseField = EfuseField::new(0, 4, 130, 1);
+/// Flash ECC mode in ROM
+pub(crate) const FLASH_ECC_MODE: EfuseField = EfuseField::new(0, 4, 131, 1);
+/// Set this bit to disable UART download mode through USB
+pub(crate) const DIS_USB_SERIAL_JTAG_DOWNLOAD_MODE: EfuseField = EfuseField::new(0, 4, 132, 1);
+/// Set this bit to enable secure UART download mode
+pub(crate) const ENABLE_SECURITY_DOWNLOAD: EfuseField = EfuseField::new(0, 4, 133, 1);
+/// Set the default UART boot message output mode
+pub(crate) const UART_PRINT_CONTROL: EfuseField = EfuseField::new(0, 4, 134, 2);
+/// Set default power supply for GPIO33-GPIO37; set when SPI flash is
+/// initialized
+pub(crate) const PIN_POWER_SELECTION: EfuseField = EfuseField::new(0, 4, 136, 1);
+/// SPI flash type
+pub(crate) const FLASH_TYPE: EfuseField = EfuseField::new(0, 4, 137, 1);
+/// Set Flash page size
+pub(crate) const FLASH_PAGE_SIZE: EfuseField = EfuseField::new(0, 4, 138, 2);
+/// Set 1 to enable ECC for flash boot
+pub(crate) const FLASH_ECC_EN: EfuseField = EfuseField::new(0, 4, 140, 1);
+/// Set this bit to force ROM code to send a resume command during SPI boot
+pub(crate) const FORCE_SEND_RESUME: EfuseField = EfuseField::new(0, 4, 141, 1);
+/// Secure version (used by ESP-IDF anti-rollback feature)
+pub(crate) const SECURE_VERSION: EfuseField = EfuseField::new(0, 4, 142, 16);
+/// Set this bit to enable power glitch function
+pub(crate) const POWERGLITCH_EN: EfuseField = EfuseField::new(0, 4, 158, 1);
+/// Set this bit to disable download through USB-OTG
+pub(crate) const DIS_USB_OTG_DOWNLOAD_MODE: EfuseField = EfuseField::new(0, 4, 159, 1);
+/// Disables check of wafer version major
+pub(crate) const DISABLE_WAFER_VERSION_MAJOR: EfuseField = EfuseField::new(0, 5, 160, 1);
+/// Disables check of blk version major
+pub(crate) const DISABLE_BLK_VERSION_MAJOR: EfuseField = EfuseField::new(0, 5, 161, 1);
+/// reserved
+pub(crate) const RESERVED_0_162: EfuseField = EfuseField::new(0, 5, 162, 22);
+/// MAC address
+pub(crate) const MAC0: EfuseField = EfuseField::new(1, 0, 0, 32);
+/// MAC address
+pub(crate) const MAC1: EfuseField = EfuseField::new(1, 1, 0, 16);
+/// SPI_PAD_configure CLK
+pub(crate) const SPI_PAD_CONFIG_CLK: EfuseField = EfuseField::new(1, 1, 48, 6);
+/// SPI_PAD_configure Q(D1)
+pub(crate) const SPI_PAD_CONFIG_Q: EfuseField = EfuseField::new(1, 1, 54, 6);
+/// SPI_PAD_configure D(D0)
+pub(crate) const SPI_PAD_CONFIG_D: EfuseField = EfuseField::new(1, 1, 60, 6);
+/// SPI_PAD_configure CS
+pub(crate) const SPI_PAD_CONFIG_CS: EfuseField = EfuseField::new(1, 2, 66, 6);
+/// SPI_PAD_configure HD(D3)
+pub(crate) const SPI_PAD_CONFIG_HD: EfuseField = EfuseField::new(1, 2, 72, 6);
+/// SPI_PAD_configure WP(D2)
+pub(crate) const SPI_PAD_CONFIG_WP: EfuseField = EfuseField::new(1, 2, 78, 6);
+/// SPI_PAD_configure DQS
+pub(crate) const SPI_PAD_CONFIG_DQS: EfuseField = EfuseField::new(1, 2, 84, 6);
+/// SPI_PAD_configure D4
+pub(crate) const SPI_PAD_CONFIG_D4: EfuseField = EfuseField::new(1, 2, 90, 6);
+/// SPI_PAD_configure D5
+pub(crate) const SPI_PAD_CONFIG_D5: EfuseField = EfuseField::new(1, 3, 96, 6);
+/// SPI_PAD_configure D6
+pub(crate) const SPI_PAD_CONFIG_D6: EfuseField = EfuseField::new(1, 3, 102, 6);
+/// SPI_PAD_configure D7
+pub(crate) const SPI_PAD_CONFIG_D7: EfuseField = EfuseField::new(1, 3, 108, 6);
+/// WAFER_VERSION_MINOR least significant bits
+pub(crate) const WAFER_VERSION_MINOR_LO: EfuseField = EfuseField::new(1, 3, 114, 3);
+/// Package version
+pub(crate) const PKG_VERSION: EfuseField = EfuseField::new(1, 3, 117, 3);
+/// BLK_VERSION_MINOR
+pub(crate) const BLK_VERSION_MINOR: EfuseField = EfuseField::new(1, 3, 120, 3);
+/// Flash capacity
+pub(crate) const FLASH_CAP: EfuseField = EfuseField::new(1, 3, 123, 3);
+/// Flash temperature
+pub(crate) const FLASH_TEMP: EfuseField = EfuseField::new(1, 3, 126, 2);
+/// Flash vendor
+pub(crate) const FLASH_VENDOR: EfuseField = EfuseField::new(1, 4, 128, 3);
+/// PSRAM capacity
+pub(crate) const PSRAM_CAP: EfuseField = EfuseField::new(1, 4, 131, 2);
+/// PSRAM temperature
+pub(crate) const PSRAM_TEMP: EfuseField = EfuseField::new(1, 4, 133, 2);
+/// PSRAM vendor
+pub(crate) const PSRAM_VENDOR: EfuseField = EfuseField::new(1, 4, 135, 2);
+/// reserved
+pub(crate) const RESERVED_1_137: EfuseField = EfuseField::new(1, 4, 137, 4);
+/// BLOCK1 K_RTC_LDO
+pub(crate) const K_RTC_LDO: EfuseField = EfuseField::new(1, 4, 141, 7);
+/// BLOCK1 K_DIG_LDO
+pub(crate) const K_DIG_LDO: EfuseField = EfuseField::new(1, 4, 148, 7);
+/// BLOCK1 voltage of rtc dbias20
+pub(crate) const V_RTC_DBIAS20: EfuseField = EfuseField::new(1, 4, 155, 8);
+/// BLOCK1 voltage of digital dbias20
+pub(crate) const V_DIG_DBIAS20: EfuseField = EfuseField::new(1, 5, 163, 8);
+/// BLOCK1 digital dbias when hvt
+pub(crate) const DIG_DBIAS_HVT: EfuseField = EfuseField::new(1, 5, 171, 5);
+/// reserved
+pub(crate) const RESERVED_1_176: EfuseField = EfuseField::new(1, 5, 176, 3);
+/// PSRAM capacity bit 3
+pub(crate) const PSRAM_CAP_3: EfuseField = EfuseField::new(1, 5, 179, 1);
+/// reserved
+pub(crate) const RESERVED_1_180: EfuseField = EfuseField::new(1, 5, 180, 3);
+/// WAFER_VERSION_MINOR most significant bit
+pub(crate) const WAFER_VERSION_MINOR_HI: EfuseField = EfuseField::new(1, 5, 183, 1);
+/// WAFER_VERSION_MAJOR
+pub(crate) const WAFER_VERSION_MAJOR: EfuseField = EfuseField::new(1, 5, 184, 2);
+/// ADC2 calibration voltage at atten3
+pub(crate) const ADC2_CAL_VOL_ATTEN3: EfuseField = EfuseField::new(1, 5, 186, 6);
+/// Optional unique 128-bit ID
+pub(crate) const OPTIONAL_UNIQUE_ID: EfuseField = EfuseField::new(2, 0, 0, 128);
+/// BLK_VERSION_MAJOR of BLOCK2
+pub(crate) const BLK_VERSION_MAJOR: EfuseField = EfuseField::new(2, 4, 128, 2);
+/// reserved
+pub(crate) const RESERVED_2_130: EfuseField = EfuseField::new(2, 4, 130, 2);
+/// Temperature calibration data
+pub(crate) const TEMP_CALIB: EfuseField = EfuseField::new(2, 4, 132, 9);
+/// ADC OCode
+pub(crate) const OCODE: EfuseField = EfuseField::new(2, 4, 141, 8);
+/// ADC1 init code at atten0
+pub(crate) const ADC1_INIT_CODE_ATTEN0: EfuseField = EfuseField::new(2, 4, 149, 8);
+/// ADC1 init code at atten1
+pub(crate) const ADC1_INIT_CODE_ATTEN1: EfuseField = EfuseField::new(2, 4, 157, 6);
+/// ADC1 init code at atten2
+pub(crate) const ADC1_INIT_CODE_ATTEN2: EfuseField = EfuseField::new(2, 5, 163, 6);
+/// ADC1 init code at atten3
+pub(crate) const ADC1_INIT_CODE_ATTEN3: EfuseField = EfuseField::new(2, 5, 169, 6);
+/// ADC2 init code at atten0
+pub(crate) const ADC2_INIT_CODE_ATTEN0: EfuseField = EfuseField::new(2, 5, 175, 8);
+/// ADC2 init code at atten1
+pub(crate) const ADC2_INIT_CODE_ATTEN1: EfuseField = EfuseField::new(2, 5, 183, 6);
+/// ADC2 init code at atten2
+pub(crate) const ADC2_INIT_CODE_ATTEN2: EfuseField = EfuseField::new(2, 5, 189, 6);
+/// ADC2 init code at atten3
+pub(crate) const ADC2_INIT_CODE_ATTEN3: EfuseField = EfuseField::new(2, 6, 195, 6);
+/// ADC1 calibration voltage at atten0
+pub(crate) const ADC1_CAL_VOL_ATTEN0: EfuseField = EfuseField::new(2, 6, 201, 8);
+/// ADC1 calibration voltage at atten1
+pub(crate) const ADC1_CAL_VOL_ATTEN1: EfuseField = EfuseField::new(2, 6, 209, 8);
+/// ADC1 calibration voltage at atten2
+pub(crate) const ADC1_CAL_VOL_ATTEN2: EfuseField = EfuseField::new(2, 6, 217, 8);
+/// ADC1 calibration voltage at atten3
+pub(crate) const ADC1_CAL_VOL_ATTEN3: EfuseField = EfuseField::new(2, 7, 225, 8);
+/// ADC2 calibration voltage at atten0
+pub(crate) const ADC2_CAL_VOL_ATTEN0: EfuseField = EfuseField::new(2, 7, 233, 8);
+/// ADC2 calibration voltage at atten1
+pub(crate) const ADC2_CAL_VOL_ATTEN1: EfuseField = EfuseField::new(2, 7, 241, 7);
+/// ADC2 calibration voltage at atten2
+pub(crate) const ADC2_CAL_VOL_ATTEN2: EfuseField = EfuseField::new(2, 7, 248, 7);
+/// reserved
+pub(crate) const RESERVED_2_255: EfuseField = EfuseField::new(2, 7, 255, 1);
+/// User data
+pub(crate) const BLOCK_USR_DATA: EfuseField = EfuseField::new(3, 0, 0, 192);
+/// reserved
+pub(crate) const RESERVED_3_192: EfuseField = EfuseField::new(3, 6, 192, 8);
+/// Custom MAC
+pub(crate) const CUSTOM_MAC: EfuseField = EfuseField::new(3, 6, 200, 48);
+/// reserved
+pub(crate) const RESERVED_3_248: EfuseField = EfuseField::new(3, 7, 248, 8);
+/// Key0 or user data
+pub(crate) const BLOCK_KEY0: EfuseField = EfuseField::new(4, 0, 0, 256);
+/// Key1 or user data
+pub(crate) const BLOCK_KEY1: EfuseField = EfuseField::new(5, 0, 0, 256);
+/// Key2 or user data
+pub(crate) const BLOCK_KEY2: EfuseField = EfuseField::new(6, 0, 0, 256);
+/// Key3 or user data
+pub(crate) const BLOCK_KEY3: EfuseField = EfuseField::new(7, 0, 0, 256);
+/// Key4 or user data
+pub(crate) const BLOCK_KEY4: EfuseField = EfuseField::new(8, 0, 0, 256);
+/// Key5 or user data
+pub(crate) const BLOCK_KEY5: EfuseField = EfuseField::new(9, 0, 0, 256);
+/// System data part 2 (reserved)
+pub(crate) const BLOCK_SYS_DATA2: EfuseField = EfuseField::new(10, 0, 0, 256);

--- a/espflash/src/targets/efuse/mod.rs
+++ b/espflash/src/targets/efuse/mod.rs
@@ -1,0 +1,27 @@
+pub(crate) mod esp32;
+pub(crate) mod esp32c2;
+pub(crate) mod esp32c3;
+pub(crate) mod esp32c6;
+pub(crate) mod esp32h2;
+pub(crate) mod esp32p4;
+pub(crate) mod esp32s2;
+pub(crate) mod esp32s3;
+
+#[derive(Debug, Clone, serde::Deserialize)]
+pub struct EfuseField {
+    pub(crate) block: u32,
+    pub(crate) word: u32,
+    pub(crate) bit_start: u32,
+    pub(crate) bit_count: u32,
+}
+
+impl EfuseField {
+    const fn new(block: u32, word: u32, bit_start: u32, bit_count: u32) -> Self {
+        Self {
+            block,
+            word,
+            bit_start,
+            bit_count,
+        }
+    }
+}

--- a/espflash/src/targets/efuse/mod.rs
+++ b/espflash/src/targets/efuse/mod.rs
@@ -7,6 +7,7 @@ pub(crate) mod esp32p4;
 pub(crate) mod esp32s2;
 pub(crate) mod esp32s3;
 
+#[allow(unused)]
 #[derive(Debug, Clone, serde::Deserialize)]
 pub struct EfuseField {
     pub(crate) block: u32,

--- a/espflash/src/targets/efuse/mod.rs
+++ b/espflash/src/targets/efuse/mod.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::empty_docs)]
+
 pub(crate) mod esp32;
 pub(crate) mod esp32c2;
 pub(crate) mod esp32c3;

--- a/espflash/src/targets/esp32.rs
+++ b/espflash/src/targets/esp32.rs
@@ -1,13 +1,21 @@
 use std::ops::Range;
 
+use super::{
+    Chip,
+    Esp32Params,
+    ReadEFuse,
+    SpiRegisters,
+    Target,
+    XtalFrequency,
+    efuse::esp32 as efuse,
+};
+#[cfg(feature = "serialport")]
+use crate::connection::Connection;
 use crate::{
     Error,
     flasher::{FlashData, FlashFrequency},
     image_format::IdfBootloaderFormat,
-    targets::{Chip, Esp32Params, ReadEFuse, SpiRegisters, Target, XtalFrequency},
 };
-#[cfg(feature = "serialport")]
-use crate::{connection::Connection, targets::bytes_to_mac_addr};
 
 pub(crate) const CHIP_ID: u16 = 0;
 
@@ -18,9 +26,8 @@ const FLASH_RANGES: &[Range<u32>] = &[
     0x3f40_0000..0x3f80_0000, // DROM
 ];
 
-// UART0_BASE_REG + 0x14
 #[cfg(feature = "serialport")]
-const UART_CLKDIV_REG: u32 = 0x3ff4_0014;
+const UART_CLKDIV_REG: u32 = 0x3ff4_0014; // UART0_BASE_REG + 0x14
 #[cfg(feature = "serialport")]
 const UART_CLKDIV_MASK: u32 = 0xfffff;
 #[cfg(feature = "serialport")]
@@ -35,10 +42,10 @@ impl Esp32 {
         CHIP_DETECT_MAGIC_VALUES.contains(&value)
     }
 
-    #[cfg(feature = "serialport")]
     /// Return the package version based on the eFuses
+    #[cfg(feature = "serialport")]
     fn package_version(&self, connection: &mut Connection) -> Result<u32, Error> {
-        let word3 = self.read_efuse(connection, 3)?;
+        let word3 = self.read_efuse_raw(connection, 0, 3)?;
 
         let pkg_version = (word3 >> 9) & 0x7;
         let pkg_version = pkg_version + (((word3 >> 2) & 0x1) << 3);
@@ -49,20 +56,32 @@ impl Esp32 {
 
 impl ReadEFuse for Esp32 {
     fn efuse_reg(&self) -> u32 {
-        0x3ff5_a000
+        0x3FF5_A000
+    }
+
+    fn block0_offset(&self) -> u32 {
+        0x0
+    }
+
+    fn block_size(&self, block: usize) -> u32 {
+        efuse::BLOCK_SIZES[block]
     }
 }
 
 impl Target for Esp32 {
+    fn chip(&self) -> Chip {
+        Chip::Esp32
+    }
+
     fn addr_is_flash(&self, addr: u32) -> bool {
         FLASH_RANGES.iter().any(|range| range.contains(&addr))
     }
 
     #[cfg(feature = "serialport")]
     fn chip_features(&self, connection: &mut Connection) -> Result<Vec<&str>, Error> {
-        let word3 = self.read_efuse(connection, 3)?;
-        let word4 = self.read_efuse(connection, 4)?;
-        let word6 = self.read_efuse(connection, 6)?;
+        let word3 = self.read_efuse_raw(connection, 0, 3)?;
+        let word4 = self.read_efuse_raw(connection, 0, 4)?;
+        let word6 = self.read_efuse_raw(connection, 0, 6)?;
 
         let mut features = vec!["WiFi"];
 
@@ -121,8 +140,11 @@ impl Target for Esp32 {
     fn major_chip_version(&self, connection: &mut Connection) -> Result<u32, Error> {
         let apb_ctl_date = connection.read_reg(0x3FF6_607C)?;
 
-        let rev_bit0 = (self.read_efuse(connection, 3)? >> 15) & 0x1;
-        let rev_bit1 = (self.read_efuse(connection, 5)? >> 20) & 0x1;
+        let word3 = self.read_efuse_raw(connection, 0, 3)?;
+        let word5 = self.read_efuse_raw(connection, 0, 5)?;
+
+        let rev_bit0 = (word3 >> 15) & 0x1;
+        let rev_bit1 = (word5 >> 20) & 0x1;
         let rev_bit2 = (apb_ctl_date >> 31) & 0x1;
 
         let combine_value = (rev_bit2 << 2) | (rev_bit1 << 1) | rev_bit0;
@@ -137,7 +159,10 @@ impl Target for Esp32 {
 
     #[cfg(feature = "serialport")]
     fn minor_chip_version(&self, connection: &mut Connection) -> Result<u32, Error> {
-        Ok((self.read_efuse(connection, 5)? >> 24) & 0x3)
+        let word5 = self.read_efuse_raw(connection, 0, 5)?;
+        let minor = (word5 >> 24) & 0x3;
+
+        Ok(minor)
     }
 
     #[cfg(feature = "serialport")]
@@ -186,18 +211,6 @@ impl Target for Esp32 {
         );
 
         IdfBootloaderFormat::new(elf_data, Chip::Esp32, flash_data, params)
-    }
-
-    #[cfg(feature = "serialport")]
-    fn mac_address(&self, connection: &mut Connection) -> Result<String, Error> {
-        let word1 = self.read_efuse(connection, 1)?;
-        let word2 = self.read_efuse(connection, 2)?;
-
-        let words = ((word2 as u64) << 32) | word1 as u64;
-        let bytes = words.to_be_bytes();
-        let bytes = &bytes[2..8];
-
-        Ok(bytes_to_mac_addr(bytes))
     }
 
     fn spi_registers(&self) -> SpiRegisters {

--- a/espflash/src/targets/esp32c3.rs
+++ b/espflash/src/targets/esp32c3.rs
@@ -1,12 +1,20 @@
 use std::ops::Range;
 
+use super::{
+    Chip,
+    Esp32Params,
+    ReadEFuse,
+    SpiRegisters,
+    Target,
+    XtalFrequency,
+    efuse::esp32c3 as efuse,
+};
 #[cfg(feature = "serialport")]
 use crate::connection::Connection;
 use crate::{
     Error,
     flasher::{FlashData, FlashFrequency},
     image_format::IdfBootloaderFormat,
-    targets::{Chip, Esp32Params, ReadEFuse, SpiRegisters, Target, XtalFrequency},
 };
 
 pub(crate) const CHIP_ID: u16 = 5;
@@ -47,9 +55,21 @@ impl ReadEFuse for Esp32c3 {
     fn efuse_reg(&self) -> u32 {
         0x6000_8800
     }
+
+    fn block0_offset(&self) -> u32 {
+        0x2D
+    }
+
+    fn block_size(&self, block: usize) -> u32 {
+        efuse::BLOCK_SIZES[block]
+    }
 }
 
 impl Target for Esp32c3 {
+    fn chip(&self) -> Chip {
+        Chip::Esp32c3
+    }
+
     fn addr_is_flash(&self, addr: u32) -> bool {
         FLASH_RANGES.iter().any(|range| range.contains(&addr))
     }
@@ -61,13 +81,13 @@ impl Target for Esp32c3 {
 
     #[cfg(feature = "serialport")]
     fn major_chip_version(&self, connection: &mut Connection) -> Result<u32, Error> {
-        Ok((self.read_efuse(connection, 22)? >> 24) & 0x3)
+        self.read_efuse(connection, efuse::WAFER_VERSION_MAJOR)
     }
 
     #[cfg(feature = "serialport")]
     fn minor_chip_version(&self, connection: &mut Connection) -> Result<u32, Error> {
-        let hi = (self.read_efuse(connection, 22)? >> 23) & 0x1;
-        let lo = (self.read_efuse(connection, 20)? >> 18) & 0x7;
+        let hi = self.read_efuse(connection, efuse::WAFER_VERSION_MINOR_HI)?;
+        let lo = self.read_efuse(connection, efuse::WAFER_VERSION_MINOR_LO)?;
 
         Ok((hi << 3) + lo)
     }

--- a/espflash/src/targets/esp32c6.rs
+++ b/espflash/src/targets/esp32c6.rs
@@ -1,12 +1,20 @@
 use std::ops::Range;
 
+use super::{
+    Chip,
+    Esp32Params,
+    ReadEFuse,
+    SpiRegisters,
+    Target,
+    XtalFrequency,
+    efuse::esp32c6 as efuse,
+};
 #[cfg(feature = "serialport")]
 use crate::connection::Connection;
 use crate::{
     Error,
     flasher::{FlashData, FlashFrequency},
     image_format::IdfBootloaderFormat,
-    targets::{Chip, Esp32Params, ReadEFuse, SpiRegisters, Target, XtalFrequency},
 };
 
 pub(crate) const CHIP_ID: u16 = 13;
@@ -42,9 +50,21 @@ impl ReadEFuse for Esp32c6 {
     fn efuse_reg(&self) -> u32 {
         0x600B_0800
     }
+
+    fn block0_offset(&self) -> u32 {
+        0x2C
+    }
+
+    fn block_size(&self, block: usize) -> u32 {
+        efuse::BLOCK_SIZES[block]
+    }
 }
 
 impl Target for Esp32c6 {
+    fn chip(&self) -> Chip {
+        Chip::Esp32c6
+    }
+
     fn addr_is_flash(&self, addr: u32) -> bool {
         FLASH_RANGES.iter().any(|range| range.contains(&addr))
     }
@@ -56,15 +76,12 @@ impl Target for Esp32c6 {
 
     #[cfg(feature = "serialport")]
     fn major_chip_version(&self, connection: &mut Connection) -> Result<u32, Error> {
-        Ok((self.read_efuse(connection, 22)? >> 24) & 0x3)
+        self.read_efuse(connection, efuse::WAFER_VERSION_MAJOR)
     }
 
     #[cfg(feature = "serialport")]
     fn minor_chip_version(&self, connection: &mut Connection) -> Result<u32, Error> {
-        let hi = (self.read_efuse(connection, 22)? >> 23) & 0x1;
-        let lo = (self.read_efuse(connection, 20)? >> 18) & 0x7;
-
-        Ok((hi << 3) + lo)
+        self.read_efuse(connection, efuse::WAFER_VERSION_MINOR)
     }
 
     #[cfg(feature = "serialport")]

--- a/espflash/src/targets/esp32s2.rs
+++ b/espflash/src/targets/esp32s2.rs
@@ -2,11 +2,19 @@ use std::ops::Range;
 
 #[cfg(feature = "serialport")]
 use super::flash_target::MAX_RAM_BLOCK_SIZE;
+use super::{
+    Chip,
+    Esp32Params,
+    ReadEFuse,
+    SpiRegisters,
+    Target,
+    XtalFrequency,
+    efuse::esp32s2 as efuse,
+};
 use crate::{
     Error,
     flasher::{FlashData, FlashFrequency},
     image_format::IdfBootloaderFormat,
-    targets::{Chip, Esp32Params, ReadEFuse, SpiRegisters, Target, XtalFrequency},
 };
 #[cfg(feature = "serialport")]
 use crate::{connection::Connection, flasher::FLASH_WRITE_SIZE};
@@ -40,28 +48,20 @@ impl Esp32s2 {
     /// Return the block2 version based on eFuses
     #[cfg(feature = "serialport")]
     fn block2_version(&self, connection: &mut Connection) -> Result<u32, Error> {
-        let blk2_word4 = self.read_efuse(connection, 27)?;
-        let block2_version = (blk2_word4 >> 4) & 0x7;
-
-        Ok(block2_version)
+        // NOTE: Perplexingly, this does not seem to work correctly?
+        self.read_efuse(connection, efuse::BLK_VERSION_MINOR)
     }
 
     /// Return the flash version based on eFuses
     #[cfg(feature = "serialport")]
     fn flash_version(&self, connection: &mut Connection) -> Result<u32, Error> {
-        let blk1_word3 = self.read_efuse(connection, 20)?;
-        let flash_version = (blk1_word3 >> 21) & 0xf;
-
-        Ok(flash_version)
+        self.read_efuse(connection, efuse::FLASH_VERSION)
     }
 
     /// Return the PSRAM version based on eFuses
     #[cfg(feature = "serialport")]
     fn psram_version(&self, connection: &mut Connection) -> Result<u32, Error> {
-        let blk1_word3 = self.read_efuse(connection, 20)?;
-        let psram_version = (blk1_word3 >> 28) & 0xf;
-
-        Ok(psram_version)
+        self.read_efuse(connection, efuse::PSRAM_VERSION)
     }
 
     /// Check if the magic value contains the specified value
@@ -72,11 +72,23 @@ impl Esp32s2 {
 
 impl ReadEFuse for Esp32s2 {
     fn efuse_reg(&self) -> u32 {
-        0x3f41_a000
+        0x3F41_A000
+    }
+
+    fn block0_offset(&self) -> u32 {
+        0x2C
+    }
+
+    fn block_size(&self, block: usize) -> u32 {
+        efuse::BLOCK_SIZES[block]
     }
 }
 
 impl Target for Esp32s2 {
+    fn chip(&self) -> Chip {
+        Chip::Esp32s2
+    }
+
     fn addr_is_flash(&self, addr: u32) -> bool {
         FLASH_RANGES.iter().any(|range| range.contains(&addr))
     }
@@ -114,13 +126,13 @@ impl Target for Esp32s2 {
 
     #[cfg(feature = "serialport")]
     fn major_chip_version(&self, connection: &mut Connection) -> Result<u32, Error> {
-        Ok((self.read_efuse(connection, 20)? >> 18) & 0x3)
+        self.read_efuse(connection, efuse::WAFER_VERSION_MAJOR)
     }
 
     #[cfg(feature = "serialport")]
     fn minor_chip_version(&self, connection: &mut Connection) -> Result<u32, Error> {
-        let hi = (self.read_efuse(connection, 20)? >> 20) & 0x1;
-        let lo = (self.read_efuse(connection, 21)? >> 4) & 0x7;
+        let hi = self.read_efuse(connection, efuse::WAFER_VERSION_MINOR_HI)?;
+        let lo = self.read_efuse(connection, efuse::WAFER_VERSION_MINOR_LO)?;
 
         Ok((hi << 3) + lo)
     }

--- a/espflash/src/targets/mod.rs
+++ b/espflash/src/targets/mod.rs
@@ -11,23 +11,27 @@ use strum::{Display, EnumIter, EnumString, VariantNames};
 
 #[cfg(feature = "serialport")]
 pub use self::flash_target::{Esp32Target, RamTarget};
-#[cfg(feature = "serialport")]
+use self::{
+    esp32::Esp32,
+    esp32c2::Esp32c2,
+    esp32c3::Esp32c3,
+    esp32c6::Esp32c6,
+    esp32h2::Esp32h2,
+    esp32p4::Esp32p4,
+    esp32s2::Esp32s2,
+    esp32s3::Esp32s3,
+};
 use crate::{
     Error,
-    connection::Connection,
-    flasher::{FLASH_WRITE_SIZE, SpiAttachParams},
     flasher::{FlashData, FlashFrequency},
     image_format::IdfBootloaderFormat,
+};
+#[cfg(feature = "serialport")]
+use crate::{
+    connection::Connection,
+    flasher::{FLASH_WRITE_SIZE, SpiAttachParams},
     targets::{
         efuse::EfuseField,
-        esp32::Esp32,
-        esp32c2::Esp32c2,
-        esp32c3::Esp32c3,
-        esp32c6::Esp32c6,
-        esp32h2::Esp32h2,
-        esp32p4::Esp32p4,
-        esp32s2::Esp32s2,
-        esp32s3::Esp32s3,
         flash_target::{FlashTarget, MAX_RAM_BLOCK_SIZE},
     },
 };

--- a/espflash/src/targets/mod.rs
+++ b/espflash/src/targets/mod.rs
@@ -11,11 +11,15 @@ use strum::{Display, EnumIter, EnumString, VariantNames};
 
 #[cfg(feature = "serialport")]
 pub use self::flash_target::{Esp32Target, RamTarget};
+#[cfg(feature = "serialport")]
 use crate::{
     Error,
+    connection::Connection,
+    flasher::{FLASH_WRITE_SIZE, SpiAttachParams},
     flasher::{FlashData, FlashFrequency},
     image_format::IdfBootloaderFormat,
     targets::{
+        efuse::EfuseField,
         esp32::Esp32,
         esp32c2::Esp32c2,
         esp32c3::Esp32c3,
@@ -24,13 +28,8 @@ use crate::{
         esp32p4::Esp32p4,
         esp32s2::Esp32s2,
         esp32s3::Esp32s3,
+        flash_target::{FlashTarget, MAX_RAM_BLOCK_SIZE},
     },
-};
-#[cfg(feature = "serialport")]
-use crate::{
-    connection::Connection,
-    flasher::{FLASH_WRITE_SIZE, SpiAttachParams},
-    targets::flash_target::{FlashTarget, MAX_RAM_BLOCK_SIZE},
 };
 
 mod efuse;
@@ -305,16 +304,44 @@ pub trait ReadEFuse {
     /// Returns the base address of the eFuse register
     fn efuse_reg(&self) -> u32;
 
+    /// Returns the offset of BLOCK0 relative to the eFuse base register address
+    fn block0_offset(&self) -> u32;
+
+    /// Returns the size of the specified block for the implementing target
+    /// device
+    fn block_size(&self, block: usize) -> u32;
+
+    /// Given an active connection, read the specified field of the eFuse region
     #[cfg(feature = "serialport")]
-    /// Given an active connection, read the nth word of the eFuse region
-    fn read_efuse(&self, connection: &mut Connection, n: u32) -> Result<u32, Error> {
-        let reg = self.efuse_reg() + (n * 0x4);
-        connection.read_reg(reg)
+    fn read_efuse(&self, connection: &mut Connection, field: EfuseField) -> Result<u32, Error> {
+        let block0_addr = self.efuse_reg() + self.block0_offset();
+        let block_offset = if field.block == 0 {
+            0
+        } else {
+            self.block_size(field.block as usize - 1)
+        };
+
+        let addr = block0_addr + block_offset + (field.word * 0x4);
+        let mask = if field.bit_count == 32 {
+            u32::MAX
+        } else {
+            (1u32 << field.bit_count) - 1
+        };
+
+        let shift = field.bit_start % 32;
+
+        let value = connection.read_reg(addr)?;
+        let value = (value >> shift) & mask;
+
+        Ok(value)
     }
 }
 
 /// Operations for interacting with supported target devices
 pub trait Target: ReadEFuse {
+    /// The associated [Chip] for the implementing target
+    fn chip(&self) -> Chip;
+
     /// Is the provided address `addr` in flash?
     fn addr_is_flash(&self, addr: u32) -> bool;
 
@@ -368,14 +395,31 @@ pub trait Target: ReadEFuse {
     #[cfg(feature = "serialport")]
     /// What is the MAC address?
     fn mac_address(&self, connection: &mut Connection) -> Result<String, Error> {
-        let word5 = self.read_efuse(connection, 17)?;
-        let word6 = self.read_efuse(connection, 18)?;
+        let (mac0_field, mac1_field) = match self.chip() {
+            Chip::Esp32 => (self::efuse::esp32::MAC0, self::efuse::esp32::MAC1),
+            Chip::Esp32c2 => (self::efuse::esp32c2::MAC0, self::efuse::esp32c2::MAC1),
+            Chip::Esp32c3 => (self::efuse::esp32c3::MAC0, self::efuse::esp32c3::MAC1),
+            Chip::Esp32c6 => (self::efuse::esp32c6::MAC0, self::efuse::esp32c6::MAC1),
+            Chip::Esp32h2 => (self::efuse::esp32h2::MAC0, self::efuse::esp32h2::MAC1),
+            Chip::Esp32p4 => (self::efuse::esp32p4::MAC0, self::efuse::esp32p4::MAC1),
+            Chip::Esp32s2 => (self::efuse::esp32s2::MAC0, self::efuse::esp32s2::MAC1),
+            Chip::Esp32s3 => (self::efuse::esp32s3::MAC0, self::efuse::esp32s3::MAC1),
+        };
 
-        let bytes = ((word6 as u64) << 32) | word5 as u64;
+        let mac0 = self.read_efuse(connection, mac0_field)?;
+        let mac1 = self.read_efuse(connection, mac1_field)?;
+
+        let bytes = ((mac1 as u64) << 32) | mac0 as u64;
         let bytes = bytes.to_be_bytes();
         let bytes = &bytes[2..];
 
-        Ok(bytes_to_mac_addr(bytes))
+        let mac_addr = bytes
+            .iter()
+            .map(|b| format!("{:02x}", b))
+            .collect::<Vec<_>>()
+            .join(":");
+
+        Ok(mac_addr)
     }
 
     #[cfg(feature = "serialport")]
@@ -449,13 +493,4 @@ pub(crate) trait UsbOtg {
             .read_reg(self.uartdev_buf_no())
             .map(|value| value == self.uartdev_buf_no_usb_otg())
     }
-}
-
-#[cfg(feature = "serialport")]
-fn bytes_to_mac_addr(bytes: &[u8]) -> String {
-    bytes
-        .iter()
-        .map(|b| format!("{:02x}", b))
-        .collect::<Vec<_>>()
-        .join(":")
 }

--- a/espflash/src/targets/mod.rs
+++ b/espflash/src/targets/mod.rs
@@ -33,6 +33,7 @@ use crate::{
     targets::flash_target::{FlashTarget, MAX_RAM_BLOCK_SIZE},
 };
 
+mod efuse;
 mod esp32;
 mod esp32c2;
 mod esp32c3;

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -5,6 +5,9 @@ edition = "2024"
 publish = false
 
 [dependencies]
+chrono     = "0.4.40"
 clap       = { version = "4.5.36", features = ["derive"] }
 env_logger = "0.11.8"
 log        = "0.4.27"
+serde      = { version = "1.0.217", features = ["derive"] }
+serde_yaml = "0.9.34"

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name    = "xtask"
+version = "0.0.0"
+edition = "2024"
+publish = false
+
+[dependencies]
+clap       = { version = "4.5.36", features = ["derive"] }
+env_logger = "0.11.8"
+log        = "0.4.27"

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -1,14 +1,276 @@
-use clap::Parser;
+use std::{
+    cmp::Ordering,
+    collections::{BTreeMap, HashMap},
+    ffi::OsStr,
+    fs::{self, OpenOptions},
+    io::{BufWriter, Write},
+    path::{Path, PathBuf},
+    process::Command,
+};
+
+use clap::{Args, Parser};
 
 type Result<T> = std::result::Result<T, Box<dyn std::error::Error>>;
 
+// ----------------------------------------------------------------------------
+// Command-line Interface
+
 #[derive(Debug, Parser)]
-enum Cli {}
+enum Cli {
+    /// Generate eFuse field definitions
+    GenerateEfuseFields(GenerateEfuseFieldsArgs),
+}
+
+#[derive(Debug, Args)]
+struct GenerateEfuseFieldsArgs {
+    /// Local path to the `esptool` repository
+    esptool_path: PathBuf,
+}
+
+// ----------------------------------------------------------------------------
+// Application
 
 fn main() -> Result<()> {
     env_logger::Builder::new()
         .filter_module("xtask", log::LevelFilter::Info)
         .init();
+
+    // The directory containing the cargo manifest for the 'xtask' package is a
+    // subdirectory within the cargo workspace:
+    let workspace = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let workspace = workspace.parent().unwrap().canonicalize()?;
+
+    match Cli::parse() {
+        Cli::GenerateEfuseFields(args) => generate_efuse_fields(&workspace, args),
+    }
+}
+
+// ----------------------------------------------------------------------------
+// Generate eFuse Fields
+
+const HEADER: &str = r#"
+//! This file was automatically generated, please do not edit it manually!
+//! 
+//! Generated: $DATE
+//! Version:   $VERSION
+
+#![allow(unused)]
+
+use super::EfuseField;
+
+"#;
+
+type EfuseFields = HashMap<String, EfuseYaml>;
+
+#[derive(Debug, serde::Deserialize)]
+struct EfuseYaml {
+    #[serde(rename = "VER_NO")]
+    version: String,
+    #[serde(rename = "EFUSES")]
+    fields: HashMap<String, EfuseAttrs>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, serde::Deserialize)]
+struct EfuseAttrs {
+    #[serde(rename = "blk")]
+    block: u32,
+    word: u32,
+    len: u32,
+    start: u32,
+    #[serde(rename = "desc")]
+    description: String,
+}
+
+impl PartialOrd for EfuseAttrs {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        match self.block.partial_cmp(&other.block) {
+            Some(Ordering::Equal) => {}
+            ord => return ord,
+        }
+
+        match self.word.partial_cmp(&other.word) {
+            Some(Ordering::Equal) => {}
+            ord => return ord,
+        }
+
+        self.start.partial_cmp(&other.start)
+    }
+}
+
+impl Ord for EfuseAttrs {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.partial_cmp(other).unwrap()
+    }
+}
+
+fn generate_efuse_fields(workspace: &Path, args: GenerateEfuseFieldsArgs) -> Result<()> {
+    let efuse_yaml_path = args
+        .esptool_path
+        .join("espefuse")
+        .join("efuse_defs")
+        .canonicalize()?;
+
+    let espflash_path = workspace.join("espflash").canonicalize()?;
+
+    let mut efuse_fields = parse_efuse_fields(&efuse_yaml_path)?;
+    process_efuse_definitions(&mut efuse_fields)?;
+    generate_efuse_definitions(&espflash_path, efuse_fields)?;
+
+    Command::new("cargo")
+        .args(&["+nightly", "fmt"])
+        .current_dir(workspace)
+        .output()?;
+
+    Ok(())
+}
+
+fn parse_efuse_fields(efuse_yaml_path: &Path) -> Result<EfuseFields> {
+    // TODO: We can probably handle this better, e.g. by defining a `Chip` enum
+    //       which can be iterated over, but for now this is good enough.
+    const CHIPS: &[&str] = &[
+        "esp32", "esp32c2", "esp32c3", "esp32c6", "esp32h2", "esp32p4", "esp32s2", "esp32s3",
+    ];
+
+    let mut efuse_fields = EfuseFields::new();
+
+    for result in fs::read_dir(efuse_yaml_path)? {
+        let path = result?.path();
+        if !path
+            .extension()
+            .is_some_and(|ext| ext == OsStr::new("yaml"))
+        {
+            continue;
+        }
+
+        let chip = path.file_stem().unwrap().to_string_lossy().to_string();
+        if !CHIPS.contains(&chip.as_str()) {
+            continue;
+        }
+
+        let efuse_yaml = fs::read_to_string(&path)?;
+        let efuse_yaml: EfuseYaml = serde_yaml::from_str(&efuse_yaml)?;
+
+        efuse_fields.insert(chip.to_string(), efuse_yaml);
+    }
+
+    Ok(efuse_fields)
+}
+
+fn process_efuse_definitions(efuse_fields: &mut EfuseFields) -> Result<()> {
+    // This is all a special case for the MAC field, which is larger than a single
+    // word (i.e. 32-bits) in size. To handle this, we just split it up into two
+    // separate fields, and update the fields' attributes accordingly.
+
+    for (_chip, yaml) in efuse_fields {
+        let mac_attrs = yaml.fields.get("MAC").unwrap();
+
+        let mut mac0_attrs = mac_attrs.clone();
+        mac0_attrs.start = 0;
+        mac0_attrs.len = 32;
+
+        let mut mac1_attrs = mac_attrs.clone();
+        mac1_attrs.word += 1;
+        mac1_attrs.len = 16;
+
+        yaml.fields.remove("MAC").unwrap();
+        yaml.fields.insert("MAC0".into(), mac0_attrs);
+        yaml.fields.insert("MAC1".into(), mac1_attrs);
+    }
+
+    Ok(())
+}
+
+fn generate_efuse_definitions(espflash_path: &Path, efuse_fields: EfuseFields) -> Result<()> {
+    let targets_efuse_path = espflash_path
+        .join("src")
+        .join("targets")
+        .join("efuse")
+        .canonicalize()?;
+
+    for (chip, yaml) in efuse_fields {
+        let f = OpenOptions::new()
+            .create(true)
+            .write(true)
+            .truncate(true)
+            .open(targets_efuse_path.join(format!("{chip}.rs")))?;
+
+        let mut writer = BufWriter::new(f);
+
+        write!(
+            writer,
+            "{}",
+            HEADER
+                .replace(
+                    "$DATE",
+                    &chrono::Utc::now().format("%Y-%m-%d %H:%M").to_string()
+                )
+                .replace("$VERSION", &yaml.version)
+                .trim_start()
+        )?;
+
+        generate_efuse_block_sizes(&mut writer, &yaml.fields)?;
+        generate_efuse_constants(&mut writer, &yaml.fields)?;
+    }
+
+    Ok(())
+}
+
+fn generate_efuse_block_sizes(
+    writer: &mut dyn Write,
+    fields: &HashMap<String, EfuseAttrs>,
+) -> Result<()> {
+    let mut field_attrs = fields.values().collect::<Vec<_>>();
+    field_attrs.sort();
+
+    let block_sizes = field_attrs
+        .chunk_by(|a, b| a.block == b.block)
+        .enumerate()
+        .map(|(block, attrs)| {
+            let last = attrs.last().unwrap();
+            let size_bits = last.start + last.len;
+            assert!(size_bits % 8 == 0);
+
+            (block, size_bits / 8)
+        })
+        .collect::<BTreeMap<_, _>>();
+
+    writeln!(writer, "/// Total size in bytes of each block")?;
+    writeln!(
+        writer,
+        "pub(crate) const BLOCK_SIZES: &[u32] = &[{}];\n",
+        block_sizes
+            .values()
+            .map(|v| v.to_string())
+            .collect::<Vec<_>>()
+            .join(", ")
+    )?;
+
+    Ok(())
+}
+
+fn generate_efuse_constants(
+    writer: &mut dyn Write,
+    fields: &HashMap<String, EfuseAttrs>,
+) -> Result<()> {
+    let mut sorted = fields.iter().collect::<Vec<_>>();
+    sorted.sort_by(|a, b| (a.1).cmp(b.1));
+
+    for (name, attrs) in sorted {
+        let EfuseAttrs {
+            block,
+            word,
+            len,
+            start,
+            description,
+        } = attrs;
+
+        writeln!(writer, "/// {description}")?;
+        writeln!(
+            writer,
+            "pub(crate) const {}: EfuseField = EfuseField::new({}, {}, {}, {});",
+            name, block, word, start, len
+        )?;
+    }
 
     Ok(())
 }

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -1,0 +1,14 @@
+use clap::Parser;
+
+type Result<T> = std::result::Result<T, Box<dyn std::error::Error>>;
+
+#[derive(Debug, Parser)]
+enum Cli {}
+
+fn main() -> Result<()> {
+    env_logger::Builder::new()
+        .filter_module("xtask", log::LevelFilter::Info)
+        .init();
+
+    Ok(())
+}


### PR DESCRIPTION
This turned out to be a large, so apologies for that. Plenty of the code can be disregarded in review though (i.e. the generated eFuse constants).

This PR introduces a new `xtask` package to the workspace. While I've been resisting adding this for some time, it's now become a bit of a necessity. This is used to generate the eFuse field definitions from the YAML files defined in the `esptool` repository.

Additionally, all code relating to reading of eFuse values has been completely rewritten. There are a few hacky bits here and there, mostly relating to the ESP32, but overall I think things are in much better shape. Perhaps we can iterate on this further and improve those areas, however for the time being I'm not too worried about it.

I have tested on all supported devices to confirm that things are working as expected; as far as I can tell, we're in good shape. There is one caveat, on the ESP32-S2 for whatever reason we are not reading the correct BLOCK2 version number; this does not really make sense to me, and honestly I'm getting kind of tired of thinking about eFuses at this point, so happy to just open an issue for this and worry about it later.

Closes #827