### PR TITLE
Correct bit start offset for `MAC1` field

### DIFF
--- a/espflash/src/targets/efuse/esp32c2.rs
+++ b/espflash/src/targets/efuse/esp32c2.rs
@@ -1,6 +1,6 @@
 //! This file was automatically generated, please do not edit it manually!
 //!
-//! Generated: 2025-04-15 12:51
+//! Generated: 2025-04-22 11:33
 //! Version:   897499b0349a608b895d467abbcf006b
 
 #![allow(unused)]
@@ -63,7 +63,7 @@ pub(crate) const SYSTEM_DATA2: EfuseField = EfuseField::new(1, 2, 64, 24);
 /// MAC address
 pub(crate) const MAC0: EfuseField = EfuseField::new(2, 0, 0, 32);
 /// MAC address
-pub(crate) const MAC1: EfuseField = EfuseField::new(2, 1, 0, 16);
+pub(crate) const MAC1: EfuseField = EfuseField::new(2, 1, 32, 16);
 /// WAFER_VERSION_MINOR
 pub(crate) const WAFER_VERSION_MINOR: EfuseField = EfuseField::new(2, 1, 48, 4);
 /// WAFER_VERSION_MAJOR

--- a/espflash/src/targets/efuse/esp32c3.rs
+++ b/espflash/src/targets/efuse/esp32c3.rs
@@ -1,6 +1,6 @@
 //! This file was automatically generated, please do not edit it manually!
 //!
-//! Generated: 2025-04-15 12:51
+//! Generated: 2025-04-22 11:33
 //! Version:   4622cf9245401eca0eb1df8122449a6d
 
 #![allow(unused)]
@@ -134,7 +134,7 @@ pub(crate) const RESERVED_0_162: EfuseField = EfuseField::new(0, 5, 162, 22);
 /// MAC address
 pub(crate) const MAC0: EfuseField = EfuseField::new(1, 0, 0, 32);
 /// MAC address
-pub(crate) const MAC1: EfuseField = EfuseField::new(1, 1, 0, 16);
+pub(crate) const MAC1: EfuseField = EfuseField::new(1, 1, 32, 16);
 /// SPI PAD CLK
 pub(crate) const SPI_PAD_CONFIG_CLK: EfuseField = EfuseField::new(1, 1, 48, 6);
 /// SPI PAD Q(D1)

--- a/espflash/src/targets/efuse/esp32c6.rs
+++ b/espflash/src/targets/efuse/esp32c6.rs
@@ -1,6 +1,6 @@
 //! This file was automatically generated, please do not edit it manually!
 //!
-//! Generated: 2025-04-15 12:51
+//! Generated: 2025-04-22 11:33
 //! Version:   df46b69f0ed3913114ba53d3a0b2b843
 
 #![allow(unused)]
@@ -159,7 +159,7 @@ pub(crate) const RPT4_RESERVED4_0: EfuseField = EfuseField::new(0, 5, 184, 8);
 /// MAC address
 pub(crate) const MAC0: EfuseField = EfuseField::new(1, 0, 0, 32);
 /// MAC address
-pub(crate) const MAC1: EfuseField = EfuseField::new(1, 1, 0, 16);
+pub(crate) const MAC1: EfuseField = EfuseField::new(1, 1, 32, 16);
 /// Stores the extended bits of MAC address
 pub(crate) const MAC_EXT: EfuseField = EfuseField::new(1, 1, 48, 16);
 /// Stores the active hp dbias

--- a/espflash/src/targets/efuse/esp32h2.rs
+++ b/espflash/src/targets/efuse/esp32h2.rs
@@ -1,6 +1,6 @@
 //! This file was automatically generated, please do not edit it manually!
 //!
-//! Generated: 2025-04-15 12:51
+//! Generated: 2025-04-22 11:33
 //! Version:   44563d2af4ebdba4db6c0a34a50c94f9
 
 #![allow(unused)]
@@ -151,7 +151,7 @@ pub(crate) const RPT4_RESERVED4_0: EfuseField = EfuseField::new(0, 5, 184, 8);
 /// MAC address
 pub(crate) const MAC0: EfuseField = EfuseField::new(1, 0, 0, 32);
 /// MAC address
