### PR TITLE
Refactor image format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated to Rust 2024 edition (#843)
 - Complete rework of reading eFuse field values (#847)
 - Updated bootloaders with `release/v5.4` ones from IDF (#857)
+- Refactor image formatting to allow supporting more image formats in a backward compatible way (#877)
+- Avoid having ESP-IDF format assumptions in the codebase (#877)
 
 ### Fixed
 

--- a/cargo-espflash/src/main.rs
+++ b/cargo-espflash/src/main.rs
@@ -15,7 +15,7 @@ use espflash::{
         *,
     },
     flasher::FlashSize,
-    image_format::check_idf_bootloader,
+    image_format::{ImageFormatKind, check_idf_bootloader},
     logging::initialize_logger,
     targets::{Chip, XtalFrequency},
     update::check_for_update,
@@ -198,6 +198,9 @@ struct FlashArgs {
     connect_args: ConnectArgs,
     #[clap(flatten)]
     flash_args: cli::FlashArgs,
+    /// Application image format to use
+    #[clap(long)]
+    format: ImageFormatKind,
 }
 
 #[derive(Debug, Args)]
@@ -207,6 +210,9 @@ struct SaveImageArgs {
     build_args: BuildArgs,
     #[clap(flatten)]
     save_image_args: cli::SaveImageArgs,
+    /// Application image format to use
+    #[clap(long)]
+    format: ImageFormatKind,
 }
 
 fn main() -> Result<()> {
@@ -359,7 +365,13 @@ fn flash(args: FlashArgs, config: &Config) -> Result<()> {
             )?;
         }
 
-        flash_elf_image(&mut flasher, &elf_data, flash_data, target_xtal_freq)?;
+        flash_elf_image(
+            &mut flasher,
+            args.format,
+            &elf_data,
+            flash_data,
+            target_xtal_freq,
+        )?;
     }
 
     if args.flash_args.monitor {
@@ -599,6 +611,7 @@ fn save_image(args: SaveImageArgs, config: &Config) -> Result<()> {
         .unwrap_or(XtalFrequency::default(args.save_image_args.chip));
 
     save_elf_as_image(
+        args.format,
         &elf_data,
         args.save_image_args.chip,
         args.save_image_args.file,

--- a/cargo-espflash/src/main.rs
+++ b/cargo-espflash/src/main.rs
@@ -372,7 +372,7 @@ fn flash(args: FlashArgs, config: &Config) -> Result<()> {
             build_ctx.partition_table_path,
         )?;
 
-        flash_elf_image(&mut flasher, image_format)?;
+        flash_image(&mut flasher, image_format)?;
     }
 
     if args.flash_args.monitor {

--- a/cargo-espflash/src/main.rs
+++ b/cargo-espflash/src/main.rs
@@ -387,7 +387,7 @@ fn flash(args: FlashArgs, config: &Config) -> Result<()> {
             if args.flash_args.erase_parts.is_some() || args.flash_args.erase_data_parts.is_some() {
                 erase_partitions(
                     &mut flasher,
-                    Some(idf_format.partition_table.clone()),
+                    Some(idf_format.partition_table()),
                     args.flash_args.erase_parts,
                     args.flash_args.erase_data_parts,
                 )?;

--- a/cargo-espflash/src/main.rs
+++ b/cargo-espflash/src/main.rs
@@ -175,7 +175,7 @@ struct BuildArgs {
 }
 
 /// Erase named partitions based on provided partition table
-/// ESP-IDF ONLY
+// ESP-IDF ONLY
 #[derive(Debug, Args)]
 #[non_exhaustive]
 pub struct ErasePartsArgs {

--- a/cargo-espflash/src/main.rs
+++ b/cargo-espflash/src/main.rs
@@ -291,7 +291,7 @@ pub fn erase_parts(args: ErasePartsArgs, config: &Config) -> Result<()> {
     let mut flasher = connect(&args.connect_args, config, false, false)?;
     let chip = flasher.chip();
     let partition_table = match partition_table {
-        Some(path) => Some(parse_partition_table(path.to_str().unwrap())?),
+        Some(path) => Some(parse_partition_table(path)?),
         None => None,
     };
 

--- a/cargo-espflash/src/main.rs
+++ b/cargo-espflash/src/main.rs
@@ -175,7 +175,6 @@ struct BuildArgs {
 }
 
 /// Erase named partitions based on provided partition table
-// ESP-IDF ONLY
 #[derive(Debug, Args)]
 #[non_exhaustive]
 pub struct ErasePartsArgs {

--- a/cargo-espflash/src/main.rs
+++ b/cargo-espflash/src/main.rs
@@ -170,6 +170,7 @@ struct BuildArgs {
 }
 
 /// Erase named partitions based on provided partition table
+/// ESP-IDF ONLY
 #[derive(Debug, Args)]
 #[non_exhaustive]
 pub struct ErasePartsArgs {

--- a/cargo-espflash/src/main.rs
+++ b/cargo-espflash/src/main.rs
@@ -622,7 +622,7 @@ fn save_image(args: SaveImageArgs, config: &Config) -> Result<()> {
     let xtal_freq = args
         .save_image_args
         .xtal_freq
-        .unwrap_or(XtalFrequency::default(args.save_image_args.chip));
+        .unwrap_or(args.save_image_args.chip.default_crystal_frequency());
 
     let flash_data = make_flash_data(
         args.save_image_args.image,

--- a/espflash/src/bin/espflash.rs
+++ b/espflash/src/bin/espflash.rs
@@ -100,6 +100,7 @@ enum Commands {
 }
 
 /// Erase named partitions based on provided partition table
+/// ESP-IDF ONLY
 #[derive(Debug, Args)]
 #[non_exhaustive]
 pub struct ErasePartsArgs {
@@ -261,7 +262,7 @@ fn flash(args: FlashArgs, config: &Config) -> Result<()> {
         flasher.load_elf_to_ram(&elf_data, Some(&mut EspflashProgress::default()))?;
     } else {
         let flash_data = make_flash_data(args.flash_args.image, &flash_config, config, None, None)?;
-
+        // ESP-IDF ONLY
         if args.flash_args.erase_parts.is_some() || args.flash_args.erase_data_parts.is_some() {
             erase_partitions(
                 &mut flasher,

--- a/espflash/src/bin/espflash.rs
+++ b/espflash/src/bin/espflash.rs
@@ -348,7 +348,7 @@ fn save_image(args: SaveImageArgs, config: &Config) -> Result<()> {
     let xtal_freq = args
         .save_image_args
         .xtal_freq
-        .unwrap_or(XtalFrequency::default(args.save_image_args.chip));
+        .unwrap_or(args.save_image_args.chip.default_crystal_frequency());
 
     let flash_data = make_flash_data(
         args.save_image_args.image,

--- a/espflash/src/bin/espflash.rs
+++ b/espflash/src/bin/espflash.rs
@@ -10,7 +10,7 @@ use espflash::{
         *,
     },
     flasher::FlashSize,
-    image_format::check_idf_bootloader,
+    image_format::{ImageFormatKind, check_idf_bootloader},
     logging::initialize_logger,
     targets::{Chip, XtalFrequency},
     update::check_for_update,
@@ -128,6 +128,9 @@ struct FlashArgs {
     flash_args: cli::FlashArgs,
     /// ELF image to flash
     image: PathBuf,
+    /// Application image format to use
+    #[clap(long)]
+    format: ImageFormatKind,
 }
 
 #[derive(Debug, Args)]
@@ -141,6 +144,9 @@ struct SaveImageArgs {
     /// Sage image arguments
     #[clap(flatten)]
     save_image_args: cli::SaveImageArgs,
+    /// Application image format to use
+    #[clap(long)]
+    format: ImageFormatKind,
 }
 
 fn main() -> Result<()> {
@@ -265,7 +271,13 @@ fn flash(args: FlashArgs, config: &Config) -> Result<()> {
             )?;
         }
 
-        flash_elf_image(&mut flasher, &elf_data, flash_data, target_xtal_freq)?;
+        flash_elf_image(
+            &mut flasher,
+            args.format,
+            &elf_data,
+            flash_data,
+            target_xtal_freq,
+        )?;
     }
 
     if args.flash_args.monitor {
@@ -319,6 +331,7 @@ fn save_image(args: SaveImageArgs, config: &Config) -> Result<()> {
         .unwrap_or(XtalFrequency::default(args.save_image_args.chip));
 
     save_elf_as_image(
+        args.format,
         &elf_data,
         args.save_image_args.chip,
         args.save_image_args.file,

--- a/espflash/src/bin/espflash.rs
+++ b/espflash/src/bin/espflash.rs
@@ -210,7 +210,7 @@ pub fn erase_parts(args: ErasePartsArgs, config: &Config) -> Result<()> {
     let mut flasher = connect(&args.connect_args, config, false, false)?;
     let chip = flasher.chip();
     let partition_table = match args.partition_table {
-        Some(path) => Some(parse_partition_table(path.to_str().unwrap())?),
+        Some(path) => Some(parse_partition_table(&path)?),
         None => None,
     };
 

--- a/espflash/src/bin/espflash.rs
+++ b/espflash/src/bin/espflash.rs
@@ -105,7 +105,6 @@ enum Commands {
 }
 
 /// Erase named partitions based on provided partition table
-// ESP-IDF ONLY
 #[derive(Debug, Args)]
 #[non_exhaustive]
 pub struct ErasePartsArgs {

--- a/espflash/src/bin/espflash.rs
+++ b/espflash/src/bin/espflash.rs
@@ -105,7 +105,7 @@ enum Commands {
 }
 
 /// Erase named partitions based on provided partition table
-/// ESP-IDF ONLY
+// ESP-IDF ONLY
 #[derive(Debug, Args)]
 #[non_exhaustive]
 pub struct ErasePartsArgs {

--- a/espflash/src/bin/espflash.rs
+++ b/espflash/src/bin/espflash.rs
@@ -132,7 +132,7 @@ struct FlashArgs {
     /// Application image format to use
     #[clap(long, default_value = "esp-idf")]
     format: ImageFormatKind,
-    // TODO: We need to be able to pass the esp_idf format args
+    /// ESP-IDF arguments
     #[clap(flatten)]
     esp_idf_format_args: cli::EspIdfFormatArgs,
 }
@@ -149,7 +149,7 @@ struct SaveImageArgs {
     #[clap(flatten)]
     save_image_args: cli::SaveImageArgs,
     /// Application image format to use
-    #[clap(long)]
+    #[clap(long, default_value = "esp-idf")]
     format: ImageFormatKind,
     // ESP-IDF arguments
     #[clap(flatten)]
@@ -271,13 +271,20 @@ fn flash(args: FlashArgs, config: &Config) -> Result<()> {
             args.flash_args.image,
             &flash_config,
             config,
+            chip,
+            target_xtal_freq,
+        );
+        let image_format = make_image_format(
+            &elf_data,
+            &flash_data,
             args.format,
+            config,
             Some(args.esp_idf_format_args),
             None,
             None,
         )?;
 
-        flash_elf_image(&mut flasher, &elf_data, flash_data, target_xtal_freq)?;
+        flash_elf_image(&mut flasher, image_format)?;
     }
 
     if args.flash_args.monitor {
@@ -317,29 +324,34 @@ fn save_image(args: SaveImageArgs, config: &Config) -> Result<()> {
         .or(config.project_config.flash.size) // If no CLI argument, try the config file
         .or_else(|| Some(FlashSize::default())); // Otherwise, use a reasonable default value
 
-    let flash_data = make_flash_data(
-        args.save_image_args.image,
-        &flash_config,
-        config,
-        args.format,
-        Some(args.esp_idf_format_args),
-        None,
-        None,
-    )?;
-
     let xtal_freq = args
         .save_image_args
         .xtal_freq
         .unwrap_or(XtalFrequency::default(args.save_image_args.chip));
 
-    save_elf_as_image(
-        &elf_data,
+    let flash_data = make_flash_data(
+        args.save_image_args.image,
+        &flash_config,
+        config,
         args.save_image_args.chip,
+        xtal_freq,
+    );
+    let image_format = make_image_format(
+        &elf_data,
+        &flash_data,
+        args.format,
+        config,
+        Some(args.esp_idf_format_args),
+        None,
+        None,
+    )?;
+
+    save_elf_as_image(
         args.save_image_args.file,
-        flash_data,
+        flash_data.flash_settings.size,
         args.save_image_args.merge,
         args.save_image_args.skip_padding,
-        xtal_freq,
+        image_format,
     )?;
 
     Ok(())

--- a/espflash/src/bin/espflash.rs
+++ b/espflash/src/bin/espflash.rs
@@ -284,7 +284,7 @@ fn flash(args: FlashArgs, config: &Config) -> Result<()> {
             None,
         )?;
 
-        flash_elf_image(&mut flasher, image_format)?;
+        flash_image(&mut flasher, image_format)?;
     }
 
     if args.flash_args.monitor {

--- a/espflash/src/bin/espflash.rs
+++ b/espflash/src/bin/espflash.rs
@@ -10,7 +10,7 @@ use espflash::{
         *,
     },
     flasher::FlashSize,
-    image_format::{ImageFormatKind, check_idf_bootloader},
+    image_format::{ImageFormatKind, check_idf_bootloader, esp_idf::parse_partition_table},
     logging::initialize_logger,
     targets::{Chip, XtalFrequency},
     update::check_for_update,
@@ -267,28 +267,17 @@ fn flash(args: FlashArgs, config: &Config) -> Result<()> {
     if args.flash_args.ram {
         flasher.load_elf_to_ram(&elf_data, Some(&mut EspflashProgress::default()))?;
     } else {
-        let format_args = cli::create_format_args(
-            args.format,
-            args.esp_idf_format_args,
-            Some(&mut flasher),
-            None,
-            None,
-        )?;
-
         let flash_data = make_flash_data(
             args.flash_args.image,
             &flash_config,
             config,
-            format_args.clone(),
+            args.format,
+            Some(args.esp_idf_format_args),
+            None,
+            None,
         )?;
 
-        flash_elf_image(
-            &mut flasher,
-            format_args,
-            &elf_data,
-            flash_data,
-            target_xtal_freq,
-        )?;
+        flash_elf_image(&mut flasher, &elf_data, flash_data, target_xtal_freq)?;
     }
 
     if args.flash_args.monitor {
@@ -328,14 +317,14 @@ fn save_image(args: SaveImageArgs, config: &Config) -> Result<()> {
         .or(config.project_config.flash.size) // If no CLI argument, try the config file
         .or_else(|| Some(FlashSize::default())); // Otherwise, use a reasonable default value
 
-    let format_args =
-        cli::create_format_args(args.format, args.esp_idf_format_args, None, None, None)?;
-
     let flash_data = make_flash_data(
         args.save_image_args.image,
         &flash_config,
         config,
-        format_args.clone(),
+        args.format,
+        Some(args.esp_idf_format_args),
+        None,
+        None,
     )?;
 
     let xtal_freq = args
@@ -344,7 +333,6 @@ fn save_image(args: SaveImageArgs, config: &Config) -> Result<()> {
         .unwrap_or(XtalFrequency::default(args.save_image_args.chip));
 
     save_elf_as_image(
-        format_args,
         &elf_data,
         args.save_image_args.chip,
         args.save_image_args.file,

--- a/espflash/src/bin/espflash.rs
+++ b/espflash/src/bin/espflash.rs
@@ -299,7 +299,7 @@ fn flash(args: FlashArgs, config: &Config) -> Result<()> {
             if args.flash_args.erase_parts.is_some() || args.flash_args.erase_data_parts.is_some() {
                 erase_partitions(
                     &mut flasher,
-                    Some(idf_format.partition_table.clone()),
+                    Some(idf_format.partition_table()),
                     args.flash_args.erase_parts,
                     args.flash_args.erase_data_parts,
                 )?;

--- a/espflash/src/cli/config.rs
+++ b/espflash/src/cli/config.rs
@@ -87,10 +87,10 @@ pub struct ProjectConfig {
     /// Baudrate
     #[serde(default)]
     pub baudrate: Option<u32>,
-    // Image format
+    /// Image format
     #[serde(default)]
     pub format: ImageFormatKind,
-    // ESP-IDF format arguments
+    /// ESP-IDF format arguments
     #[serde(default)]
     pub esp_idf_format_args: cli::EspIdfFormatArgs,
     /// Flash settings

--- a/espflash/src/cli/config.rs
+++ b/espflash/src/cli/config.rs
@@ -91,9 +91,11 @@ pub struct ProjectConfig {
     #[serde(default)]
     pub bootloader: Option<PathBuf>,
     /// Partition table path
+    /// ESP-IDF ONLY
     #[serde(default)]
     pub partition_table: Option<PathBuf>,
     /// Partition table offset
+    /// ESP-IDF ONLY
     #[serde(default)]
     pub partition_table_offset: Option<u32>,
     /// Flash settings

--- a/espflash/src/cli/config.rs
+++ b/espflash/src/cli/config.rs
@@ -19,7 +19,7 @@ use miette::{IntoDiagnostic, Result, WrapErr};
 use serde::{Deserialize, Serialize};
 use serialport::UsbPortInfo;
 
-use crate::{Error, flasher::FlashSettings};
+use crate::{Error, cli, flasher::FlashSettings, image_format::ImageFormatKind};
 
 /// A configured, known serial connection
 #[derive(Debug, Deserialize, Serialize, Default, Clone)]
@@ -87,17 +87,12 @@ pub struct ProjectConfig {
     /// Baudrate
     #[serde(default)]
     pub baudrate: Option<u32>,
-    /// Bootloader path
+    // Image format
     #[serde(default)]
-    pub bootloader: Option<PathBuf>,
-    /// Partition table path
-    /// ESP-IDF ONLY
+    pub format: ImageFormatKind,
+    // ESP-IDF format arguments
     #[serde(default)]
-    pub partition_table: Option<PathBuf>,
-    /// Partition table offset
-    /// ESP-IDF ONLY
-    #[serde(default)]
-    pub partition_table_offset: Option<u32>,
+    pub esp_idf_format_args: cli::EspIdfFormatArgs,
     /// Flash settings
     #[serde(default)]
     pub flash: FlashSettings,
@@ -129,14 +124,14 @@ impl Config {
             ProjectConfig::default()
         };
 
-        if let Some(table) = &project_config.partition_table {
+        if let Some(table) = &project_config.esp_idf_format_args.partition_table {
             match table.extension() {
                 Some(ext) if ext == "bin" || ext == "csv" => {}
                 _ => return Err(Error::InvalidPartitionTablePath.into()),
             }
         }
 
-        if let Some(bootloader) = &project_config.bootloader {
+        if let Some(bootloader) = &project_config.esp_idf_format_args.bootloader {
             if bootloader.extension() != Some(OsStr::new("bin")) {
                 return Err(Error::InvalidBootloaderPath.into());
             }

--- a/espflash/src/cli/mod.rs
+++ b/espflash/src/cli/mod.rs
@@ -928,7 +928,7 @@ pub fn read_flash(args: ReadFlashArgs, config: &Config) -> Result<()> {
 /// Convert and display CSV and binary partition tables
 pub fn partition_table(args: PartitionTableArgs) -> Result<()> {
     if args.to_binary {
-        let table = parse_partition_table(args.partition_table.to_str().unwrap())?;
+        let table = parse_partition_table(&args.partition_table)?;
 
         // Use either stdout or a file if provided for the output.
         let mut writer: Box<dyn Write> = if let Some(output) = args.output {

--- a/espflash/src/cli/mod.rs
+++ b/espflash/src/cli/mod.rs
@@ -141,9 +141,11 @@ pub struct FlashConfigArgs {
 #[group(skip)]
 pub struct FlashArgs {
     /// Erase partitions by label
+    /// ESP_IDF ONLY
     #[arg(long, value_name = "LABELS", value_delimiter = ',')]
     pub erase_parts: Option<Vec<String>>,
     /// Erase specified data partitions
+    /// ESP_IDF ONLY
     #[arg(long, value_name = "PARTS", value_enum, value_delimiter = ',')]
     pub erase_data_parts: Option<Vec<DataType>>,
     /// Open a serial monitor after flashing
@@ -165,7 +167,8 @@ pub struct FlashArgs {
     pub image: ImageArgs,
 }
 
-/// Operations for partitions tables
+/// Operations for ESP-IDF partition tables
+/// ESP-IDF ONLY
 #[derive(Debug, Args)]
 #[non_exhaustive]
 pub struct PartitionTableArgs {
@@ -241,9 +244,13 @@ pub struct ImageArgs {
     #[arg(long, value_name = "FILE")]
     pub bootloader: Option<PathBuf>,
     /// Path to a CSV file containing partition table
+    ///
+    /// This only applies when using ESP-IDF image format
     #[arg(long, value_name = "FILE")]
     pub partition_table: Option<PathBuf>,
     /// Partition table offset
+    ///
+    /// This only applies when using ESP-IDF image format
     #[arg(long, value_name = "OFFSET", value_parser = parse_u32)]
     pub partition_table_offset: Option<u32>,
     /// Label of target app partition
@@ -340,6 +347,7 @@ pub struct WriteBinArgs {
     pub target: WriteTarget,
     /// Path to a CSV file containing partition table, needed to resolve the
     /// partition label.
+    /// ESP_IDF ONLY
     #[arg(long, value_name = "FILE")]
     pub partition_table: Option<PathBuf>,
     /// File containing the binary data to write
@@ -662,6 +670,7 @@ pub fn save_elf_as_image(
         chip.into_target()
             .flash_image(format, elf_data, flash_data.clone(), None, xtal_freq)?;
 
+    // ESP_IDF ONLY
     let metadata = image.metadata();
     if metadata.contains_key("app_size") && metadata.contains_key("part_size") {
         let app_size = metadata["app_size"].parse::<u32>().unwrap();
@@ -840,6 +849,7 @@ pub fn flash_elf_image(
 }
 
 /// Erase one or more partitions by label or [DataType]
+/// ESP-IDF ONLY
 pub fn erase_partitions(
     flasher: &mut Flasher,
     partition_table: Option<PartitionTable>,

--- a/espflash/src/cli/mod.rs
+++ b/espflash/src/cli/mod.rs
@@ -820,8 +820,8 @@ pub fn erase_region(args: EraseRegionArgs, config: &Config) -> Result<()> {
 }
 
 /// Write an ELF image to a target device's flash
-pub fn flash_elf_image<'a>(flasher: &mut Flasher, image_format: ImageFormat<'a>) -> Result<()> {
-    flasher.load_elf_to_flash(Some(&mut EspflashProgress::default()), image_format)?;
+pub fn flash_image<'a>(flasher: &mut Flasher, image_format: ImageFormat<'a>) -> Result<()> {
+    flasher.load_image_to_flash(Some(&mut EspflashProgress::default()), image_format)?;
     info!("Flashing has completed!");
 
     Ok(())

--- a/espflash/src/cli/mod.rs
+++ b/espflash/src/cli/mod.rs
@@ -645,6 +645,7 @@ pub fn serial_monitor(args: MonitorArgs, config: &Config) -> Result<()> {
 }
 
 /// Convert the provided firmware image from ELF to binary
+#[allow(clippy::too_many_arguments)]
 pub fn save_elf_as_image(
     format: ImageFormatKind,
     elf_data: &[u8],

--- a/espflash/src/cli/mod.rs
+++ b/espflash/src/cli/mod.rs
@@ -954,7 +954,6 @@ pub fn partition_table(args: PartitionTableArgs) -> Result<()> {
 }
 
 /// Pretty print a partition table
-// TODO: Move to esp-idf mod?
 fn pretty_print(table: PartitionTable) {
     let mut pretty = Table::new();
 

--- a/espflash/src/cli/mod.rs
+++ b/espflash/src/cli/mod.rs
@@ -177,7 +177,6 @@ pub struct FlashArgs {
 }
 
 /// Operations for ESP-IDF partition tables
-// ESP-IDF ONLY
 #[derive(Debug, Args)]
 #[non_exhaustive]
 pub struct PartitionTableArgs {
@@ -658,7 +657,6 @@ pub fn save_elf_as_image<'a>(
     skip_padding: bool,
     image_format: ImageFormat<'a>,
 ) -> Result<()> {
-    // ESP_IDF ONLY
     let metadata = image_format.metadata();
     if metadata.contains_key("app_size") && metadata.contains_key("part_size") {
         let app_size = metadata["app_size"].parse::<u32>().unwrap();
@@ -822,7 +820,6 @@ pub fn flash_image<'a>(flasher: &mut Flasher, image_format: ImageFormat<'a>) -> 
 }
 
 /// Erase one or more partitions by label or [DataType]
-// ESP-IDF ONLY
 pub fn erase_partitions(
     flasher: &mut Flasher,
     partition_table: Option<PartitionTable>,

--- a/espflash/src/cli/mod.rs
+++ b/espflash/src/cli/mod.rs
@@ -161,7 +161,7 @@ pub struct FlashArgs {
     /// Don't skip flashing of parts with matching checksum
     #[arg(long)]
     pub no_skip: bool,
-    /// TODO
+    /// Image related arguments
     #[clap(flatten)]
     pub image: ImageArgs,
     /// Erase partitions by label
@@ -177,7 +177,7 @@ pub struct FlashArgs {
 }
 
 /// Operations for ESP-IDF partition tables
-/// ESP-IDF ONLY
+// ESP-IDF ONLY
 #[derive(Debug, Args)]
 #[non_exhaustive]
 pub struct PartitionTableArgs {
@@ -266,23 +266,15 @@ pub struct ImageArgs {
 #[group(skip)]
 pub struct EspIdfFormatArgs {
     /// Path to a binary ESP-IDF bootloader file
-    ///
-    /// This only applies when using ESP-IDF image format
     #[arg(long, value_name = "FILE")]
     pub bootloader: Option<PathBuf>,
     /// Path to a CSV file containing partition table
-    ///
-    /// This only applies when using ESP-IDF image format
     #[arg(long, value_name = "FILE")]
     pub partition_table: Option<PathBuf>,
     /// Partition table offset
-    ///
-    /// This only applies when using ESP-IDF image format
     #[arg(long, value_name = "OFFSET", value_parser = parse_u32)]
     pub partition_table_offset: Option<u32>,
     /// Label of target app partition
-    ///
-    /// This only applies when using ESP-IDF image format
     #[arg(long, value_name = "LABEL")]
     pub target_app_partition: Option<String>,
 }
@@ -830,7 +822,7 @@ pub fn flash_image<'a>(flasher: &mut Flasher, image_format: ImageFormat<'a>) -> 
 }
 
 /// Erase one or more partitions by label or [DataType]
-/// ESP-IDF ONLY
+// ESP-IDF ONLY
 pub fn erase_partitions(
     flasher: &mut Flasher,
     partition_table: Option<PartitionTable>,
@@ -1014,6 +1006,7 @@ fn pretty_print(table: PartitionTable) {
     println!("{pretty}");
 }
 
+/// Make an image format from the given arguments
 pub fn make_image_format<'a>(
     elf_data: &'a [u8],
     flash_data: &FlashData,
@@ -1059,6 +1052,7 @@ pub fn make_image_format<'a>(
     Ok(image_format.into())
 }
 
+/// Make flash data from the given arguments
 pub fn make_flash_data(
     image_args: ImageArgs,
     flash_config_args: &FlashConfigArgs,
@@ -1172,6 +1166,7 @@ pub fn ensure_chip_compatibility(chip: Chip, elf: Option<&[u8]>) -> Result<()> {
     }
 }
 
+/// Check if the given arguments are valid for the ESP-IDF format
 pub fn check_esp_idf_args(
     format: ImageFormatKind,
     erase_parts: &Option<Vec<String>>,

--- a/espflash/src/cli/mod.rs
+++ b/espflash/src/cli/mod.rs
@@ -1045,7 +1045,6 @@ pub fn make_image_format<'a>(
                     .clone()
                     .or(build_ctx_partition_table);
             }
-            // TODO: Verify that we can ignore chip revision, it was not used before?
             IdfBootloaderFormat::new(
                 elf_data,
                 flash_data,

--- a/espflash/src/cli/mod.rs
+++ b/espflash/src/cli/mod.rs
@@ -164,6 +164,16 @@ pub struct FlashArgs {
     /// TODO
     #[clap(flatten)]
     pub image: ImageArgs,
+    /// Erase partitions by label
+    ///
+    /// Only valid when using the `esp-idf` format.
+    #[arg(long, value_name = "LABELS", value_delimiter = ',')]
+    pub erase_parts: Option<Vec<String>>,
+    /// Erase specified data partitions
+    ///
+    /// Only valid when using the `esp-idf` format.
+    #[arg(long, value_name = "PARTS", value_enum, value_delimiter = ',')]
+    pub erase_data_parts: Option<Vec<DataType>>,
 }
 
 /// Operations for ESP-IDF partition tables
@@ -275,14 +285,6 @@ pub struct EspIdfFormatArgs {
     /// This only applies when using ESP-IDF image format
     #[arg(long, value_name = "LABEL")]
     pub target_app_partition: Option<String>,
-    /// Erase partitions by label
-    // TODO: We may need to check if this makes sense in the subcommand
-    #[arg(long, value_name = "LABELS", value_delimiter = ',')]
-    pub erase_parts: Option<Vec<String>>,
-    /// Erase specified data partitions
-    // TODO: We may need to check if this makes sense in the subcommand
-    #[arg(long, value_name = "PARTS", value_enum, value_delimiter = ',')]
-    pub erase_data_parts: Option<Vec<DataType>>,
 }
 
 /// Arguments for connection and monitoring
@@ -1169,6 +1171,20 @@ pub fn ensure_chip_compatibility(chip: Chip, elf: Option<&[u8]>) -> Result<()> {
         })
         .into_diagnostic(),
     }
+}
+
+pub fn check_esp_idf_args(
+    format: ImageFormatKind,
+    erase_parts: &Option<Vec<String>>,
+    erase_data_parts: &Option<Vec<DataType>>,
+) -> Result<()> {
+    if format != ImageFormatKind::EspIdf && (erase_parts.is_some() || erase_data_parts.is_some()) {
+        return Err(miette::miette!(
+            "`erase-parts` and `erase-data` parts are only supported when using the `esp-idf` format."
+        ));
+    }
+
+    Ok(())
 }
 
 mod test {

--- a/espflash/src/flasher/mod.rs
+++ b/espflash/src/flasher/mod.rs
@@ -30,17 +30,13 @@ use crate::{
 #[cfg(feature = "serialport")]
 use crate::{
     connection::{
-        Connection,
-        Port,
+        Connection, Port,
         command::{Command, CommandType},
         reset::{ResetAfterOperation, ResetBeforeOperation},
     },
     error::{ConnectionError, ResultExt as _},
     flasher::stubs::{
-        CHIP_DETECT_MAGIC_REG_ADDR,
-        DEFAULT_TIMEOUT,
-        EXPECTED_STUB_HANDSHAKE,
-        FlashStub,
+        CHIP_DETECT_MAGIC_REG_ADDR, DEFAULT_TIMEOUT, EXPECTED_STUB_HANDSHAKE, FlashStub,
     },
     image_format::{ImageFormat, Segment, ram_segments, rom_segments},
 };
@@ -480,7 +476,9 @@ pub struct FlashData {
     pub min_chip_rev: u16,
     /// MMU page size.
     pub mmu_page_size: Option<u32>,
+    /// Target chip.
     pub chip: Chip,
+    /// Crystal frequency.
     pub xtal_freq: XtalFrequency,
 }
 

--- a/espflash/src/flasher/mod.rs
+++ b/espflash/src/flasher/mod.rs
@@ -26,6 +26,7 @@ pub(crate) use self::stubs::{FLASH_SECTOR_SIZE, FLASH_WRITE_SIZE};
 pub use crate::targets::flash_target::ProgressCallbacks;
 use crate::{
     Error,
+    image_format::ImageFormatKind,
     targets::{Chip, XtalFrequency},
 };
 #[cfg(feature = "serialport")]
@@ -1074,6 +1075,7 @@ impl Flasher {
     /// Load an ELF image to flash and execute it
     pub fn load_elf_to_flash(
         &mut self,
+        format: ImageFormatKind,
         elf_data: &[u8],
         flash_data: FlashData,
         mut progress: Option<&mut dyn ProgressCallbacks>,
@@ -1090,10 +1092,13 @@ impl Flasher {
                 .chip_revision(&mut self.connection)?,
         );
 
-        let image =
-            self.chip
-                .into_target()
-                .flash_image(elf_data, flash_data, chip_revision, xtal_freq)?;
+        let image = self.chip.into_target().flash_image(
+            format,
+            elf_data,
+            flash_data,
+            chip_revision,
+            xtal_freq,
+        )?;
 
         // When the `cli` feature is enabled, display the image size information.
         #[cfg(feature = "cli")]

--- a/espflash/src/flasher/mod.rs
+++ b/espflash/src/flasher/mod.rs
@@ -1037,7 +1037,7 @@ impl Flasher {
     }
 
     /// Load an ELF image to flash and execute it
-    pub fn load_elf_to_flash<'a>(
+    pub fn load_image_to_flash<'a>(
         &mut self,
         mut progress: Option<&mut dyn ProgressCallbacks>,
         image_format: ImageFormat<'a>,

--- a/espflash/src/flasher/mod.rs
+++ b/espflash/src/flasher/mod.rs
@@ -30,13 +30,17 @@ use crate::{
 #[cfg(feature = "serialport")]
 use crate::{
     connection::{
-        Connection, Port,
+        Connection,
+        Port,
         command::{Command, CommandType},
         reset::{ResetAfterOperation, ResetBeforeOperation},
     },
     error::{ConnectionError, ResultExt as _},
     flasher::stubs::{
-        CHIP_DETECT_MAGIC_REG_ADDR, DEFAULT_TIMEOUT, EXPECTED_STUB_HANDSHAKE, FlashStub,
+        CHIP_DETECT_MAGIC_REG_ADDR,
+        DEFAULT_TIMEOUT,
+        EXPECTED_STUB_HANDSHAKE,
+        FlashStub,
     },
     image_format::{ImageFormat, Segment, ram_segments, rom_segments},
 };

--- a/espflash/src/flasher/mod.rs
+++ b/espflash/src/flasher/mod.rs
@@ -477,13 +477,13 @@ impl FlashSettings {
 #[derive(Debug, Clone)]
 #[non_exhaustive]
 pub struct FlashData {
-    /// Bootloader binary.
+    // Should also probably be removed
     pub bootloader: Option<Vec<u8>>,
-    /// Partition table.
+    // // ESP-IDF ONLY
     pub partition_table: Option<PartitionTable>,
-    /// Partition table offset.
+    // // ESP-IDF ONLY
     pub partition_table_offset: Option<u32>,
-    /// Target app partition.
+    // // ESP-IDF ONLY
     pub target_app_partition: Option<String>,
     /// Flash settings.
     pub flash_settings: FlashSettings,

--- a/espflash/src/flasher/mod.rs
+++ b/espflash/src/flasher/mod.rs
@@ -1102,7 +1102,15 @@ impl Flasher {
 
         // When the `cli` feature is enabled, display the image size information.
         #[cfg(feature = "cli")]
-        crate::cli::display_image_size(image.app_size(), image.part_size());
+        {
+            let metadata = image.metadata();
+            if metadata.contains_key("app_size") && metadata.contains_key("part_size") {
+                let app_size = metadata["app_size"].parse::<u32>().unwrap();
+                let part_size = metadata["part_size"].parse::<u32>().unwrap();
+
+                crate::cli::display_image_size(app_size, Some(part_size));
+            }
+        }
 
         for segment in image.flash_segments() {
             target

--- a/espflash/src/image_format/esp_idf.rs
+++ b/espflash/src/image_format/esp_idf.rs
@@ -1,13 +1,7 @@
 //! ESP-IDF application binary image format
 
 use std::{
-    borrow::Cow,
-    collections::HashMap,
-    ffi::c_char,
-    fs,
-    io::Write,
-    iter::once,
-    mem::size_of,
+    borrow::Cow, collections::HashMap, ffi::c_char, fs, io::Write, iter::once, mem::size_of,
     path::Path,
 };
 
@@ -16,12 +10,7 @@ use esp_idf_part::{AppType, DataType, Flags, Partition, PartitionTable, SubType,
 use log::warn;
 use miette::{IntoDiagnostic, Result};
 use object::{
-    Endianness,
-    File,
-    Object,
-    ObjectSection,
-    ObjectSymbol,
-    read::elf::ElfFile32 as ElfFile,
+    Endianness, File, Object, ObjectSection, ObjectSymbol, read::elf::ElfFile32 as ElfFile,
 };
 use sha2::{Digest, Sha256};
 
@@ -628,6 +617,7 @@ impl<'a> IdfBootloaderFormat<'a> {
         ])
     }
 
+    /// Returns the partition table.
     pub fn partition_table(&self) -> PartitionTable {
         self.partition_table.clone()
     }

--- a/espflash/src/image_format/esp_idf.rs
+++ b/espflash/src/image_format/esp_idf.rs
@@ -245,8 +245,8 @@ impl AppDescriptor {
 #[derive(Debug)]
 pub struct IdfBootloaderFormat<'a> {
     boot_addr: u32,
-    pub bootloader: Cow<'a, [u8]>,
-    pub partition_table: PartitionTable,
+    bootloader: Cow<'a, [u8]>,
+    partition_table: PartitionTable,
     flash_segment: Segment<'a>,
     app_size: u32,
     partition_table_size: u32,
@@ -626,6 +626,10 @@ impl<'a> IdfBootloaderFormat<'a> {
             ("app_size", self.app_size.to_string()),
             ("part_size", self.partition_table_size.to_string()),
         ])
+    }
+
+    pub fn partition_table(&self) -> PartitionTable {
+        self.partition_table.clone()
     }
 }
 

--- a/espflash/src/image_format/esp_idf.rs
+++ b/espflash/src/image_format/esp_idf.rs
@@ -1,7 +1,13 @@
 //! ESP-IDF application binary image format
 
 use std::{
-    borrow::Cow, collections::HashMap, ffi::c_char, fs, io::Write, iter::once, mem::size_of,
+    borrow::Cow,
+    collections::HashMap,
+    ffi::c_char,
+    fs,
+    io::Write,
+    iter::once,
+    mem::size_of,
     path::Path,
 };
 
@@ -10,7 +16,12 @@ use esp_idf_part::{AppType, DataType, Flags, Partition, PartitionTable, SubType,
 use log::warn;
 use miette::{IntoDiagnostic, Result};
 use object::{
-    Endianness, File, Object, ObjectSection, ObjectSymbol, read::elf::ElfFile32 as ElfFile,
+    Endianness,
+    File,
+    Object,
+    ObjectSection,
+    ObjectSymbol,
+    read::elf::ElfFile32 as ElfFile,
 };
 use sha2::{Digest, Sha256};
 

--- a/espflash/src/image_format/esp_idf.rs
+++ b/espflash/src/image_format/esp_idf.rs
@@ -262,7 +262,7 @@ impl<'a> IdfBootloaderFormat<'a> {
         let elf = ElfFile::parse(elf_data)?;
 
         let partition_table = if let Some(partition_table_path) = partition_table_path {
-            parse_partition_table(partition_table_path.to_str().unwrap())?
+            parse_partition_table(partition_table_path)?
         } else {
             default_partition_table(
                 flash_data.chip,
@@ -783,8 +783,7 @@ fn update_checksum(data: &[u8], mut checksum: u8) -> u8 {
 }
 
 /// Parse a [PartitionTable] from the provided path
-pub fn parse_partition_table(path: &str) -> Result<PartitionTable, Error> {
-    let path = Path::new(path);
+pub fn parse_partition_table(path: &Path) -> Result<PartitionTable, Error> {
     let data = fs::read(path).map_err(|e| Error::FileOpenError(path.display().to_string(), e))?;
 
     Ok(PartitionTable::try_from(data)?)

--- a/espflash/src/image_format/esp_idf.rs
+++ b/espflash/src/image_format/esp_idf.rs
@@ -67,7 +67,11 @@ const BOOTLOADER_ESP32S2: &[u8] =
 const BOOTLOADER_ESP32S3: &[u8] =
     include_bytes!("../../resources/bootloaders/esp32s3-bootloader.bin");
 
-pub(crate) fn bootloader(chip: Chip, xtal_freq: XtalFrequency) -> Result<&'static [u8], Error> {
+/// Get the default bootloader for the given chip and crystal frequency
+pub(crate) fn default_bootloader(
+    chip: Chip,
+    xtal_freq: XtalFrequency,
+) -> Result<&'static [u8], Error> {
     let error = Error::UnsupportedFeature {
         chip,
         feature: "the selected crystal frequency".into(),
@@ -286,7 +290,7 @@ impl<'a> IdfBootloaderFormat<'a> {
             let bootloader = fs::read(bootloader_path)?;
             Cow::Owned(bootloader)
         } else {
-            let default_bootloader = bootloader(flash_data.chip, flash_data.xtal_freq)?;
+            let default_bootloader = default_bootloader(flash_data.chip, flash_data.xtal_freq)?;
             Cow::Borrowed(default_bootloader)
         };
 

--- a/espflash/src/image_format/esp_idf.rs
+++ b/espflash/src/image_format/esp_idf.rs
@@ -1,6 +1,6 @@
 //! ESP-IDF application binary image format
 
-use std::{borrow::Cow, ffi::c_char, io::Write, iter::once, mem::size_of};
+use std::{borrow::Cow, collections::HashMap, ffi::c_char, io::Write, iter::once, mem::size_of};
 
 use bytemuck::{Pod, Zeroable, bytes_of, from_bytes, pod_read_unaligned};
 use esp_idf_part::{AppType, DataType, Flags, Partition, PartitionTable, SubType, Type};
@@ -586,14 +586,12 @@ impl<'a> IdfBootloaderFormat<'a> {
         Box::new(once(self.flash_segment))
     }
 
-    /// Get the size of the application binary.
-    pub fn app_size(&self) -> u32 {
-        self.app_size
-    }
-
-    /// Get the size of the partition.
-    pub fn part_size(&self) -> Option<u32> {
-        Some(self.part_size)
+    /// Returns a map of metadata about the application image.
+    pub fn metadata(&self) -> HashMap<&str, String> {
+        HashMap::from([
+            ("app_size", self.app_size.to_string()),
+            ("part_size", self.part_size.to_string()),
+        ])
     }
 }
 

--- a/espflash/src/image_format/mod.rs
+++ b/espflash/src/image_format/mod.rs
@@ -21,8 +21,6 @@ use object::{
 use serde::{Deserialize, Serialize};
 
 pub use self::{esp_idf::IdfBootloaderFormat, metadata::Metadata};
-#[cfg(feature = "cli")]
-use crate::cli::EspIdfFormatArgs;
 use crate::targets::Chip;
 
 pub mod esp_idf;
@@ -39,26 +37,6 @@ pub enum ImageFormatKind {
     /// See: <https://docs.espressif.com/projects/esp-idf/en/stable/esp32/api-reference/system/app_image_format.html>
     #[default]
     EspIdf,
-}
-
-#[cfg(not(feature = "cli"))]
-#[derive(Debug, Clone, Default)]
-pub struct EspIdfFormatArgs {
-    /// Path to a binary ESP-IDF bootloader file
-    pub bootloader: Option<PathBuf>,
-    /// Path to a CSV file containing partition table
-    pub partition_table: Option<PathBuf>,
-    /// Partition table offset
-    pub partition_table_offset: Option<u32>,
-    /// Label of target app partition
-    pub target_app_partition: Option<String>,
-    /// Erase partitions by label
-    pub erase_parts: Option<Vec<String>>,
-}
-
-#[derive(Debug, Clone)]
-pub enum ImageFormatArgs {
-    EspIdf(EspIdfFormatArgs),
 }
 
 /// Binary application image format data

--- a/espflash/src/image_format/mod.rs
+++ b/espflash/src/image_format/mod.rs
@@ -3,6 +3,7 @@
 use std::{
     borrow::Cow,
     cmp::Ordering,
+    collections::HashMap,
     fmt::{Debug, Formatter},
     mem::take,
     ops::AddAssign,
@@ -57,6 +58,13 @@ impl<'a> ImageFormat<'a> {
     pub fn ota_segments(self) -> Vec<Segment<'a>> {
         match self {
             ImageFormat::EspIdf(idf) => idf.ota_segments().collect(),
+        }
+    }
+
+    /// Returns metadata about the application image
+    pub fn metadata(&self) -> HashMap<&str, String> {
+        match self {
+            ImageFormat::EspIdf(idf) => idf.metadata(),
         }
     }
 }

--- a/espflash/src/targets/esp32.rs
+++ b/espflash/src/targets/esp32.rs
@@ -5,7 +5,7 @@ use super::{Chip, ReadEFuse, SpiRegisters, Target, XtalFrequency, efuse::esp32 a
 use crate::connection::Connection;
 use crate::{
     Error,
-    flasher::{FlashData, FlashFrequency},
+    flasher::FlashData,
     image_format::{IdfBootloaderFormat, ImageFormat, ImageFormatArgs},
 };
 
@@ -172,15 +172,7 @@ impl Target for Esp32 {
     ) -> Result<ImageFormat<'a>, Error> {
         match &flash_data.format_args {
             ImageFormatArgs::EspIdf(_) => {
-                let idf = IdfBootloaderFormat::new(
-                    elf_data,
-                    Chip::Esp32,
-                    flash_data,
-                    xtal_freq,
-                    0x1_0000,
-                    0x3f_0000,
-                    FlashFrequency::_40Mhz,
-                )?;
+                let idf = IdfBootloaderFormat::new(elf_data, Chip::Esp32, flash_data, xtal_freq)?;
                 Ok(idf.into())
             }
         }

--- a/espflash/src/targets/esp32.rs
+++ b/espflash/src/targets/esp32.rs
@@ -1,20 +1,12 @@
 use std::ops::Range;
 
-use super::{
-    Chip,
-    Esp32Params,
-    ReadEFuse,
-    SpiRegisters,
-    Target,
-    XtalFrequency,
-    efuse::esp32 as efuse,
-};
+use super::{Chip, ReadEFuse, SpiRegisters, Target, XtalFrequency, efuse::esp32 as efuse};
 #[cfg(feature = "serialport")]
 use crate::connection::Connection;
 use crate::{
     Error,
     flasher::{FlashData, FlashFrequency},
-    image_format::{self, IdfBootloaderFormat, ImageFormat, ImageFormatKind},
+    image_format::{IdfBootloaderFormat, ImageFormat, ImageFormatKind},
 };
 
 pub(crate) const CHIP_ID: u16 = 0;
@@ -179,23 +171,17 @@ impl Target for Esp32 {
         _chip_revision: Option<(u32, u32)>,
         xtal_freq: XtalFrequency,
     ) -> Result<ImageFormat<'a>, Error> {
-        let bootloader: &'static [u8] = match format {
-            ImageFormatKind::EspIdf => image_format::esp_idf::bootloader(Chip::Esp32, xtal_freq)?,
-        };
-
-        let params = Esp32Params::new(
-            0x1000,
-            0x1_0000,
-            0x3f_0000,
-            CHIP_ID,
-            FlashFrequency::_40Mhz,
-            bootloader,
-            None,
-        );
-
         match format {
             ImageFormatKind::EspIdf => {
-                let idf = IdfBootloaderFormat::new(elf_data, Chip::Esp32, flash_data, params)?;
+                let idf = IdfBootloaderFormat::new(
+                    elf_data,
+                    Chip::Esp32,
+                    flash_data,
+                    xtal_freq,
+                    0x1_0000,
+                    0x3f_0000,
+                    FlashFrequency::_40Mhz,
+                )?;
                 Ok(idf.into())
             }
         }

--- a/espflash/src/targets/esp32.rs
+++ b/espflash/src/targets/esp32.rs
@@ -1,13 +1,9 @@
 use std::ops::Range;
 
 use super::{Chip, ReadEFuse, SpiRegisters, Target, XtalFrequency, efuse::esp32 as efuse};
+use crate::Error;
 #[cfg(feature = "serialport")]
 use crate::connection::Connection;
-use crate::{
-    Error,
-    flasher::FlashData,
-    image_format::{IdfBootloaderFormat, ImageFormat, ImageFormatArgs},
-};
 
 pub(crate) const CHIP_ID: u16 = 0;
 
@@ -161,21 +157,6 @@ impl Target for Esp32 {
         };
 
         Ok(norm_xtal)
-    }
-
-    fn flash_image<'a>(
-        &self,
-        elf_data: &'a [u8],
-        flash_data: FlashData,
-        _chip_revision: Option<(u32, u32)>,
-        xtal_freq: XtalFrequency,
-    ) -> Result<ImageFormat<'a>, Error> {
-        match &flash_data.format_args {
-            ImageFormatArgs::EspIdf(_) => {
-                let idf = IdfBootloaderFormat::new(elf_data, Chip::Esp32, flash_data, xtal_freq)?;
-                Ok(idf.into())
-            }
-        }
     }
 
     fn spi_registers(&self) -> SpiRegisters {

--- a/espflash/src/targets/esp32.rs
+++ b/espflash/src/targets/esp32.rs
@@ -5,8 +5,9 @@ use super::{Chip, ReadEFuse, SpiRegisters, Target, XtalFrequency, efuse::esp32 a
 use crate::connection::Connection;
 use crate::{
     Error,
+    cli::FormatArgs,
     flasher::{FlashData, FlashFrequency},
-    image_format::{IdfBootloaderFormat, ImageFormat, ImageFormatKind},
+    image_format::{IdfBootloaderFormat, ImageFormat},
 };
 
 pub(crate) const CHIP_ID: u16 = 0;
@@ -165,18 +166,19 @@ impl Target for Esp32 {
 
     fn flash_image<'a>(
         &self,
-        format: ImageFormatKind,
+        format_args: FormatArgs,
         elf_data: &'a [u8],
         flash_data: FlashData,
         _chip_revision: Option<(u32, u32)>,
         xtal_freq: XtalFrequency,
     ) -> Result<ImageFormat<'a>, Error> {
-        match format {
-            ImageFormatKind::EspIdf => {
+        match format_args {
+            FormatArgs::EspIdf(esp_idf_format_args) => {
                 let idf = IdfBootloaderFormat::new(
                     elf_data,
                     Chip::Esp32,
                     flash_data,
+                    esp_idf_format_args,
                     xtal_freq,
                     0x1_0000,
                     0x3f_0000,

--- a/espflash/src/targets/esp32.rs
+++ b/espflash/src/targets/esp32.rs
@@ -5,9 +5,8 @@ use super::{Chip, ReadEFuse, SpiRegisters, Target, XtalFrequency, efuse::esp32 a
 use crate::connection::Connection;
 use crate::{
     Error,
-    cli::FormatArgs,
     flasher::{FlashData, FlashFrequency},
-    image_format::{IdfBootloaderFormat, ImageFormat},
+    image_format::{IdfBootloaderFormat, ImageFormat, ImageFormatArgs},
 };
 
 pub(crate) const CHIP_ID: u16 = 0;
@@ -166,19 +165,17 @@ impl Target for Esp32 {
 
     fn flash_image<'a>(
         &self,
-        format_args: FormatArgs,
         elf_data: &'a [u8],
         flash_data: FlashData,
         _chip_revision: Option<(u32, u32)>,
         xtal_freq: XtalFrequency,
     ) -> Result<ImageFormat<'a>, Error> {
-        match format_args {
-            FormatArgs::EspIdf(esp_idf_format_args) => {
+        match &flash_data.format_args {
+            ImageFormatArgs::EspIdf(_) => {
                 let idf = IdfBootloaderFormat::new(
                     elf_data,
                     Chip::Esp32,
                     flash_data,
-                    esp_idf_format_args,
                     xtal_freq,
                     0x1_0000,
                     0x3f_0000,

--- a/espflash/src/targets/esp32c2.rs
+++ b/espflash/src/targets/esp32c2.rs
@@ -5,8 +5,9 @@ use super::{Chip, ReadEFuse, SpiRegisters, Target, XtalFrequency, efuse::esp32c2
 use crate::connection::Connection;
 use crate::{
     Error,
+    cli::FormatArgs,
     flasher::{FlashData, FlashFrequency},
-    image_format::{IdfBootloaderFormat, ImageFormat, ImageFormatKind},
+    image_format::{IdfBootloaderFormat, ImageFormat},
 };
 
 pub(crate) const CHIP_ID: u16 = 12;
@@ -100,18 +101,19 @@ impl Target for Esp32c2 {
 
     fn flash_image<'a>(
         &self,
-        format: ImageFormatKind,
+        format_args: FormatArgs,
         elf_data: &'a [u8],
         flash_data: FlashData,
         _chip_revision: Option<(u32, u32)>,
         xtal_freq: XtalFrequency,
     ) -> Result<ImageFormat<'a>, Error> {
-        match format {
-            ImageFormatKind::EspIdf => {
+        match format_args {
+            FormatArgs::EspIdf(esp_idf_format_args) => {
                 let idf = IdfBootloaderFormat::new(
                     elf_data,
                     Chip::Esp32c2,
                     flash_data,
+                    esp_idf_format_args,
                     xtal_freq,
                     0x1_0000,
                     0x1f_0000,
@@ -119,6 +121,7 @@ impl Target for Esp32c2 {
                 )?;
                 Ok(idf.into())
             }
+
         }
     }
 

--- a/espflash/src/targets/esp32c2.rs
+++ b/espflash/src/targets/esp32c2.rs
@@ -3,11 +3,7 @@ use std::{collections::HashMap, ops::Range};
 use super::{Chip, ReadEFuse, SpiRegisters, Target, XtalFrequency, efuse::esp32c2 as efuse};
 #[cfg(feature = "serialport")]
 use crate::connection::Connection;
-use crate::{
-    Error,
-    flasher::{FlashData, FlashFrequency},
-    image_format::{IdfBootloaderFormat, ImageFormat, ImageFormatArgs},
-};
+use crate::{Error, flasher::FlashFrequency};
 
 pub(crate) const CHIP_ID: u16 = 12;
 
@@ -96,21 +92,6 @@ impl Target for Esp32c2 {
         let encodings = [(_15Mhz, 0x2), (_20Mhz, 0x1), (_30Mhz, 0x0), (_60Mhz, 0xF)];
 
         HashMap::from(encodings)
-    }
-
-    fn flash_image<'a>(
-        &self,
-        elf_data: &'a [u8],
-        flash_data: FlashData,
-        _chip_revision: Option<(u32, u32)>,
-        xtal_freq: XtalFrequency,
-    ) -> Result<ImageFormat<'a>, Error> {
-        match &flash_data.format_args {
-            ImageFormatArgs::EspIdf(_) => {
-                let idf = IdfBootloaderFormat::new(elf_data, Chip::Esp32c2, flash_data, xtal_freq)?;
-                Ok(idf.into())
-            }
-        }
     }
 
     fn spi_registers(&self) -> SpiRegisters {

--- a/espflash/src/targets/esp32c2.rs
+++ b/espflash/src/targets/esp32c2.rs
@@ -107,15 +107,7 @@ impl Target for Esp32c2 {
     ) -> Result<ImageFormat<'a>, Error> {
         match &flash_data.format_args {
             ImageFormatArgs::EspIdf(_) => {
-                let idf = IdfBootloaderFormat::new(
-                    elf_data,
-                    Chip::Esp32c2,
-                    flash_data,
-                    xtal_freq,
-                    0x1_0000,
-                    0x1f_0000,
-                    FlashFrequency::_30Mhz,
-                )?;
+                let idf = IdfBootloaderFormat::new(elf_data, Chip::Esp32c2, flash_data, xtal_freq)?;
                 Ok(idf.into())
             }
         }

--- a/espflash/src/targets/esp32c2.rs
+++ b/espflash/src/targets/esp32c2.rs
@@ -5,9 +5,8 @@ use super::{Chip, ReadEFuse, SpiRegisters, Target, XtalFrequency, efuse::esp32c2
 use crate::connection::Connection;
 use crate::{
     Error,
-    cli::FormatArgs,
     flasher::{FlashData, FlashFrequency},
-    image_format::{IdfBootloaderFormat, ImageFormat},
+    image_format::{IdfBootloaderFormat, ImageFormat, ImageFormatArgs},
 };
 
 pub(crate) const CHIP_ID: u16 = 12;
@@ -101,19 +100,17 @@ impl Target for Esp32c2 {
 
     fn flash_image<'a>(
         &self,
-        format_args: FormatArgs,
         elf_data: &'a [u8],
         flash_data: FlashData,
         _chip_revision: Option<(u32, u32)>,
         xtal_freq: XtalFrequency,
     ) -> Result<ImageFormat<'a>, Error> {
-        match format_args {
-            FormatArgs::EspIdf(esp_idf_format_args) => {
+        match &flash_data.format_args {
+            ImageFormatArgs::EspIdf(_) => {
                 let idf = IdfBootloaderFormat::new(
                     elf_data,
                     Chip::Esp32c2,
                     flash_data,
-                    esp_idf_format_args,
                     xtal_freq,
                     0x1_0000,
                     0x1f_0000,
@@ -121,7 +118,6 @@ impl Target for Esp32c2 {
                 )?;
                 Ok(idf.into())
             }
-
         }
     }
 

--- a/espflash/src/targets/esp32c2.rs
+++ b/espflash/src/targets/esp32c2.rs
@@ -1,20 +1,12 @@
 use std::{collections::HashMap, ops::Range};
 
-use super::{
-    Chip,
-    Esp32Params,
-    ReadEFuse,
-    SpiRegisters,
-    Target,
-    XtalFrequency,
-    efuse::esp32c2 as efuse,
-};
+use super::{Chip, ReadEFuse, SpiRegisters, Target, XtalFrequency, efuse::esp32c2 as efuse};
 #[cfg(feature = "serialport")]
 use crate::connection::Connection;
 use crate::{
     Error,
     flasher::{FlashData, FlashFrequency},
-    image_format::{self, IdfBootloaderFormat, ImageFormat, ImageFormatKind},
+    image_format::{IdfBootloaderFormat, ImageFormat, ImageFormatKind},
 };
 
 pub(crate) const CHIP_ID: u16 = 12;
@@ -114,23 +106,17 @@ impl Target for Esp32c2 {
         _chip_revision: Option<(u32, u32)>,
         xtal_freq: XtalFrequency,
     ) -> Result<ImageFormat<'a>, Error> {
-        let bootloader: &'static [u8] = match format {
-            ImageFormatKind::EspIdf => image_format::esp_idf::bootloader(Chip::Esp32c2, xtal_freq)?,
-        };
-
-        let params = Esp32Params::new(
-            0x0,
-            0x1_0000,
-            0x1f_0000,
-            CHIP_ID,
-            FlashFrequency::_30Mhz,
-            bootloader,
-            Some(&[16 * 1024, 32 * 1024, 64 * 1024]),
-        );
-
         match format {
             ImageFormatKind::EspIdf => {
-                let idf = IdfBootloaderFormat::new(elf_data, Chip::Esp32c2, flash_data, params)?;
+                let idf = IdfBootloaderFormat::new(
+                    elf_data,
+                    Chip::Esp32c2,
+                    flash_data,
+                    xtal_freq,
+                    0x1_0000,
+                    0x1f_0000,
+                    FlashFrequency::_30Mhz,
+                )?;
                 Ok(idf.into())
             }
         }

--- a/espflash/src/targets/esp32c3.rs
+++ b/espflash/src/targets/esp32c3.rs
@@ -5,7 +5,7 @@ use super::{Chip, ReadEFuse, SpiRegisters, Target, XtalFrequency, efuse::esp32c3
 use crate::connection::Connection;
 use crate::{
     Error,
-    flasher::{FlashData, FlashFrequency},
+    flasher::FlashData,
     image_format::{IdfBootloaderFormat, ImageFormat, ImageFormatArgs},
 };
 
@@ -89,15 +89,7 @@ impl Target for Esp32c3 {
     ) -> Result<ImageFormat<'a>, Error> {
         match &flash_data.format_args {
             ImageFormatArgs::EspIdf(_) => {
-                let idf = IdfBootloaderFormat::new(
-                    elf_data,
-                    Chip::Esp32c3,
-                    flash_data,
-                    xtal_freq,
-                    0x1_0000,
-                    0x3f_0000,
-                    FlashFrequency::_40Mhz,
-                )?;
+                let idf = IdfBootloaderFormat::new(elf_data, Chip::Esp32c3, flash_data, xtal_freq)?;
                 Ok(idf.into())
             }
         }

--- a/espflash/src/targets/esp32c3.rs
+++ b/espflash/src/targets/esp32c3.rs
@@ -5,9 +5,8 @@ use super::{Chip, ReadEFuse, SpiRegisters, Target, XtalFrequency, efuse::esp32c3
 use crate::connection::Connection;
 use crate::{
     Error,
-    cli::FormatArgs,
     flasher::{FlashData, FlashFrequency},
-    image_format::{IdfBootloaderFormat, ImageFormat},
+    image_format::{IdfBootloaderFormat, ImageFormat, ImageFormatArgs},
 };
 
 pub(crate) const CHIP_ID: u16 = 5;
@@ -83,19 +82,17 @@ impl Target for Esp32c3 {
 
     fn flash_image<'a>(
         &self,
-        format_args: FormatArgs,
         elf_data: &'a [u8],
         flash_data: FlashData,
         _chip_revision: Option<(u32, u32)>,
         xtal_freq: XtalFrequency,
     ) -> Result<ImageFormat<'a>, Error> {
-        match format_args {
-            FormatArgs::EspIdf(esp_idf_format_args) => {
+        match &flash_data.format_args {
+            ImageFormatArgs::EspIdf(_) => {
                 let idf = IdfBootloaderFormat::new(
                     elf_data,
                     Chip::Esp32c3,
                     flash_data,
-                    esp_idf_format_args,
                     xtal_freq,
                     0x1_0000,
                     0x3f_0000,
@@ -103,7 +100,6 @@ impl Target for Esp32c3 {
                 )?;
                 Ok(idf.into())
             }
-
         }
     }
 

--- a/espflash/src/targets/esp32c3.rs
+++ b/espflash/src/targets/esp32c3.rs
@@ -14,7 +14,7 @@ use crate::connection::Connection;
 use crate::{
     Error,
     flasher::{FlashData, FlashFrequency},
-    image_format::IdfBootloaderFormat,
+    image_format::{self, IdfBootloaderFormat, ImageFormat, ImageFormatKind},
 };
 
 pub(crate) const CHIP_ID: u16 = 5;
@@ -30,16 +30,6 @@ const FLASH_RANGES: &[Range<u32>] = &[
     0x4200_0000..0x4280_0000, // IROM
     0x3c00_0000..0x3c80_0000, // DROM
 ];
-
-const PARAMS: Esp32Params = Esp32Params::new(
-    0x0,
-    0x1_0000,
-    0x3f_0000,
-    CHIP_ID,
-    FlashFrequency::_40Mhz,
-    include_bytes!("../../resources/bootloaders/esp32c3-bootloader.bin"),
-    None,
-);
 
 /// ESP32-C3 Target
 pub struct Esp32c3;
@@ -100,19 +90,32 @@ impl Target for Esp32c3 {
 
     fn flash_image<'a>(
         &self,
+        format: ImageFormatKind,
         elf_data: &'a [u8],
         flash_data: FlashData,
         _chip_revision: Option<(u32, u32)>,
         xtal_freq: XtalFrequency,
-    ) -> Result<IdfBootloaderFormat<'a>, Error> {
-        if xtal_freq != XtalFrequency::_40Mhz {
-            return Err(Error::UnsupportedFeature {
-                chip: Chip::Esp32c3,
-                feature: "the selected crystal frequency".into(),
-            });
-        }
+    ) -> Result<ImageFormat<'a>, Error> {
+        let bootloader: &'static [u8] = match format {
+            ImageFormatKind::EspIdf => image_format::esp_idf::bootloader(Chip::Esp32c3, xtal_freq)?,
+        };
 
-        IdfBootloaderFormat::new(elf_data, Chip::Esp32c3, flash_data, PARAMS)
+        let params = Esp32Params::new(
+            0x0,
+            0x1_0000,
+            0x3f_0000,
+            CHIP_ID,
+            FlashFrequency::_40Mhz,
+            bootloader,
+            None,
+        );
+
+        match format {
+            ImageFormatKind::EspIdf => {
+                let idf = IdfBootloaderFormat::new(elf_data, Chip::Esp32c3, flash_data, params)?;
+                Ok(idf.into())
+            }
+        }
     }
 
     fn spi_registers(&self) -> SpiRegisters {

--- a/espflash/src/targets/esp32c3.rs
+++ b/espflash/src/targets/esp32c3.rs
@@ -1,20 +1,12 @@
 use std::ops::Range;
 
-use super::{
-    Chip,
-    Esp32Params,
-    ReadEFuse,
-    SpiRegisters,
-    Target,
-    XtalFrequency,
-    efuse::esp32c3 as efuse,
-};
+use super::{Chip, ReadEFuse, SpiRegisters, Target, XtalFrequency, efuse::esp32c3 as efuse};
 #[cfg(feature = "serialport")]
 use crate::connection::Connection;
 use crate::{
     Error,
     flasher::{FlashData, FlashFrequency},
-    image_format::{self, IdfBootloaderFormat, ImageFormat, ImageFormatKind},
+    image_format::{IdfBootloaderFormat, ImageFormat, ImageFormatKind},
 };
 
 pub(crate) const CHIP_ID: u16 = 5;
@@ -96,23 +88,21 @@ impl Target for Esp32c3 {
         _chip_revision: Option<(u32, u32)>,
         xtal_freq: XtalFrequency,
     ) -> Result<ImageFormat<'a>, Error> {
-        let bootloader: &'static [u8] = match format {
-            ImageFormatKind::EspIdf => image_format::esp_idf::bootloader(Chip::Esp32c3, xtal_freq)?,
-        };
-
-        let params = Esp32Params::new(
-            0x0,
-            0x1_0000,
-            0x3f_0000,
-            CHIP_ID,
-            FlashFrequency::_40Mhz,
-            bootloader,
-            None,
-        );
+        // let bootloader: &'static [u8] = match format {
+        //     ImageFormatKind::EspIdf =>
+        // image_format::esp_idf::bootloader(Chip::Esp32c3, xtal_freq)?, };
 
         match format {
             ImageFormatKind::EspIdf => {
-                let idf = IdfBootloaderFormat::new(elf_data, Chip::Esp32c3, flash_data, params)?;
+                let idf = IdfBootloaderFormat::new(
+                    elf_data,
+                    Chip::Esp32c3,
+                    flash_data,
+                    xtal_freq,
+                    0x1_0000,
+                    0x3f_0000,
+                    FlashFrequency::_40Mhz,
+                )?;
                 Ok(idf.into())
             }
         }

--- a/espflash/src/targets/esp32c3.rs
+++ b/espflash/src/targets/esp32c3.rs
@@ -5,8 +5,9 @@ use super::{Chip, ReadEFuse, SpiRegisters, Target, XtalFrequency, efuse::esp32c3
 use crate::connection::Connection;
 use crate::{
     Error,
+    cli::FormatArgs,
     flasher::{FlashData, FlashFrequency},
-    image_format::{IdfBootloaderFormat, ImageFormat, ImageFormatKind},
+    image_format::{IdfBootloaderFormat, ImageFormat},
 };
 
 pub(crate) const CHIP_ID: u16 = 5;
@@ -82,22 +83,19 @@ impl Target for Esp32c3 {
 
     fn flash_image<'a>(
         &self,
-        format: ImageFormatKind,
+        format_args: FormatArgs,
         elf_data: &'a [u8],
         flash_data: FlashData,
         _chip_revision: Option<(u32, u32)>,
         xtal_freq: XtalFrequency,
     ) -> Result<ImageFormat<'a>, Error> {
-        // let bootloader: &'static [u8] = match format {
-        //     ImageFormatKind::EspIdf =>
-        // image_format::esp_idf::bootloader(Chip::Esp32c3, xtal_freq)?, };
-
-        match format {
-            ImageFormatKind::EspIdf => {
+        match format_args {
+            FormatArgs::EspIdf(esp_idf_format_args) => {
                 let idf = IdfBootloaderFormat::new(
                     elf_data,
                     Chip::Esp32c3,
                     flash_data,
+                    esp_idf_format_args,
                     xtal_freq,
                     0x1_0000,
                     0x3f_0000,
@@ -105,6 +103,7 @@ impl Target for Esp32c3 {
                 )?;
                 Ok(idf.into())
             }
+
         }
     }
 

--- a/espflash/src/targets/esp32c3.rs
+++ b/espflash/src/targets/esp32c3.rs
@@ -1,13 +1,9 @@
 use std::ops::Range;
 
 use super::{Chip, ReadEFuse, SpiRegisters, Target, XtalFrequency, efuse::esp32c3 as efuse};
+use crate::Error;
 #[cfg(feature = "serialport")]
 use crate::connection::Connection;
-use crate::{
-    Error,
-    flasher::FlashData,
-    image_format::{IdfBootloaderFormat, ImageFormat, ImageFormatArgs},
-};
 
 pub(crate) const CHIP_ID: u16 = 5;
 
@@ -78,21 +74,6 @@ impl Target for Esp32c3 {
     fn crystal_freq(&self, _connection: &mut Connection) -> Result<XtalFrequency, Error> {
         // The ESP32-C3's XTAL has a fixed frequency of 40MHz.
         Ok(XtalFrequency::_40Mhz)
-    }
-
-    fn flash_image<'a>(
-        &self,
-        elf_data: &'a [u8],
-        flash_data: FlashData,
-        _chip_revision: Option<(u32, u32)>,
-        xtal_freq: XtalFrequency,
-    ) -> Result<ImageFormat<'a>, Error> {
-        match &flash_data.format_args {
-            ImageFormatArgs::EspIdf(_) => {
-                let idf = IdfBootloaderFormat::new(elf_data, Chip::Esp32c3, flash_data, xtal_freq)?;
-                Ok(idf.into())
-            }
-        }
     }
 
     fn spi_registers(&self) -> SpiRegisters {

--- a/espflash/src/targets/esp32c5.rs
+++ b/espflash/src/targets/esp32c5.rs
@@ -1,20 +1,12 @@
 use std::ops::Range;
 
-use super::{
-    Chip,
-    Esp32Params,
-    ReadEFuse,
-    SpiRegisters,
-    Target,
-    XtalFrequency,
-    efuse::esp32c5 as efuse,
-};
+use super::{Chip, ReadEFuse, SpiRegisters, Target, XtalFrequency, efuse::esp32c5 as efuse};
 #[cfg(feature = "serialport")]
 use crate::connection::Connection;
 use crate::{
     Error,
     flasher::{FlashData, FlashFrequency},
-    image_format::{self, IdfBootloaderFormat, ImageFormat, ImageFormatKind},
+    image_format::{IdfBootloaderFormat, ImageFormat, ImageFormatKind},
 };
 
 pub(crate) const CHIP_ID: u16 = 23;
@@ -108,23 +100,17 @@ impl Target for Esp32c5 {
         _chip_revision: Option<(u32, u32)>,
         xtal_freq: XtalFrequency,
     ) -> Result<ImageFormat<'a>, Error> {
-        let bootloader: &'static [u8] = match format {
-            ImageFormatKind::EspIdf => image_format::esp_idf::bootloader(Chip::Esp32c5, xtal_freq)?,
-        };
-
-        let params = Esp32Params::new(
-            0x2000,
-            0x1_0000,
-            0x3f_0000,
-            CHIP_ID,
-            FlashFrequency::_40Mhz,
-            bootloader,
-            None,
-        );
-
         match format {
             ImageFormatKind::EspIdf => {
-                let idf = IdfBootloaderFormat::new(elf_data, Chip::Esp32c5, flash_data, params)?;
+                let idf = IdfBootloaderFormat::new(
+                    elf_data,
+                    Chip::Esp32c5,
+                    flash_data,
+                    xtal_freq,
+                    0x1_0000,
+                    0x3f_0000,
+                    FlashFrequency::_40Mhz,
+                )?;
                 Ok(idf.into())
             }
         }

--- a/espflash/src/targets/esp32c5.rs
+++ b/espflash/src/targets/esp32c5.rs
@@ -5,8 +5,9 @@ use super::{Chip, ReadEFuse, SpiRegisters, Target, XtalFrequency, efuse::esp32c5
 use crate::connection::Connection;
 use crate::{
     Error,
+    cli::FormatArgs,
     flasher::{FlashData, FlashFrequency},
-    image_format::{IdfBootloaderFormat, ImageFormat, ImageFormatKind},
+    image_format::{IdfBootloaderFormat, ImageFormat},
 };
 
 pub(crate) const CHIP_ID: u16 = 23;
@@ -94,18 +95,19 @@ impl Target for Esp32c5 {
 
     fn flash_image<'a>(
         &self,
-        format: ImageFormatKind,
+        format_args: FormatArgs,
         elf_data: &'a [u8],
         flash_data: FlashData,
         _chip_revision: Option<(u32, u32)>,
         xtal_freq: XtalFrequency,
     ) -> Result<ImageFormat<'a>, Error> {
-        match format {
-            ImageFormatKind::EspIdf => {
+        match format_args {
+            FormatArgs::EspIdf(esp_idf_format_args) => {
                 let idf = IdfBootloaderFormat::new(
                     elf_data,
                     Chip::Esp32c5,
                     flash_data,
+                    esp_idf_format_args,
                     xtal_freq,
                     0x1_0000,
                     0x3f_0000,
@@ -113,6 +115,7 @@ impl Target for Esp32c5 {
                 )?;
                 Ok(idf.into())
             }
+
         }
     }
 

--- a/espflash/src/targets/esp32c5.rs
+++ b/espflash/src/targets/esp32c5.rs
@@ -5,9 +5,8 @@ use super::{Chip, ReadEFuse, SpiRegisters, Target, XtalFrequency, efuse::esp32c5
 use crate::connection::Connection;
 use crate::{
     Error,
-    cli::FormatArgs,
     flasher::{FlashData, FlashFrequency},
-    image_format::{IdfBootloaderFormat, ImageFormat},
+    image_format::{IdfBootloaderFormat, ImageFormat, ImageFormatArgs},
 };
 
 pub(crate) const CHIP_ID: u16 = 23;
@@ -95,19 +94,17 @@ impl Target for Esp32c5 {
 
     fn flash_image<'a>(
         &self,
-        format_args: FormatArgs,
         elf_data: &'a [u8],
         flash_data: FlashData,
         _chip_revision: Option<(u32, u32)>,
         xtal_freq: XtalFrequency,
     ) -> Result<ImageFormat<'a>, Error> {
-        match format_args {
-            FormatArgs::EspIdf(esp_idf_format_args) => {
+        match &flash_data.format_args {
+            ImageFormatArgs::EspIdf(_) => {
                 let idf = IdfBootloaderFormat::new(
                     elf_data,
                     Chip::Esp32c5,
                     flash_data,
-                    esp_idf_format_args,
                     xtal_freq,
                     0x1_0000,
                     0x3f_0000,
@@ -115,7 +112,6 @@ impl Target for Esp32c5 {
                 )?;
                 Ok(idf.into())
             }
-
         }
     }
 

--- a/espflash/src/targets/esp32c5.rs
+++ b/espflash/src/targets/esp32c5.rs
@@ -5,7 +5,7 @@ use super::{Chip, ReadEFuse, SpiRegisters, Target, XtalFrequency, efuse::esp32c5
 use crate::connection::Connection;
 use crate::{
     Error,
-    flasher::{FlashData, FlashFrequency},
+    flasher::FlashData,
     image_format::{IdfBootloaderFormat, ImageFormat, ImageFormatArgs},
 };
 
@@ -101,15 +101,7 @@ impl Target for Esp32c5 {
     ) -> Result<ImageFormat<'a>, Error> {
         match &flash_data.format_args {
             ImageFormatArgs::EspIdf(_) => {
-                let idf = IdfBootloaderFormat::new(
-                    elf_data,
-                    Chip::Esp32c5,
-                    flash_data,
-                    xtal_freq,
-                    0x1_0000,
-                    0x3f_0000,
-                    FlashFrequency::_40Mhz,
-                )?;
+                let idf = IdfBootloaderFormat::new(elf_data, Chip::Esp32c5, flash_data, xtal_freq)?;
                 Ok(idf.into())
             }
         }

--- a/espflash/src/targets/esp32c5.rs
+++ b/espflash/src/targets/esp32c5.rs
@@ -1,13 +1,9 @@
 use std::ops::Range;
 
 use super::{Chip, ReadEFuse, SpiRegisters, Target, XtalFrequency, efuse::esp32c5 as efuse};
+use crate::Error;
 #[cfg(feature = "serialport")]
 use crate::connection::Connection;
-use crate::{
-    Error,
-    flasher::FlashData,
-    image_format::{IdfBootloaderFormat, ImageFormat, ImageFormatArgs},
-};
 
 pub(crate) const CHIP_ID: u16 = 23;
 
@@ -90,21 +86,6 @@ impl Target for Esp32c5 {
         };
 
         Ok(norm_xtal)
-    }
-
-    fn flash_image<'a>(
-        &self,
-        elf_data: &'a [u8],
-        flash_data: FlashData,
-        _chip_revision: Option<(u32, u32)>,
-        xtal_freq: XtalFrequency,
-    ) -> Result<ImageFormat<'a>, Error> {
-        match &flash_data.format_args {
-            ImageFormatArgs::EspIdf(_) => {
-                let idf = IdfBootloaderFormat::new(elf_data, Chip::Esp32c5, flash_data, xtal_freq)?;
-                Ok(idf.into())
-            }
-        }
     }
 
     fn spi_registers(&self) -> SpiRegisters {

--- a/espflash/src/targets/esp32c6.rs
+++ b/espflash/src/targets/esp32c6.rs
@@ -5,9 +5,8 @@ use super::{Chip, ReadEFuse, SpiRegisters, Target, XtalFrequency, efuse::esp32c6
 use crate::connection::Connection;
 use crate::{
     Error,
-    cli::FormatArgs,
     flasher::{FlashData, FlashFrequency},
-    image_format::{IdfBootloaderFormat, ImageFormat},
+    image_format::{IdfBootloaderFormat, ImageFormat, ImageFormatArgs},
 };
 
 pub(crate) const CHIP_ID: u16 = 13;
@@ -75,19 +74,17 @@ impl Target for Esp32c6 {
 
     fn flash_image<'a>(
         &self,
-        format_args: FormatArgs,
         elf_data: &'a [u8],
         flash_data: FlashData,
         _chip_revision: Option<(u32, u32)>,
         xtal_freq: XtalFrequency,
     ) -> Result<ImageFormat<'a>, Error> {
-        match format_args {
-            FormatArgs::EspIdf(esp_idf_format_args) => {
+        match &flash_data.format_args {
+            ImageFormatArgs::EspIdf(_) => {
                 let idf = IdfBootloaderFormat::new(
                     elf_data,
                     Chip::Esp32c6,
                     flash_data,
-                    esp_idf_format_args,
                     xtal_freq,
                     0x1_0000,
                     0x3f_0000,

--- a/espflash/src/targets/esp32c6.rs
+++ b/espflash/src/targets/esp32c6.rs
@@ -1,20 +1,12 @@
 use std::ops::Range;
 
-use super::{
-    Chip,
-    Esp32Params,
-    ReadEFuse,
-    SpiRegisters,
-    Target,
-    XtalFrequency,
-    efuse::esp32c6 as efuse,
-};
+use super::{Chip, ReadEFuse, SpiRegisters, Target, XtalFrequency, efuse::esp32c6 as efuse};
 #[cfg(feature = "serialport")]
 use crate::connection::Connection;
 use crate::{
     Error,
     flasher::{FlashData, FlashFrequency},
-    image_format::{self, IdfBootloaderFormat, ImageFormat, ImageFormatKind},
+    image_format::{IdfBootloaderFormat, ImageFormat, ImageFormatKind},
 };
 
 pub(crate) const CHIP_ID: u16 = 13;
@@ -88,23 +80,17 @@ impl Target for Esp32c6 {
         _chip_revision: Option<(u32, u32)>,
         xtal_freq: XtalFrequency,
     ) -> Result<ImageFormat<'a>, Error> {
-        let bootloader: &'static [u8] = match format {
-            ImageFormatKind::EspIdf => image_format::esp_idf::bootloader(Chip::Esp32c6, xtal_freq)?,
-        };
-
-        let params = Esp32Params::new(
-            0x0,
-            0x1_0000,
-            0x3f_0000,
-            CHIP_ID,
-            FlashFrequency::_40Mhz,
-            bootloader,
-            Some(&[8 * 1024, 16 * 1024, 32 * 1024, 64 * 1024]),
-        );
-
         match format {
             ImageFormatKind::EspIdf => {
-                let idf = IdfBootloaderFormat::new(elf_data, Chip::Esp32c6, flash_data, params)?;
+                let idf = IdfBootloaderFormat::new(
+                    elf_data,
+                    Chip::Esp32c6,
+                    flash_data,
+                    xtal_freq,
+                    0x1_0000,
+                    0x3f_0000,
+                    FlashFrequency::_40Mhz,
+                )?;
                 Ok(idf.into())
             }
         }

--- a/espflash/src/targets/esp32c6.rs
+++ b/espflash/src/targets/esp32c6.rs
@@ -5,8 +5,9 @@ use super::{Chip, ReadEFuse, SpiRegisters, Target, XtalFrequency, efuse::esp32c6
 use crate::connection::Connection;
 use crate::{
     Error,
+    cli::FormatArgs,
     flasher::{FlashData, FlashFrequency},
-    image_format::{IdfBootloaderFormat, ImageFormat, ImageFormatKind},
+    image_format::{IdfBootloaderFormat, ImageFormat},
 };
 
 pub(crate) const CHIP_ID: u16 = 13;
@@ -74,18 +75,19 @@ impl Target for Esp32c6 {
 
     fn flash_image<'a>(
         &self,
-        format: ImageFormatKind,
+        format_args: FormatArgs,
         elf_data: &'a [u8],
         flash_data: FlashData,
         _chip_revision: Option<(u32, u32)>,
         xtal_freq: XtalFrequency,
     ) -> Result<ImageFormat<'a>, Error> {
-        match format {
-            ImageFormatKind::EspIdf => {
+        match format_args {
+            FormatArgs::EspIdf(esp_idf_format_args) => {
                 let idf = IdfBootloaderFormat::new(
                     elf_data,
                     Chip::Esp32c6,
                     flash_data,
+                    esp_idf_format_args,
                     xtal_freq,
                     0x1_0000,
                     0x3f_0000,

--- a/espflash/src/targets/esp32c6.rs
+++ b/espflash/src/targets/esp32c6.rs
@@ -1,13 +1,9 @@
 use std::ops::Range;
 
 use super::{Chip, ReadEFuse, SpiRegisters, Target, XtalFrequency, efuse::esp32c6 as efuse};
+use crate::Error;
 #[cfg(feature = "serialport")]
 use crate::connection::Connection;
-use crate::{
-    Error,
-    flasher::FlashData,
-    image_format::{IdfBootloaderFormat, ImageFormat, ImageFormatArgs},
-};
 
 pub(crate) const CHIP_ID: u16 = 13;
 
@@ -70,21 +66,6 @@ impl Target for Esp32c6 {
     fn crystal_freq(&self, _connection: &mut Connection) -> Result<XtalFrequency, Error> {
         // The ESP32-C6's XTAL has a fixed frequency of 40MHz.
         Ok(XtalFrequency::_40Mhz)
-    }
-
-    fn flash_image<'a>(
-        &self,
-        elf_data: &'a [u8],
-        flash_data: FlashData,
-        _chip_revision: Option<(u32, u32)>,
-        xtal_freq: XtalFrequency,
-    ) -> Result<ImageFormat<'a>, Error> {
-        match &flash_data.format_args {
-            ImageFormatArgs::EspIdf(_) => {
-                let idf = IdfBootloaderFormat::new(elf_data, Chip::Esp32c6, flash_data, xtal_freq)?;
-                Ok(idf.into())
-            }
-        }
     }
 
     fn spi_registers(&self) -> SpiRegisters {

--- a/espflash/src/targets/esp32c6.rs
+++ b/espflash/src/targets/esp32c6.rs
@@ -5,7 +5,7 @@ use super::{Chip, ReadEFuse, SpiRegisters, Target, XtalFrequency, efuse::esp32c6
 use crate::connection::Connection;
 use crate::{
     Error,
-    flasher::{FlashData, FlashFrequency},
+    flasher::FlashData,
     image_format::{IdfBootloaderFormat, ImageFormat, ImageFormatArgs},
 };
 
@@ -81,15 +81,7 @@ impl Target for Esp32c6 {
     ) -> Result<ImageFormat<'a>, Error> {
         match &flash_data.format_args {
             ImageFormatArgs::EspIdf(_) => {
-                let idf = IdfBootloaderFormat::new(
-                    elf_data,
-                    Chip::Esp32c6,
-                    flash_data,
-                    xtal_freq,
-                    0x1_0000,
-                    0x3f_0000,
-                    FlashFrequency::_40Mhz,
-                )?;
+                let idf = IdfBootloaderFormat::new(elf_data, Chip::Esp32c6, flash_data, xtal_freq)?;
                 Ok(idf.into())
             }
         }

--- a/espflash/src/targets/esp32h2.rs
+++ b/espflash/src/targets/esp32h2.rs
@@ -1,20 +1,12 @@
 use std::{collections::HashMap, ops::Range};
 
-use super::{
-    Chip,
-    Esp32Params,
-    ReadEFuse,
-    SpiRegisters,
-    Target,
-    XtalFrequency,
-    efuse::esp32h2 as efuse,
-};
+use super::{Chip, ReadEFuse, SpiRegisters, Target, XtalFrequency, efuse::esp32h2 as efuse};
 #[cfg(feature = "serialport")]
 use crate::connection::Connection;
 use crate::{
     Error,
     flasher::{FlashData, FlashFrequency},
-    image_format::{self, IdfBootloaderFormat, ImageFormat, ImageFormatKind},
+    image_format::{IdfBootloaderFormat, ImageFormat, ImageFormatKind},
 };
 
 pub(crate) const CHIP_ID: u16 = 16;
@@ -96,23 +88,17 @@ impl Target for Esp32h2 {
         _chip_revision: Option<(u32, u32)>,
         xtal_freq: XtalFrequency,
     ) -> Result<ImageFormat<'a>, Error> {
-        let bootloader: &'static [u8] = match format {
-            ImageFormatKind::EspIdf => image_format::esp_idf::bootloader(Chip::Esp32h2, xtal_freq)?,
-        };
-
-        let params = Esp32Params::new(
-            0x0,
-            0x1_0000,
-            0x3f_0000,
-            CHIP_ID,
-            FlashFrequency::_24Mhz,
-            bootloader,
-            Some(&[8 * 1024, 16 * 1024, 32 * 1024, 64 * 1024]),
-        );
-
         match format {
             ImageFormatKind::EspIdf => {
-                let idf = IdfBootloaderFormat::new(elf_data, Chip::Esp32h2, flash_data, params)?;
+                let idf = IdfBootloaderFormat::new(
+                    elf_data,
+                    Chip::Esp32h2,
+                    flash_data,
+                    xtal_freq,
+                    0x1_0000,
+                    0x3f_0000,
+                    FlashFrequency::_24Mhz,
+                )?;
                 Ok(idf.into())
             }
         }

--- a/espflash/src/targets/esp32h2.rs
+++ b/espflash/src/targets/esp32h2.rs
@@ -5,9 +5,8 @@ use super::{Chip, ReadEFuse, SpiRegisters, Target, XtalFrequency, efuse::esp32h2
 use crate::connection::Connection;
 use crate::{
     Error,
-    cli::FormatArgs,
     flasher::{FlashData, FlashFrequency},
-    image_format::{IdfBootloaderFormat, ImageFormat},
+    image_format::{IdfBootloaderFormat, ImageFormat, ImageFormatArgs},
 };
 
 pub(crate) const CHIP_ID: u16 = 16;
@@ -83,19 +82,17 @@ impl Target for Esp32h2 {
 
     fn flash_image<'a>(
         &self,
-        format_args: FormatArgs,
         elf_data: &'a [u8],
         flash_data: FlashData,
         _chip_revision: Option<(u32, u32)>,
         xtal_freq: XtalFrequency,
     ) -> Result<ImageFormat<'a>, Error> {
-        match format_args {
-            FormatArgs::EspIdf(esp_idf_format_args) => {
+        match &flash_data.format_args {
+            ImageFormatArgs::EspIdf(_) => {
                 let idf = IdfBootloaderFormat::new(
                     elf_data,
                     Chip::Esp32h2,
                     flash_data,
-                    esp_idf_format_args,
                     xtal_freq,
                     0x1_0000,
                     0x3f_0000,
@@ -103,7 +100,6 @@ impl Target for Esp32h2 {
                 )?;
                 Ok(idf.into())
             }
-
         }
     }
 

--- a/espflash/src/targets/esp32h2.rs
+++ b/espflash/src/targets/esp32h2.rs
@@ -3,11 +3,7 @@ use std::{collections::HashMap, ops::Range};
 use super::{Chip, ReadEFuse, SpiRegisters, Target, XtalFrequency, efuse::esp32h2 as efuse};
 #[cfg(feature = "serialport")]
 use crate::connection::Connection;
-use crate::{
-    Error,
-    flasher::{FlashData, FlashFrequency},
-    image_format::{IdfBootloaderFormat, ImageFormat, ImageFormatArgs},
-};
+use crate::{Error, flasher::FlashFrequency};
 
 pub(crate) const CHIP_ID: u16 = 16;
 
@@ -78,21 +74,6 @@ impl Target for Esp32h2 {
         let encodings = [(_12Mhz, 0x2), (_16Mhz, 0x1), (_24Mhz, 0x0), (_48Mhz, 0xF)];
 
         HashMap::from(encodings)
-    }
-
-    fn flash_image<'a>(
-        &self,
-        elf_data: &'a [u8],
-        flash_data: FlashData,
-        _chip_revision: Option<(u32, u32)>,
-        xtal_freq: XtalFrequency,
-    ) -> Result<ImageFormat<'a>, Error> {
-        match &flash_data.format_args {
-            ImageFormatArgs::EspIdf(_) => {
-                let idf = IdfBootloaderFormat::new(elf_data, Chip::Esp32h2, flash_data, xtal_freq)?;
-                Ok(idf.into())
-            }
-        }
     }
 
     fn spi_registers(&self) -> SpiRegisters {

--- a/espflash/src/targets/esp32h2.rs
+++ b/espflash/src/targets/esp32h2.rs
@@ -14,7 +14,7 @@ use crate::connection::Connection;
 use crate::{
     Error,
     flasher::{FlashData, FlashFrequency},
-    image_format::IdfBootloaderFormat,
+    image_format::{self, IdfBootloaderFormat, ImageFormat, ImageFormatKind},
 };
 
 pub(crate) const CHIP_ID: u16 = 16;
@@ -25,16 +25,6 @@ const FLASH_RANGES: &[Range<u32>] = &[
     0x4200_0000..0x4280_0000, // IROM
     0x4280_0000..0x4300_0000, // DROM
 ];
-
-const PARAMS: Esp32Params = Esp32Params::new(
-    0x0,
-    0x1_0000,
-    0x3f_0000,
-    CHIP_ID,
-    FlashFrequency::_24Mhz,
-    include_bytes!("../../resources/bootloaders/esp32h2-bootloader.bin"),
-    Some(&[8 * 1024, 16 * 1024, 32 * 1024, 64 * 1024]),
-);
 
 /// ESP32-H2 Target
 pub struct Esp32h2;
@@ -100,19 +90,32 @@ impl Target for Esp32h2 {
 
     fn flash_image<'a>(
         &self,
+        format: ImageFormatKind,
         elf_data: &'a [u8],
         flash_data: FlashData,
         _chip_revision: Option<(u32, u32)>,
         xtal_freq: XtalFrequency,
-    ) -> Result<IdfBootloaderFormat<'a>, Error> {
-        if xtal_freq != XtalFrequency::_32Mhz {
-            return Err(Error::UnsupportedFeature {
-                chip: Chip::Esp32h2,
-                feature: "the selected crystal frequency".into(),
-            });
-        }
+    ) -> Result<ImageFormat<'a>, Error> {
+        let bootloader: &'static [u8] = match format {
+            ImageFormatKind::EspIdf => image_format::esp_idf::bootloader(Chip::Esp32h2, xtal_freq)?,
+        };
 
-        IdfBootloaderFormat::new(elf_data, Chip::Esp32h2, flash_data, PARAMS)
+        let params = Esp32Params::new(
+            0x0,
+            0x1_0000,
+            0x3f_0000,
+            CHIP_ID,
+            FlashFrequency::_24Mhz,
+            bootloader,
+            Some(&[8 * 1024, 16 * 1024, 32 * 1024, 64 * 1024]),
+        );
+
+        match format {
+            ImageFormatKind::EspIdf => {
+                let idf = IdfBootloaderFormat::new(elf_data, Chip::Esp32h2, flash_data, params)?;
+                Ok(idf.into())
+            }
+        }
     }
 
     fn spi_registers(&self) -> SpiRegisters {

--- a/espflash/src/targets/esp32h2.rs
+++ b/espflash/src/targets/esp32h2.rs
@@ -5,8 +5,9 @@ use super::{Chip, ReadEFuse, SpiRegisters, Target, XtalFrequency, efuse::esp32h2
 use crate::connection::Connection;
 use crate::{
     Error,
+    cli::FormatArgs,
     flasher::{FlashData, FlashFrequency},
-    image_format::{IdfBootloaderFormat, ImageFormat, ImageFormatKind},
+    image_format::{IdfBootloaderFormat, ImageFormat},
 };
 
 pub(crate) const CHIP_ID: u16 = 16;
@@ -82,18 +83,19 @@ impl Target for Esp32h2 {
 
     fn flash_image<'a>(
         &self,
-        format: ImageFormatKind,
+        format_args: FormatArgs,
         elf_data: &'a [u8],
         flash_data: FlashData,
         _chip_revision: Option<(u32, u32)>,
         xtal_freq: XtalFrequency,
     ) -> Result<ImageFormat<'a>, Error> {
-        match format {
-            ImageFormatKind::EspIdf => {
+        match format_args {
+            FormatArgs::EspIdf(esp_idf_format_args) => {
                 let idf = IdfBootloaderFormat::new(
                     elf_data,
                     Chip::Esp32h2,
                     flash_data,
+                    esp_idf_format_args,
                     xtal_freq,
                     0x1_0000,
                     0x3f_0000,
@@ -101,6 +103,7 @@ impl Target for Esp32h2 {
                 )?;
                 Ok(idf.into())
             }
+
         }
     }
 

--- a/espflash/src/targets/esp32h2.rs
+++ b/espflash/src/targets/esp32h2.rs
@@ -89,15 +89,7 @@ impl Target for Esp32h2 {
     ) -> Result<ImageFormat<'a>, Error> {
         match &flash_data.format_args {
             ImageFormatArgs::EspIdf(_) => {
-                let idf = IdfBootloaderFormat::new(
-                    elf_data,
-                    Chip::Esp32h2,
-                    flash_data,
-                    xtal_freq,
-                    0x1_0000,
-                    0x3f_0000,
-                    FlashFrequency::_24Mhz,
-                )?;
+                let idf = IdfBootloaderFormat::new(elf_data, Chip::Esp32h2, flash_data, xtal_freq)?;
                 Ok(idf.into())
             }
         }

--- a/espflash/src/targets/esp32p4.rs
+++ b/espflash/src/targets/esp32p4.rs
@@ -1,20 +1,12 @@
 use std::ops::Range;
 
-use super::{
-    Chip,
-    Esp32Params,
-    ReadEFuse,
-    SpiRegisters,
-    Target,
-    XtalFrequency,
-    efuse::esp32p4 as efuse,
-};
+use super::{Chip, ReadEFuse, SpiRegisters, Target, XtalFrequency, efuse::esp32p4 as efuse};
 #[cfg(feature = "serialport")]
 use crate::connection::Connection;
 use crate::{
     Error,
     flasher::{FlashData, FlashFrequency},
-    image_format::{self, IdfBootloaderFormat, ImageFormat, ImageFormatKind},
+    image_format::{IdfBootloaderFormat, ImageFormat, ImageFormatKind},
 };
 
 pub(crate) const CHIP_ID: u16 = 18;
@@ -88,23 +80,17 @@ impl Target for Esp32p4 {
         _chip_revision: Option<(u32, u32)>,
         xtal_freq: XtalFrequency,
     ) -> Result<ImageFormat<'a>, Error> {
-        let bootloader: &'static [u8] = match format {
-            ImageFormatKind::EspIdf => image_format::esp_idf::bootloader(Chip::Esp32p4, xtal_freq)?,
-        };
-
-        let params = Esp32Params::new(
-            0x2000,
-            0x1_0000,
-            0x3f_0000,
-            CHIP_ID,
-            FlashFrequency::_40Mhz,
-            bootloader,
-            None,
-        );
-
         match format {
             ImageFormatKind::EspIdf => {
-                let idf = IdfBootloaderFormat::new(elf_data, Chip::Esp32p4, flash_data, params)?;
+                let idf = IdfBootloaderFormat::new(
+                    elf_data,
+                    Chip::Esp32p4,
+                    flash_data,
+                    xtal_freq,
+                    0x1_0000,
+                    0x3f_0000,
+                    FlashFrequency::_40Mhz,
+                )?;
                 Ok(idf.into())
             }
         }

--- a/espflash/src/targets/esp32p4.rs
+++ b/espflash/src/targets/esp32p4.rs
@@ -1,13 +1,9 @@
 use std::ops::Range;
 
 use super::{Chip, ReadEFuse, SpiRegisters, Target, XtalFrequency, efuse::esp32p4 as efuse};
+use crate::Error;
 #[cfg(feature = "serialport")]
 use crate::connection::Connection;
-use crate::{
-    Error,
-    flasher::FlashData,
-    image_format::{IdfBootloaderFormat, ImageFormat, ImageFormatArgs},
-};
 
 pub(crate) const CHIP_ID: u16 = 18;
 
@@ -70,21 +66,6 @@ impl Target for Esp32p4 {
     fn crystal_freq(&self, _connection: &mut Connection) -> Result<XtalFrequency, Error> {
         // The ESP32-P4's XTAL has a fixed frequency of 40MHz.
         Ok(XtalFrequency::_40Mhz)
-    }
-
-    fn flash_image<'a>(
-        &self,
-        elf_data: &'a [u8],
-        flash_data: FlashData,
-        _chip_revision: Option<(u32, u32)>,
-        xtal_freq: XtalFrequency,
-    ) -> Result<ImageFormat<'a>, Error> {
-        match &flash_data.format_args {
-            ImageFormatArgs::EspIdf(_) => {
-                let idf = IdfBootloaderFormat::new(elf_data, Chip::Esp32p4, flash_data, xtal_freq)?;
-                Ok(idf.into())
-            }
-        }
     }
 
     fn spi_registers(&self) -> SpiRegisters {

--- a/espflash/src/targets/esp32p4.rs
+++ b/espflash/src/targets/esp32p4.rs
@@ -5,8 +5,9 @@ use super::{Chip, ReadEFuse, SpiRegisters, Target, XtalFrequency, efuse::esp32p4
 use crate::connection::Connection;
 use crate::{
     Error,
+    cli::FormatArgs,
     flasher::{FlashData, FlashFrequency},
-    image_format::{IdfBootloaderFormat, ImageFormat, ImageFormatKind},
+    image_format::{IdfBootloaderFormat, ImageFormat},
 };
 
 pub(crate) const CHIP_ID: u16 = 18;
@@ -74,18 +75,19 @@ impl Target for Esp32p4 {
 
     fn flash_image<'a>(
         &self,
-        format: ImageFormatKind,
+        format_args: FormatArgs,
         elf_data: &'a [u8],
         flash_data: FlashData,
         _chip_revision: Option<(u32, u32)>,
         xtal_freq: XtalFrequency,
     ) -> Result<ImageFormat<'a>, Error> {
-        match format {
-            ImageFormatKind::EspIdf => {
+        match format_args {
+            FormatArgs::EspIdf(esp_idf_format_args) => {
                 let idf = IdfBootloaderFormat::new(
                     elf_data,
                     Chip::Esp32p4,
                     flash_data,
+                    esp_idf_format_args,
                     xtal_freq,
                     0x1_0000,
                     0x3f_0000,

--- a/espflash/src/targets/esp32p4.rs
+++ b/espflash/src/targets/esp32p4.rs
@@ -14,7 +14,7 @@ use crate::connection::Connection;
 use crate::{
     Error,
     flasher::{FlashData, FlashFrequency},
-    image_format::IdfBootloaderFormat,
+    image_format::{self, IdfBootloaderFormat, ImageFormat, ImageFormatKind},
 };
 
 pub(crate) const CHIP_ID: u16 = 18;
@@ -25,16 +25,6 @@ const FLASH_RANGES: &[Range<u32>] = &[
     0x4000_0000..0x4C00_0000, // IROM
     0x4000_0000..0x4C00_0000, // DROM
 ];
-
-const PARAMS: Esp32Params = Esp32Params::new(
-    0x2000,
-    0x1_0000,
-    0x3f_0000,
-    CHIP_ID,
-    FlashFrequency::_40Mhz,
-    include_bytes!("../../resources/bootloaders/esp32p4-bootloader.bin"),
-    None,
-);
 
 /// ESP32-P4 Target
 pub struct Esp32p4;
@@ -92,19 +82,32 @@ impl Target for Esp32p4 {
 
     fn flash_image<'a>(
         &self,
+        format: ImageFormatKind,
         elf_data: &'a [u8],
         flash_data: FlashData,
         _chip_revision: Option<(u32, u32)>,
         xtal_freq: XtalFrequency,
-    ) -> Result<IdfBootloaderFormat<'a>, Error> {
-        if xtal_freq != XtalFrequency::_40Mhz {
-            return Err(Error::UnsupportedFeature {
-                chip: Chip::Esp32p4,
-                feature: "the selected crystal frequency".into(),
-            });
-        }
+    ) -> Result<ImageFormat<'a>, Error> {
+        let bootloader: &'static [u8] = match format {
+            ImageFormatKind::EspIdf => image_format::esp_idf::bootloader(Chip::Esp32p4, xtal_freq)?,
+        };
 
-        IdfBootloaderFormat::new(elf_data, Chip::Esp32p4, flash_data, PARAMS)
+        let params = Esp32Params::new(
+            0x2000,
+            0x1_0000,
+            0x3f_0000,
+            CHIP_ID,
+            FlashFrequency::_40Mhz,
+            bootloader,
+            None,
+        );
+
+        match format {
+            ImageFormatKind::EspIdf => {
+                let idf = IdfBootloaderFormat::new(elf_data, Chip::Esp32p4, flash_data, params)?;
+                Ok(idf.into())
+            }
+        }
     }
 
     fn spi_registers(&self) -> SpiRegisters {

--- a/espflash/src/targets/esp32p4.rs
+++ b/espflash/src/targets/esp32p4.rs
@@ -5,9 +5,8 @@ use super::{Chip, ReadEFuse, SpiRegisters, Target, XtalFrequency, efuse::esp32p4
 use crate::connection::Connection;
 use crate::{
     Error,
-    cli::FormatArgs,
     flasher::{FlashData, FlashFrequency},
-    image_format::{IdfBootloaderFormat, ImageFormat},
+    image_format::{IdfBootloaderFormat, ImageFormat, ImageFormatArgs},
 };
 
 pub(crate) const CHIP_ID: u16 = 18;
@@ -75,19 +74,17 @@ impl Target for Esp32p4 {
 
     fn flash_image<'a>(
         &self,
-        format_args: FormatArgs,
         elf_data: &'a [u8],
         flash_data: FlashData,
         _chip_revision: Option<(u32, u32)>,
         xtal_freq: XtalFrequency,
     ) -> Result<ImageFormat<'a>, Error> {
-        match format_args {
-            FormatArgs::EspIdf(esp_idf_format_args) => {
+        match &flash_data.format_args {
+            ImageFormatArgs::EspIdf(_) => {
                 let idf = IdfBootloaderFormat::new(
                     elf_data,
                     Chip::Esp32p4,
                     flash_data,
-                    esp_idf_format_args,
                     xtal_freq,
                     0x1_0000,
                     0x3f_0000,

--- a/espflash/src/targets/esp32p4.rs
+++ b/espflash/src/targets/esp32p4.rs
@@ -5,7 +5,7 @@ use super::{Chip, ReadEFuse, SpiRegisters, Target, XtalFrequency, efuse::esp32p4
 use crate::connection::Connection;
 use crate::{
     Error,
-    flasher::{FlashData, FlashFrequency},
+    flasher::FlashData,
     image_format::{IdfBootloaderFormat, ImageFormat, ImageFormatArgs},
 };
 
@@ -81,15 +81,7 @@ impl Target for Esp32p4 {
     ) -> Result<ImageFormat<'a>, Error> {
         match &flash_data.format_args {
             ImageFormatArgs::EspIdf(_) => {
-                let idf = IdfBootloaderFormat::new(
-                    elf_data,
-                    Chip::Esp32p4,
-                    flash_data,
-                    xtal_freq,
-                    0x1_0000,
-                    0x3f_0000,
-                    FlashFrequency::_40Mhz,
-                )?;
+                let idf = IdfBootloaderFormat::new(elf_data, Chip::Esp32p4, flash_data, xtal_freq)?;
                 Ok(idf.into())
             }
         }

--- a/espflash/src/targets/esp32s2.rs
+++ b/espflash/src/targets/esp32s2.rs
@@ -5,9 +5,8 @@ use super::flash_target::MAX_RAM_BLOCK_SIZE;
 use super::{Chip, ReadEFuse, SpiRegisters, Target, XtalFrequency, efuse::esp32s2 as efuse};
 use crate::{
     Error,
-    cli::FormatArgs,
     flasher::{FlashData, FlashFrequency},
-    image_format::{IdfBootloaderFormat, ImageFormat},
+    image_format::{IdfBootloaderFormat, ImageFormat, ImageFormatArgs},
 };
 #[cfg(feature = "serialport")]
 use crate::{connection::Connection, flasher::FLASH_WRITE_SIZE};
@@ -138,19 +137,17 @@ impl Target for Esp32s2 {
 
     fn flash_image<'a>(
         &self,
-        format_args: FormatArgs,
         elf_data: &'a [u8],
         flash_data: FlashData,
         _chip_revision: Option<(u32, u32)>,
         xtal_freq: XtalFrequency,
     ) -> Result<ImageFormat<'a>, Error> {
-        match format_args {
-            FormatArgs::EspIdf(esp_idf_format_args) => {
+        match &flash_data.format_args {
+            ImageFormatArgs::EspIdf(_) => {
                 let idf = IdfBootloaderFormat::new(
                     elf_data,
                     Chip::Esp32s2,
                     flash_data,
-                    esp_idf_format_args,
                     xtal_freq,
                     0x1_0000,
                     0x10_0000,

--- a/espflash/src/targets/esp32s2.rs
+++ b/espflash/src/targets/esp32s2.rs
@@ -3,11 +3,7 @@ use std::ops::Range;
 #[cfg(feature = "serialport")]
 use super::flash_target::MAX_RAM_BLOCK_SIZE;
 use super::{Chip, ReadEFuse, SpiRegisters, Target, XtalFrequency, efuse::esp32s2 as efuse};
-use crate::{
-    Error,
-    flasher::FlashData,
-    image_format::{IdfBootloaderFormat, ImageFormat, ImageFormatArgs},
-};
+use crate::Error;
 #[cfg(feature = "serialport")]
 use crate::{connection::Connection, flasher::FLASH_WRITE_SIZE};
 
@@ -133,21 +129,6 @@ impl Target for Esp32s2 {
         } else {
             FLASH_WRITE_SIZE
         })
-    }
-
-    fn flash_image<'a>(
-        &self,
-        elf_data: &'a [u8],
-        flash_data: FlashData,
-        _chip_revision: Option<(u32, u32)>,
-        xtal_freq: XtalFrequency,
-    ) -> Result<ImageFormat<'a>, Error> {
-        match &flash_data.format_args {
-            ImageFormatArgs::EspIdf(_) => {
-                let idf = IdfBootloaderFormat::new(elf_data, Chip::Esp32s2, flash_data, xtal_freq)?;
-                Ok(idf.into())
-            }
-        }
     }
 
     #[cfg(feature = "serialport")]

--- a/espflash/src/targets/esp32s2.rs
+++ b/espflash/src/targets/esp32s2.rs
@@ -2,19 +2,11 @@ use std::ops::Range;
 
 #[cfg(feature = "serialport")]
 use super::flash_target::MAX_RAM_BLOCK_SIZE;
-use super::{
-    Chip,
-    Esp32Params,
-    ReadEFuse,
-    SpiRegisters,
-    Target,
-    XtalFrequency,
-    efuse::esp32s2 as efuse,
-};
+use super::{Chip, ReadEFuse, SpiRegisters, Target, XtalFrequency, efuse::esp32s2 as efuse};
 use crate::{
     Error,
     flasher::{FlashData, FlashFrequency},
-    image_format::{self, IdfBootloaderFormat, ImageFormat, ImageFormatKind},
+    image_format::{IdfBootloaderFormat, ImageFormat, ImageFormatKind},
 };
 #[cfg(feature = "serialport")]
 use crate::{connection::Connection, flasher::FLASH_WRITE_SIZE};
@@ -151,23 +143,17 @@ impl Target for Esp32s2 {
         _chip_revision: Option<(u32, u32)>,
         xtal_freq: XtalFrequency,
     ) -> Result<ImageFormat<'a>, Error> {
-        let bootloader: &'static [u8] = match format {
-            ImageFormatKind::EspIdf => image_format::esp_idf::bootloader(Chip::Esp32s2, xtal_freq)?,
-        };
-
-        let params = Esp32Params::new(
-            0x1000,
-            0x1_0000,
-            0x10_0000,
-            CHIP_ID,
-            FlashFrequency::_40Mhz,
-            bootloader,
-            None,
-        );
-
         match format {
             ImageFormatKind::EspIdf => {
-                let idf = IdfBootloaderFormat::new(elf_data, Chip::Esp32s2, flash_data, params)?;
+                let idf = IdfBootloaderFormat::new(
+                    elf_data,
+                    Chip::Esp32s2,
+                    flash_data,
+                    xtal_freq,
+                    0x1_0000,
+                    0x10_0000,
+                    FlashFrequency::_40Mhz,
+                )?;
                 Ok(idf.into())
             }
         }

--- a/espflash/src/targets/esp32s2.rs
+++ b/espflash/src/targets/esp32s2.rs
@@ -5,8 +5,9 @@ use super::flash_target::MAX_RAM_BLOCK_SIZE;
 use super::{Chip, ReadEFuse, SpiRegisters, Target, XtalFrequency, efuse::esp32s2 as efuse};
 use crate::{
     Error,
+    cli::FormatArgs,
     flasher::{FlashData, FlashFrequency},
-    image_format::{IdfBootloaderFormat, ImageFormat, ImageFormatKind},
+    image_format::{IdfBootloaderFormat, ImageFormat},
 };
 #[cfg(feature = "serialport")]
 use crate::{connection::Connection, flasher::FLASH_WRITE_SIZE};
@@ -137,18 +138,19 @@ impl Target for Esp32s2 {
 
     fn flash_image<'a>(
         &self,
-        format: ImageFormatKind,
+        format_args: FormatArgs,
         elf_data: &'a [u8],
         flash_data: FlashData,
         _chip_revision: Option<(u32, u32)>,
         xtal_freq: XtalFrequency,
     ) -> Result<ImageFormat<'a>, Error> {
-        match format {
-            ImageFormatKind::EspIdf => {
+        match format_args {
+            FormatArgs::EspIdf(esp_idf_format_args) => {
                 let idf = IdfBootloaderFormat::new(
                     elf_data,
                     Chip::Esp32s2,
                     flash_data,
+                    esp_idf_format_args,
                     xtal_freq,
                     0x1_0000,
                     0x10_0000,

--- a/espflash/src/targets/esp32s2.rs
+++ b/espflash/src/targets/esp32s2.rs
@@ -5,7 +5,7 @@ use super::flash_target::MAX_RAM_BLOCK_SIZE;
 use super::{Chip, ReadEFuse, SpiRegisters, Target, XtalFrequency, efuse::esp32s2 as efuse};
 use crate::{
     Error,
-    flasher::{FlashData, FlashFrequency},
+    flasher::FlashData,
     image_format::{IdfBootloaderFormat, ImageFormat, ImageFormatArgs},
 };
 #[cfg(feature = "serialport")]
@@ -144,15 +144,7 @@ impl Target for Esp32s2 {
     ) -> Result<ImageFormat<'a>, Error> {
         match &flash_data.format_args {
             ImageFormatArgs::EspIdf(_) => {
-                let idf = IdfBootloaderFormat::new(
-                    elf_data,
-                    Chip::Esp32s2,
-                    flash_data,
-                    xtal_freq,
-                    0x1_0000,
-                    0x10_0000,
-                    FlashFrequency::_40Mhz,
-                )?;
+                let idf = IdfBootloaderFormat::new(elf_data, Chip::Esp32s2, flash_data, xtal_freq)?;
                 Ok(idf.into())
             }
         }

--- a/espflash/src/targets/esp32s3.rs
+++ b/espflash/src/targets/esp32s3.rs
@@ -5,7 +5,7 @@ use super::{Chip, ReadEFuse, SpiRegisters, Target, XtalFrequency, efuse::esp32s3
 use crate::connection::Connection;
 use crate::{
     Error,
-    flasher::{FlashData, FlashFrequency},
+    flasher::FlashData,
     image_format::{IdfBootloaderFormat, ImageFormat, ImageFormatArgs},
 };
 
@@ -106,15 +106,7 @@ impl Target for Esp32s3 {
     ) -> Result<ImageFormat<'a>, Error> {
         match &flash_data.format_args {
             ImageFormatArgs::EspIdf(_) => {
-                let idf = IdfBootloaderFormat::new(
-                    elf_data,
-                    Chip::Esp32s3,
-                    flash_data,
-                    xtal_freq,
-                    0x1_0000,
-                    0x10_0000,
-                    FlashFrequency::_40Mhz,
-                )?;
+                let idf = IdfBootloaderFormat::new(elf_data, Chip::Esp32s3, flash_data, xtal_freq)?;
                 Ok(idf.into())
             }
         }

--- a/espflash/src/targets/esp32s3.rs
+++ b/espflash/src/targets/esp32s3.rs
@@ -1,13 +1,9 @@
 use std::ops::Range;
 
 use super::{Chip, ReadEFuse, SpiRegisters, Target, XtalFrequency, efuse::esp32s3 as efuse};
+use crate::Error;
 #[cfg(feature = "serialport")]
 use crate::connection::Connection;
-use crate::{
-    Error,
-    flasher::FlashData,
-    image_format::{IdfBootloaderFormat, ImageFormat, ImageFormatArgs},
-};
 
 pub(crate) const CHIP_ID: u16 = 9;
 
@@ -95,21 +91,6 @@ impl Target for Esp32s3 {
     fn crystal_freq(&self, _connection: &mut Connection) -> Result<XtalFrequency, Error> {
         // The ESP32-S3's XTAL has a fixed frequency of 40MHz.
         Ok(XtalFrequency::_40Mhz)
-    }
-
-    fn flash_image<'a>(
-        &self,
-        elf_data: &'a [u8],
-        flash_data: FlashData,
-        _chip_revision: Option<(u32, u32)>,
-        xtal_freq: XtalFrequency,
-    ) -> Result<ImageFormat<'a>, Error> {
-        match &flash_data.format_args {
-            ImageFormatArgs::EspIdf(_) => {
-                let idf = IdfBootloaderFormat::new(elf_data, Chip::Esp32s3, flash_data, xtal_freq)?;
-                Ok(idf.into())
-            }
-        }
     }
 
     fn spi_registers(&self) -> SpiRegisters {

--- a/espflash/src/targets/esp32s3.rs
+++ b/espflash/src/targets/esp32s3.rs
@@ -1,20 +1,12 @@
 use std::ops::Range;
 
-use super::{
-    Chip,
-    Esp32Params,
-    ReadEFuse,
-    SpiRegisters,
-    Target,
-    XtalFrequency,
-    efuse::esp32s3 as efuse,
-};
+use super::{Chip, ReadEFuse, SpiRegisters, Target, XtalFrequency, efuse::esp32s3 as efuse};
 #[cfg(feature = "serialport")]
 use crate::connection::Connection;
 use crate::{
     Error,
     flasher::{FlashData, FlashFrequency},
-    image_format::{self, IdfBootloaderFormat, ImageFormat, ImageFormatKind},
+    image_format::{IdfBootloaderFormat, ImageFormat, ImageFormatKind},
 };
 
 pub(crate) const CHIP_ID: u16 = 9;
@@ -113,23 +105,17 @@ impl Target for Esp32s3 {
         _chip_revision: Option<(u32, u32)>,
         xtal_freq: XtalFrequency,
     ) -> Result<ImageFormat<'a>, Error> {
-        let bootloader: &'static [u8] = match format {
-            ImageFormatKind::EspIdf => image_format::esp_idf::bootloader(Chip::Esp32s3, xtal_freq)?,
-        };
-
-        let params = Esp32Params::new(
-            0x0,
-            0x1_0000,
-            0x10_0000,
-            CHIP_ID,
-            FlashFrequency::_40Mhz,
-            bootloader,
-            None,
-        );
-
         match format {
             ImageFormatKind::EspIdf => {
-                let idf = IdfBootloaderFormat::new(elf_data, Chip::Esp32s3, flash_data, params)?;
+                let idf = IdfBootloaderFormat::new(
+                    elf_data,
+                    Chip::Esp32s3,
+                    flash_data,
+                    xtal_freq,
+                    0x1_0000,
+                    0x10_0000,
+                    FlashFrequency::_40Mhz,
+                )?;
                 Ok(idf.into())
             }
         }

--- a/espflash/src/targets/esp32s3.rs
+++ b/espflash/src/targets/esp32s3.rs
@@ -5,9 +5,8 @@ use super::{Chip, ReadEFuse, SpiRegisters, Target, XtalFrequency, efuse::esp32s3
 use crate::connection::Connection;
 use crate::{
     Error,
-    cli::FormatArgs,
     flasher::{FlashData, FlashFrequency},
-    image_format::{IdfBootloaderFormat, ImageFormat},
+    image_format::{IdfBootloaderFormat, ImageFormat, ImageFormatArgs},
 };
 
 pub(crate) const CHIP_ID: u16 = 9;
@@ -100,19 +99,17 @@ impl Target for Esp32s3 {
 
     fn flash_image<'a>(
         &self,
-        format_args: FormatArgs,
         elf_data: &'a [u8],
         flash_data: FlashData,
         _chip_revision: Option<(u32, u32)>,
         xtal_freq: XtalFrequency,
     ) -> Result<ImageFormat<'a>, Error> {
-        match format_args {
-            FormatArgs::EspIdf(esp_idf_format_args) => {
+        match &flash_data.format_args {
+            ImageFormatArgs::EspIdf(_) => {
                 let idf = IdfBootloaderFormat::new(
                     elf_data,
                     Chip::Esp32s3,
                     flash_data,
-                    esp_idf_format_args,
                     xtal_freq,
                     0x1_0000,
                     0x10_0000,

--- a/espflash/src/targets/esp32s3.rs
+++ b/espflash/src/targets/esp32s3.rs
@@ -5,8 +5,9 @@ use super::{Chip, ReadEFuse, SpiRegisters, Target, XtalFrequency, efuse::esp32s3
 use crate::connection::Connection;
 use crate::{
     Error,
+    cli::FormatArgs,
     flasher::{FlashData, FlashFrequency},
-    image_format::{IdfBootloaderFormat, ImageFormat, ImageFormatKind},
+    image_format::{IdfBootloaderFormat, ImageFormat},
 };
 
 pub(crate) const CHIP_ID: u16 = 9;
@@ -99,18 +100,19 @@ impl Target for Esp32s3 {
 
     fn flash_image<'a>(
         &self,
-        format: ImageFormatKind,
+        format_args: FormatArgs,
         elf_data: &'a [u8],
         flash_data: FlashData,
         _chip_revision: Option<(u32, u32)>,
         xtal_freq: XtalFrequency,
     ) -> Result<ImageFormat<'a>, Error> {
-        match format {
-            ImageFormatKind::EspIdf => {
+        match format_args {
+            FormatArgs::EspIdf(esp_idf_format_args) => {
                 let idf = IdfBootloaderFormat::new(
                     elf_data,
                     Chip::Esp32s3,
                     flash_data,
+                    esp_idf_format_args,
                     xtal_freq,
                     0x1_0000,
                     0x10_0000,

--- a/espflash/src/targets/esp32s3.rs
+++ b/espflash/src/targets/esp32s3.rs
@@ -14,7 +14,7 @@ use crate::connection::Connection;
 use crate::{
     Error,
     flasher::{FlashData, FlashFrequency},
-    image_format::IdfBootloaderFormat,
+    image_format::{self, IdfBootloaderFormat, ImageFormat, ImageFormatKind},
 };
 
 pub(crate) const CHIP_ID: u16 = 9;
@@ -25,16 +25,6 @@ const FLASH_RANGES: &[Range<u32>] = &[
     0x4200_0000..0x4400_0000, // IROM
     0x3c00_0000..0x3e00_0000, // DROM
 ];
-
-const PARAMS: Esp32Params = Esp32Params::new(
-    0x0,
-    0x1_0000,
-    0x10_0000,
-    CHIP_ID,
-    FlashFrequency::_40Mhz,
-    include_bytes!("../../resources/bootloaders/esp32s3-bootloader.bin"),
-    None,
-);
 
 /// ESP32-S2 Target
 pub struct Esp32s3;
@@ -117,19 +107,32 @@ impl Target for Esp32s3 {
 
     fn flash_image<'a>(
         &self,
+        format: ImageFormatKind,
         elf_data: &'a [u8],
         flash_data: FlashData,
         _chip_revision: Option<(u32, u32)>,
         xtal_freq: XtalFrequency,
-    ) -> Result<IdfBootloaderFormat<'a>, Error> {
-        if xtal_freq != XtalFrequency::_40Mhz {
-            return Err(Error::UnsupportedFeature {
-                chip: Chip::Esp32s3,
-                feature: "the selected crystal frequency".into(),
-            });
-        }
+    ) -> Result<ImageFormat<'a>, Error> {
+        let bootloader: &'static [u8] = match format {
+            ImageFormatKind::EspIdf => image_format::esp_idf::bootloader(Chip::Esp32s3, xtal_freq)?,
+        };
 
-        IdfBootloaderFormat::new(elf_data, Chip::Esp32s3, flash_data, PARAMS)
+        let params = Esp32Params::new(
+            0x0,
+            0x1_0000,
+            0x10_0000,
+            CHIP_ID,
+            FlashFrequency::_40Mhz,
+            bootloader,
+            None,
+        );
+
+        match format {
+            ImageFormatKind::EspIdf => {
+                let idf = IdfBootloaderFormat::new(elf_data, Chip::Esp32s3, flash_data, params)?;
+                Ok(idf.into())
+            }
+        }
     }
 
     fn spi_registers(&self) -> SpiRegisters {

--- a/espflash/src/targets/mod.rs
+++ b/espflash/src/targets/mod.rs
@@ -185,6 +185,7 @@ impl Chip {
         }
     }
 
+    /// Returns the valid MMU page sizes for the [Chip]
     pub fn valid_mmu_page_sizes(self) -> Option<&'static [u32]> {
         match self {
             Chip::Esp32c2 => Some(&[16 * 1024, 32 * 1024, 64 * 1024]),
@@ -194,6 +195,7 @@ impl Chip {
         }
     }
 
+    /// Returns the boot address for the [Chip]
     pub fn boot_address(&self) -> u32 {
         match self {
             Chip::Esp32c2 | Chip::Esp32c3 | Chip::Esp32c6 | Chip::Esp32h2 | Chip::Esp32s3 => 0x0,
@@ -202,6 +204,7 @@ impl Chip {
         }
     }
 
+    /// Returns the default flash frequency for the [Chip]
     pub fn default_flash_frequency(&self) -> FlashFrequency {
         match self {
             Chip::Esp32
@@ -216,6 +219,7 @@ impl Chip {
         }
     }
 
+    /// Returns the default crystal frequency for the [Chip]
     pub fn default_crystal_frequency(&self) -> XtalFrequency {
         match self {
             Chip::Esp32c5 => XtalFrequency::_48Mhz,

--- a/espflash/src/targets/mod.rs
+++ b/espflash/src/targets/mod.rs
@@ -24,7 +24,6 @@ use self::{
 };
 use crate::{
     Error,
-    cli::FormatArgs,
     flasher::{FlashData, FlashFrequency},
     image_format::ImageFormat,
 };
@@ -410,7 +409,6 @@ pub trait Target: ReadEFuse {
     /// Build an image from the provided data for flashing
     fn flash_image<'a>(
         &self,
-        format_args: FormatArgs,
         elf_data: &'a [u8],
         flash_data: FlashData,
         chip_revision: Option<(u32, u32)>,

--- a/espflash/src/targets/mod.rs
+++ b/espflash/src/targets/mod.rs
@@ -22,11 +22,7 @@ use self::{
     esp32s2::Esp32s2,
     esp32s3::Esp32s3,
 };
-use crate::{
-    Error,
-    flasher::{FlashData, FlashFrequency},
-    image_format::ImageFormat,
-};
+use crate::{Error, flasher::FlashFrequency};
 #[cfg(feature = "serialport")]
 use crate::{
     connection::Connection,
@@ -76,6 +72,7 @@ pub enum XtalFrequency {
     _48Mhz,
 }
 
+// TODO: This feels a bit werid, maybe move it to the Chip enum for consistency?
 impl XtalFrequency {
     /// Default crystal frequency for a given chip.
     pub fn default(chip: Chip) -> Self {
@@ -419,15 +416,6 @@ pub trait Target: ReadEFuse {
     fn flash_write_size(&self, _connection: &mut Connection) -> Result<usize, Error> {
         Ok(FLASH_WRITE_SIZE)
     }
-
-    /// Build an image from the provided data for flashing
-    fn flash_image<'a>(
-        &self,
-        elf_data: &'a [u8],
-        flash_data: FlashData,
-        chip_revision: Option<(u32, u32)>,
-        xtal_freq: XtalFrequency,
-    ) -> Result<ImageFormat<'a>, Error>;
 
     #[cfg(feature = "serialport")]
     /// What is the MAC address?

--- a/espflash/src/targets/mod.rs
+++ b/espflash/src/targets/mod.rs
@@ -25,7 +25,7 @@ use self::{
 use crate::{
     Error,
     flasher::{FlashData, FlashFrequency},
-    image_format::IdfBootloaderFormat,
+    image_format::{ImageFormat, ImageFormatKind},
 };
 #[cfg(feature = "serialport")]
 use crate::{
@@ -434,11 +434,12 @@ pub trait Target: ReadEFuse {
     /// Build an image from the provided data for flashing
     fn flash_image<'a>(
         &self,
+        format: ImageFormatKind,
         elf_data: &'a [u8],
         flash_data: FlashData,
         chip_revision: Option<(u32, u32)>,
         xtal_freq: XtalFrequency,
-    ) -> Result<IdfBootloaderFormat<'a>, Error>;
+    ) -> Result<ImageFormat<'a>, Error>;
 
     #[cfg(feature = "serialport")]
     /// What is the MAC address?

--- a/espflash/src/targets/mod.rs
+++ b/espflash/src/targets/mod.rs
@@ -24,8 +24,9 @@ use self::{
 };
 use crate::{
     Error,
+    cli::FormatArgs,
     flasher::{FlashData, FlashFrequency},
-    image_format::{ImageFormat, ImageFormatKind},
+    image_format::ImageFormat,
 };
 #[cfg(feature = "serialport")]
 use crate::{
@@ -409,7 +410,7 @@ pub trait Target: ReadEFuse {
     /// Build an image from the provided data for flashing
     fn flash_image<'a>(
         &self,
-        format: ImageFormatKind,
+        format_args: FormatArgs,
         elf_data: &'a [u8],
         flash_data: FlashData,
         chip_revision: Option<(u32, u32)>,

--- a/espflash/src/targets/mod.rs
+++ b/espflash/src/targets/mod.rs
@@ -217,6 +217,20 @@ impl Chip {
         }
     }
 
+    pub fn default_flash_frequency(&self) -> FlashFrequency {
+        match self {
+            Chip::Esp32
+            | Chip::Esp32c3
+            | Chip::Esp32c5
+            | Chip::Esp32c6
+            | Chip::Esp32p4
+            | Chip::Esp32s2
+            | Chip::Esp32s3 => FlashFrequency::_40Mhz,
+            Chip::Esp32c2 => FlashFrequency::_30Mhz,
+            Chip::Esp32h2 => FlashFrequency::_24Mhz,
+        }
+    }
+
     #[cfg(feature = "serialport")]
     pub fn flash_target(
         &self,

--- a/espflash/src/targets/mod.rs
+++ b/espflash/src/targets/mod.rs
@@ -72,18 +72,6 @@ pub enum XtalFrequency {
     _48Mhz,
 }
 
-// TODO: This feels a bit werid, maybe move it to the Chip enum for consistency?
-impl XtalFrequency {
-    /// Default crystal frequency for a given chip.
-    pub fn default(chip: Chip) -> Self {
-        match chip {
-            Chip::Esp32c5 => Self::_48Mhz,
-            Chip::Esp32h2 => Self::_32Mhz,
-            _ => Self::_40Mhz,
-        }
-    }
-}
-
 /// All supported devices
 #[cfg_attr(feature = "cli", derive(clap::ValueEnum))]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Display, EnumIter, EnumString, VariantNames)]
@@ -225,6 +213,14 @@ impl Chip {
             | Chip::Esp32s3 => FlashFrequency::_40Mhz,
             Chip::Esp32c2 => FlashFrequency::_30Mhz,
             Chip::Esp32h2 => FlashFrequency::_24Mhz,
+        }
+    }
+
+    pub fn default_crystal_frequency(&self) -> XtalFrequency {
+        match self {
+            Chip::Esp32c5 => XtalFrequency::_48Mhz,
+            Chip::Esp32h2 => XtalFrequency::_32Mhz,
+            _ => XtalFrequency::_40Mhz,
         }
     }
 

--- a/espflash/tests/scripts/write-bin.sh
+++ b/espflash/tests/scripts/write-bin.sh
@@ -21,22 +21,3 @@ if ! grep -q -a -F $'\x01\xa0' flash_content.bin; then
     echo "Failed verifying content"
     exit 1
 fi
-
-result=$(espflash write-bin nvs binary_file.bin --partition-table $part_table 2>&1)
-echo "$result"
-if [[ ! $result =~ "Binary successfully written to flash!" ]]; then
-    echo "Failed to write binary to the nvs partition label"
-    exit 1
-fi
-
-result=$(espflash read-flash 0x9000 64 flash_content.bin 2>&1)
-echo "$result"
-if [[ ! $result =~ "Flash content successfully read and written to" ]]; then
-    echo "Failed to read flash content"
-    exit 1
-fi
-# Check that the flash_content.bin contains the '01 a0' bytes
-if ! grep -q -a -F $'\x01\xa0' flash_content.bin; then
-    echo "Failed verifying content"
-    exit 1
-fi


### PR DESCRIPTION
Draft PR as there are still some missing parts:
- [x] We need to check if the provided `EspIdfFormatArgs`  make sense for the selected subcommand
- There are still some esp-idf specifics that are not in the esp-idf module, maybe we should move them
- Not sure if I like the `make_...` methods, but I cant think of anything better
- Not sure if some things should live in `targets/<chip>.rs` or as method of the Chip enum
  - This can/should be done in a later PR if required.
- [x] There are also some `TODO`s in the code that need to be resolved
- [x] Maybe there is some docstrings missing
- [x] There are still some `ESP-IDF only` annotations

Any feedback or suggestion is more than welcome!