### PR TITLE
Check if bootloader has app descriptor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add support for the ESP32-C5 (#863)
 - `--after` options now work with `espflash board-info`, `espflash read-flash` and `espflash checksum-md5` (#867)
 - Add support for serial port configuration files. (#777)
+- Add a `check-app-descriptor` bool option to `ImageArgs` and add the flag to `flash` commad(#872)
 
 ### Changed
 

--- a/cargo-espflash/src/main.rs
+++ b/cargo-espflash/src/main.rs
@@ -8,6 +8,7 @@ use cargo_metadata::{Message, MetadataCommand};
 use clap::{Args, CommandFactory, Parser, Subcommand};
 use espflash::{
     Error as EspflashError,
+    bt::check_bootloader,
     cli::{
         self,
         config::Config,
@@ -317,6 +318,11 @@ fn flash(args: FlashArgs, config: &Config) -> Result<()> {
 
     // Read the ELF data from the build path and load it to the target.
     let elf_data = fs::read(build_ctx.artifact_path.clone()).into_diagnostic()?;
+
+    // Check if the ELF contains the app descriptor, if required.
+    if args.flash_args.image.check_app_descriptor.unwrap_or(true) {
+        check_bootloader(&elf_data)?;
+    }
 
     let mut monitor_args = args.flash_args.monitor_args;
     monitor_args.elf = Some(build_ctx.artifact_path.clone());

--- a/cargo-espflash/src/main.rs
+++ b/cargo-espflash/src/main.rs
@@ -8,7 +8,6 @@ use cargo_metadata::{Message, MetadataCommand};
 use clap::{Args, CommandFactory, Parser, Subcommand};
 use espflash::{
     Error as EspflashError,
-    bt::check_bootloader,
     cli::{
         self,
         config::Config,
@@ -16,6 +15,7 @@ use espflash::{
         *,
     },
     flasher::FlashSize,
+    image_format::check_idf_bootloader,
     logging::initialize_logger,
     targets::{Chip, XtalFrequency},
     update::check_for_update,
@@ -321,7 +321,7 @@ fn flash(args: FlashArgs, config: &Config) -> Result<()> {
 
     // Check if the ELF contains the app descriptor, if required.
     if args.flash_args.image.check_app_descriptor.unwrap_or(true) {
-        check_bootloader(&elf_data)?;
+        check_idf_bootloader(&elf_data)?;
     }
 
     let mut monitor_args = args.flash_args.monitor_args;

--- a/espflash/src/bin/espflash.rs
+++ b/espflash/src/bin/espflash.rs
@@ -3,6 +3,7 @@ use std::{fs, path::PathBuf};
 use clap::{Args, CommandFactory, Parser, Subcommand};
 use espflash::{
     Error,
+    bt::check_bootloader,
     cli::{
         self,
         config::Config,
@@ -16,7 +17,6 @@ use espflash::{
 };
 use log::{LevelFilter, debug, info};
 use miette::{IntoDiagnostic, Result, WrapErr};
-use object::{File, Object, ObjectSymbol};
 
 #[derive(Debug, Parser)]
 #[command(about, max_term_width = 100, propagate_version = true, version)]
@@ -236,14 +236,9 @@ fn flash(args: FlashArgs, config: &Config) -> Result<()> {
     // Read the ELF data from the build path and load it to the target.
     let elf_data = fs::read(&args.image).into_diagnostic()?;
 
+    // Check if the ELF contains the app descriptor, if required.
     if args.flash_args.image.check_app_descriptor.unwrap_or(true) {
-        let object = File::parse(elf_data.as_slice()).into_diagnostic()?;
-        let section = object.section_by_name(".rodata_desc").is_some();
-        let symbol = object.symbols().any(|sym| sym.name() == Ok("esp_app_desc"));
-
-        if !section || !symbol {
-            return Err(Error::AppDescriptorNotPresent).into_diagnostic();
-        }
+        check_bootloader(&elf_data)?;
     }
 
     print_board_info(&mut flasher)?;

--- a/espflash/src/bin/espflash.rs
+++ b/espflash/src/bin/espflash.rs
@@ -3,7 +3,6 @@ use std::{fs, path::PathBuf};
 use clap::{Args, CommandFactory, Parser, Subcommand};
 use espflash::{
     Error,
-    bt::check_bootloader,
     cli::{
         self,
         config::Config,
@@ -11,6 +10,7 @@ use espflash::{
         *,
     },
     flasher::FlashSize,
+    image_format::check_idf_bootloader,
     logging::initialize_logger,
     targets::{Chip, XtalFrequency},
     update::check_for_update,
@@ -238,7 +238,7 @@ fn flash(args: FlashArgs, config: &Config) -> Result<()> {
 
     // Check if the ELF contains the app descriptor, if required.
     if args.flash_args.image.check_app_descriptor.unwrap_or(true) {
-        check_bootloader(&elf_data)?;
+        check_idf_bootloader(&elf_data)?;
     }
 
     print_board_info(&mut flasher)?;

--- a/espflash/src/cli/mod.rs
+++ b/espflash/src/cli/mod.rs
@@ -253,6 +253,9 @@ pub struct ImageArgs {
     /// MMU page size.
     #[arg(long, value_name = "MMU_PAGE_SIZE", value_parser = parse_u32)]
     pub mmu_page_size: Option<u32>,
+    /// Flag to check the app descriptor in bootloader
+    #[arg(long, default_value = "true", value_parser = clap::value_parser!(bool))]
+    pub check_app_descriptor: Option<bool>,
 }
 
 #[derive(Debug, Args)]

--- a/espflash/src/error.rs
+++ b/espflash/src/error.rs
@@ -253,6 +253,12 @@ pub enum Error {
         help("Make sure you set the correct flash size with the `--flash-size` option")
     )]
     PartitionTableDoesNotFit(FlashSize),
+
+    #[error(
+        "The app descriptor is not present in the project. You need to add the https://github.com/esp-rs/esp-hal/tree/main/esp-bootloader-esp-idf to your project."
+    )]
+    #[diagnostic(code(espflash::app_desc::app_descriptor_not_present))]
+    AppDescriptorNotPresent,
 }
 
 #[cfg(feature = "serialport")]

--- a/espflash/src/image_format/esp_idf.rs
+++ b/espflash/src/image_format/esp_idf.rs
@@ -674,7 +674,7 @@ where
     s
 }
 
-// Check if the provided ELF contains the app descriptor.
+/// Check if the provided ELF contains the app descriptor required by [the IDF bootloader](https://docs.espressif.com/projects/esp-idf/en/stable/esp32/api-guides/bootloader.html).
 pub fn check_idf_bootloader(elf_data: &Vec<u8>) -> Result<()> {
     let object = File::parse(elf_data.as_slice()).into_diagnostic()?;
     let section = object.section_by_name(".rodata_desc").is_some();

--- a/espflash/src/image_format/mod.rs
+++ b/espflash/src/image_format/mod.rs
@@ -22,6 +22,8 @@ use crate::targets::Chip;
 mod esp_idf;
 mod metadata;
 
+pub use esp_idf::check_idf_bootloader;
+
 /// A segment of code from the source ELF
 #[derive(Default, Clone, Eq)]
 pub struct Segment<'a> {

--- a/espflash/src/lib.rs
+++ b/espflash/src/lib.rs
@@ -76,3 +76,23 @@ pub mod update {
         }
     }
 }
+
+pub mod bt {
+    use miette::{IntoDiagnostic, Result};
+    use object::{File, Object, ObjectSymbol};
+
+    use crate::Error;
+
+    // Check if the provided ELF contains the app descriptor.
+    pub fn check_bootloader(elf_data: &Vec<u8>) -> Result<()> {
+        let object = File::parse(elf_data.as_slice()).into_diagnostic()?;
+        let section = object.section_by_name(".rodata_desc").is_some();
+        let symbol = object.symbols().any(|sym| sym.name() == Ok("esp_app_desc"));
+
+        if !section || !symbol {
+            return Err(Error::AppDescriptorNotPresent).into_diagnostic();
+        }
+
+        Ok(())
+    }
+}

--- a/espflash/src/lib.rs
+++ b/espflash/src/lib.rs
@@ -76,23 +76,3 @@ pub mod update {
         }
     }
 }
-
-pub mod bt {
-    use miette::{IntoDiagnostic, Result};
-    use object::{File, Object, ObjectSymbol};
-
-    use crate::Error;
-
-    // Check if the provided ELF contains the app descriptor.
-    pub fn check_bootloader(elf_data: &Vec<u8>) -> Result<()> {
-        let object = File::parse(elf_data.as_slice()).into_diagnostic()?;
-        let section = object.section_by_name(".rodata_desc").is_some();
-        let symbol = object.symbols().any(|sym| sym.name() == Ok("esp_app_desc"));
-
-        if !section || !symbol {
-            return Err(Error::AppDescriptorNotPresent).into_diagnostic();
-        }
-
-        Ok(())
-    }
-}


### PR DESCRIPTION
This checks, if the bootloader has an app desc present, if not, returns an error. 
Also added an option for users to disable the check.

closes https://github.com/esp-rs/espflash/issues/866