-pub(crate) const MAC1: EfuseField = EfuseField::new(1, 1, 0, 16);
+pub(crate) const MAC1: EfuseField = EfuseField::new(1, 1, 32, 16);
 /// Stores the extended bits of MAC address
 pub(crate) const MAC_EXT: EfuseField = EfuseField::new(1, 1, 48, 16);
 /// Stores RF Calibration data. RXIQ version

--- a/espflash/src/targets/efuse/esp32p4.rs
+++ b/espflash/src/targets/efuse/esp32p4.rs
@@ -1,6 +1,6 @@
 //! This file was automatically generated, please do not edit it manually!
 //!
-//! Generated: 2025-04-15 12:51
+//! Generated: 2025-04-22 11:33
 //! Version:   73787d3f5ae45b80abca925a7562120b
 
 #![allow(unused)]
@@ -192,7 +192,7 @@ pub(crate) const RESERVE_0_182: EfuseField = EfuseField::new(0, 5, 182, 10);
 /// MAC address
 pub(crate) const MAC0: EfuseField = EfuseField::new(1, 0, 0, 32);
 /// MAC address
-pub(crate) const MAC1: EfuseField = EfuseField::new(1, 1, 0, 16);
+pub(crate) const MAC1: EfuseField = EfuseField::new(1, 1, 32, 16);
 /// Stores the extended bits of MAC address
 pub(crate) const RESERVED_1_16: EfuseField = EfuseField::new(1, 1, 48, 16);
 /// Minor chip version

--- a/espflash/src/targets/efuse/esp32s2.rs
+++ b/espflash/src/targets/efuse/esp32s2.rs
@@ -1,6 +1,6 @@
 //! This file was automatically generated, please do not edit it manually!
 //!
-//! Generated: 2025-04-15 12:51
+//! Generated: 2025-04-22 11:33
 //! Version:   888a61f6f500d9c7ee0aa32016b0bee7
 
 #![allow(unused)]
@@ -149,7 +149,7 @@ pub(crate) const RESERVED_0_162: EfuseField = EfuseField::new(0, 5, 162, 30);
 /// MAC address
 pub(crate) const MAC0: EfuseField = EfuseField::new(1, 0, 0, 32);
 /// MAC address
-pub(crate) const MAC1: EfuseField = EfuseField::new(1, 1, 0, 16);
+pub(crate) const MAC1: EfuseField = EfuseField::new(1, 1, 32, 16);
 /// SPI_PAD_configure CLK
 pub(crate) const SPI_PAD_CONFIG_CLK: EfuseField = EfuseField::new(1, 1, 48, 6);
 /// SPI_PAD_configure Q(D1)

--- a/espflash/src/targets/efuse/esp32s3.rs
+++ b/espflash/src/targets/efuse/esp32s3.rs
@@ -1,6 +1,6 @@
 //! This file was automatically generated, please do not edit it manually!
 //!
-//! Generated: 2025-04-15 12:51
+//! Generated: 2025-04-22 11:33
 //! Version:   7127dd097e72bb90d0b790d460993126
 
 #![allow(unused)]
@@ -165,7 +165,7 @@ pub(crate) const RESERVED_0_162: EfuseField = EfuseField::new(0, 5, 162, 22);
 /// MAC address
 pub(crate) const MAC0: EfuseField = EfuseField::new(1, 0, 0, 32);
 /// MAC address
-pub(crate) const MAC1: EfuseField = EfuseField::new(1, 1, 0, 16);
+pub(crate) const MAC1: EfuseField = EfuseField::new(1, 1, 32, 16);
 /// SPI_PAD_configure CLK
 pub(crate) const SPI_PAD_CONFIG_CLK: EfuseField = EfuseField::new(1, 1, 48, 6);
 /// SPI_PAD_configure Q(D1)

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -166,6 +166,7 @@ fn process_efuse_definitions(efuse_fields: &mut EfuseFields) -> Result<()> {
 
         let mut mac1_attrs = mac_attrs.clone();
         mac1_attrs.word += 1;
+        mac1_attrs.start = 32;
         mac1_attrs.len = 16;
 
         yaml.fields.remove("MAC").unwrap();


### PR DESCRIPTION
Oops 😅 

(Because of how we're reading the MAC address, this thankfully didn't affect `espflash`, however when porting this functionality over to `esp-hal` I noticed this change was required, so may as well be correct here anyway)