### PR TITLE
Fix resetting after board-info, read_flash and checksum_md5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `--mmu-page-size` parameter for `flash` and `save-image` (#835)
 - Run some arguments checks for monitoring flags. (#842)
 - Add support for the ESP32-C5 (#863)
+- `--after` options now work with `espflash board-info`, `espflash read-flash` and `espflash checksum-md5` (#867)
 
 ### Changed
 

--- a/espflash/src/cli/mod.rs
+++ b/espflash/src/cli/mod.rs
@@ -440,12 +440,15 @@ pub fn board_info(args: &ConnectArgs, config: &Config) -> Result<()> {
     let mut flasher = connect(args, config, true, true)?;
     print_board_info(&mut flasher)?;
 
-    if flasher.chip() != Chip::Esp32 {
+    let chip = flasher.chip();
+    if chip != Chip::Esp32 {
         let security_info = flasher.security_info()?;
         println!("{security_info}");
     } else {
         println!("Security features: None");
     }
+
+    flasher.connection().reset_after(!args.no_stub, chip)?;
 
     Ok(())
 }
@@ -456,6 +459,11 @@ pub fn checksum_md5(args: &ChecksumMd5Args, config: &Config) -> Result<()> {
 
     let checksum = flasher.checksum_md5(args.address, args.size)?;
     println!("0x{:x}", checksum);
+
+    let chip = flasher.chip();
+    flasher
+        .connection()
+        .reset_after(!args.connect_args.no_stub, chip)?;
 
     Ok(())
 }
@@ -900,6 +908,11 @@ pub fn read_flash(args: ReadFlashArgs, config: &Config) -> Result<()> {
             args.file,
         )?;
     }
+
+    let chip = flasher.chip();
+    flasher
+        .connection()
+        .reset_after(!args.connect_args.no_stub, chip)?;
 
     Ok(())
 }


### PR DESCRIPTION
`espflash board-info` looks like the only way to currently reset a board non-interactively, so let's make sure the advertised `-a` options are actually effective.