### PR TITLE
Add secure padding for save-image

### DIFF
--- a/espflash/src/cli/mod.rs
+++ b/espflash/src/cli/mod.rs
@@ -253,6 +253,9 @@ pub struct ImageArgs {
     /// MMU page size.
     #[arg(long, value_name = "MMU_PAGE_SIZE", value_parser = parse_u32)]
     pub mmu_page_size: Option<u32>,
+    /// Whether to apply padding for secure boot v2
+    #[arg(long)]
+    pub secure_pad_v2: bool,
 }
 
 #[derive(Debug, Args)]
@@ -1060,6 +1063,7 @@ pub fn make_flash_data(
         flash_settings,
         image_args.min_chip_rev,
         image_args.mmu_page_size,
+        image_args.secure_pad_v2,
     )
 }
 

--- a/espflash/src/connection/mod.rs
+++ b/espflash/src/connection/mod.rs
@@ -39,7 +39,7 @@ use crate::{
 };
 
 pub(crate) mod command;
-pub(crate) mod reset;
+pub mod reset;
 
 const MAX_CONNECT_ATTEMPTS: usize = 7;
 const MAX_SYNC_ATTEMPTS: usize = 5;

--- a/espflash/src/flasher/mod.rs
+++ b/espflash/src/flasher/mod.rs
@@ -477,6 +477,7 @@ pub struct FlashData {
     pub flash_settings: FlashSettings,
     pub min_chip_rev: u16,
     pub mmu_page_size: Option<u32>,
+    pub secure_pad_v2: bool,
 }
 
 impl FlashData {
@@ -488,6 +489,7 @@ impl FlashData {
         flash_settings: FlashSettings,
         min_chip_rev: u16,
         mmu_page_size: Option<u32>,
+        secure_pad_v2: bool,
     ) -> Result<Self, Error> {
         // If the '--bootloader' option is provided, load the binary file at the
         // specified path.
@@ -520,6 +522,7 @@ impl FlashData {
             flash_settings,
             min_chip_rev,
             mmu_page_size,
+            secure_pad_v2,
         })
     }
 }

--- a/espflash/src/image_format/esp_idf.rs
+++ b/espflash/src/image_format/esp_idf.rs
@@ -401,6 +401,18 @@ impl<'a> IdfBootloaderFormat<'a> {
             segment_count += 1;
         }
 
+        if flash_data.secure_pad_v2 {
+            let current_size = data.len();
+            let padding_size = (65536 - ((current_size + 56) % 65536)) % 65536;
+            let padding_bytes = vec![0; padding_size];
+            let segment = Segment {
+                addr: 0,
+                data: Cow::Owned(padding_bytes),
+            };
+            checksum = save_segment(&mut data, &segment, checksum)?;
+            segment_count += 1;
+        }
+
         let padding = 15 - (data.len() % 16);
         let padding = &[0u8; 16][0..padding];
         data.write_all(padding)?;


### PR DESCRIPTION
This PR adds support for "secure padding", just like esptool.py's `--secure-pad-v2` option, as discussed in #713.

In contrast to https://github.com/esp-rs/espflash/compare/main...SergioGasquez:espflash:feat/secure-padding, this also adds an additional padding section, just like esptool.py. Thus, using esptool.py and espflash save-image with `--secure-pad-v2` will now result in exactly the same output.

Also, it makes the `connection::reset` crate public again, since it is required to call the `Flasher::connect` method when espflash is used as a library. It was previously made `pub(crate)` in be1ff81b15b11b5449a559baff4f0d7d6d525290.