### PR TITLE
Move construction of Connection outside of flasher

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `--after` options now work with `espflash board-info`, `espflash read-flash` and `espflash checksum-md5` (#867)
 - Add support for serial port configuration files. (#777)
 - Add a `check-app-descriptor` bool option to `ImageArgs` and add the flag to `flash` commad(#872)
+- `Connection::into_serial` to get the underlying port from the connection (#882)
 
 ### Changed
 
@@ -49,6 +50,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated bootloaders with `release/v5.4` ones from IDF (#857)
 - Refactor image formatting to allow supporting more image formats in a backward compatible way (#877)
 - Avoid having ESP-IDF format assumptions in the codebase (#877)
+- `Flasher` now takes the `Connection` in new, instead of constructing the connection inside `Flasher::connect` (#882)
+- `detect_chip` has moved to the `Connection` struct (#882)
+- `Flasher::into_serial` has been replaced by `Flasher::into_connection` (#882)
 
 ### Fixed
 
@@ -61,6 +65,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed a case where esplash transformed the firmware elf in a way that made it unbootable (#831)
 - The app descriptor is now correctly placed in the front of the bianry (#835)
 - espflash now extracts the MMU page size from the app descriptor (#835)
+- `ResetBeforeOperation` & `ResetAfterOperation` are now public, to allow the creation of a `Connection` (#882)
 
 ### Removed
 

--- a/cargo-espflash/src/main.rs
+++ b/cargo-espflash/src/main.rs
@@ -410,7 +410,12 @@ fn flash(args: FlashArgs, config: &Config) -> Result<()> {
 
         monitor_args.elf = Some(build_ctx.artifact_path);
 
-        monitor(flasher.into_serial(), Some(&elf_data), pid, monitor_args)
+        monitor(
+            flasher.into_connection().into_serial(),
+            Some(&elf_data),
+            pid,
+            monitor_args,
+        )
     } else {
         Ok(())
     }

--- a/cargo-espflash/src/main.rs
+++ b/cargo-espflash/src/main.rs
@@ -397,7 +397,7 @@ fn flash(args: FlashArgs, config: &Config) -> Result<()> {
     }
 
     if args.flash_args.monitor {
-        let pid = flasher.usb_pid();
+        let pid = flasher.connection().usb_pid();
 
         // The 26MHz ESP32-C2's need to be treated as a special case.
         if chip == Chip::Esp32c2

--- a/espflash/src/bin/espflash.rs
+++ b/espflash/src/bin/espflash.rs
@@ -309,7 +309,7 @@ fn flash(args: FlashArgs, config: &Config) -> Result<()> {
     }
 
     if args.flash_args.monitor {
-        let pid = flasher.usb_pid();
+        let pid = flasher.connection().usb_pid();
 
         // The 26MHz ESP32-C2's need to be treated as a special case.
         if chip == Chip::Esp32c2

--- a/espflash/src/bin/espflash.rs
+++ b/espflash/src/bin/espflash.rs
@@ -322,7 +322,12 @@ fn flash(args: FlashArgs, config: &Config) -> Result<()> {
 
         monitor_args.elf = Some(args.image);
 
-        monitor(flasher.into_serial(), Some(&elf_data), pid, monitor_args)
+        monitor(
+            flasher.into_connection().into_serial(),
+            Some(&elf_data),
+            pid,
+            monitor_args,
+        )
     } else {
         Ok(())
     }

--- a/espflash/src/cli/mod.rs
+++ b/espflash/src/cli/mod.rs
@@ -34,7 +34,10 @@ use self::{
     monitor::{LogFormat, check_monitor_args, monitor},
 };
 use crate::{
-    connection::reset::{ResetAfterOperation, ResetBeforeOperation},
+    connection::{
+        Connection,
+        reset::{ResetAfterOperation, ResetBeforeOperation},
+    },
     error::{Error, MissingPartition, MissingPartitionTable},
     flasher::{
         FLASH_SECTOR_SIZE,
@@ -435,16 +438,21 @@ pub fn connect(
         _ => unreachable!(),
     };
 
-    Ok(Flasher::connect(
+    let connection = Connection::new(
         *Box::new(serial_port),
         port_info,
-        args.baud.or(config.project_config.baudrate),
+        args.after,
+        args.before,
+        args.baud
+            .or(config.project_config.baudrate)
+            .unwrap_or(115_200),
+    );
+    Ok(Flasher::connect(
+        connection,
         !args.no_stub,
         !no_verify,
         !no_skip,
         args.chip,
-        args.after,
-        args.before,
     )?)
 }
 

--- a/espflash/src/cli/mod.rs
+++ b/espflash/src/cli/mod.rs
@@ -626,7 +626,7 @@ pub fn print_board_info(flasher: &mut Flasher) -> Result<()> {
 /// Open a serial monitor
 pub fn serial_monitor(args: MonitorArgs, config: &Config) -> Result<()> {
     let mut flasher = connect(&args.connect_args, config, true, true)?;
-    let pid = flasher.usb_pid();
+    let pid = flasher.connection().usb_pid();
 
     let elf = if let Some(elf_path) = args.monitor_args.elf.clone() {
         let path = fs::canonicalize(elf_path).into_diagnostic()?;
@@ -1119,17 +1119,14 @@ pub fn write_bin(args: WriteBinArgs, config: &Config) -> Result<()> {
     )?;
 
     if args.monitor {
-        let pid = flasher.usb_pid();
+        let pid = flasher.connection().usb_pid();
         let mut monitor_args = args.monitor_args;
-
         if chip == Chip::Esp32c2
             && target_xtal_freq == XtalFrequency::_26Mhz
             && monitor_args.monitor_baud == 115_200
         {
-            // 115_200 * 26 MHz / 40 MHz = 74_880
             monitor_args.monitor_baud = 74_880;
         }
-
         monitor(flasher.into_serial(), None, pid, monitor_args)?;
     }
 

--- a/espflash/src/cli/mod.rs
+++ b/espflash/src/cli/mod.rs
@@ -654,7 +654,12 @@ pub fn serial_monitor(args: MonitorArgs, config: &Config) -> Result<()> {
         monitor_args.monitor_baud = 74_880;
     }
 
-    monitor(flasher.into_serial(), elf.as_deref(), pid, monitor_args)
+    monitor(
+        flasher.into_connection().into_serial(),
+        elf.as_deref(),
+        pid,
+        monitor_args,
+    )
 }
 
 /// Convert the provided firmware image from ELF to binary
@@ -1127,7 +1132,12 @@ pub fn write_bin(args: WriteBinArgs, config: &Config) -> Result<()> {
         {
             monitor_args.monitor_baud = 74_880;
         }
-        monitor(flasher.into_serial(), None, pid, monitor_args)?;
+        monitor(
+            flasher.into_connection().into_serial(),
+            None,
+            pid,
+            monitor_args,
+        )?;
     }
 
     Ok(())

--- a/espflash/src/connection/mod.rs
+++ b/espflash/src/connection/mod.rs
@@ -399,8 +399,8 @@ impl Connection {
     }
 
     /// Get the current baud rate of the serial port.
-    pub fn baud(&self) -> Result<u32, Error> {
-        Ok(self.serial.baud_rate()?)
+    pub fn speed(&self) -> u32 {
+        self.speed
     }
 
     /// Run a command with a timeout defined by the command type.

--- a/espflash/src/connection/mod.rs
+++ b/espflash/src/connection/mod.rs
@@ -134,6 +134,7 @@ pub struct Connection {
     after_operation: ResetAfterOperation,
     before_operation: ResetBeforeOperation,
     pub(crate) secure_download_mode: bool,
+    pub(crate) speed: u32,
 }
 
 impl Connection {
@@ -143,6 +144,7 @@ impl Connection {
         port_info: UsbPortInfo,
         after_operation: ResetAfterOperation,
         before_operation: ResetBeforeOperation,
+        speed: u32,
     ) -> Self {
         Connection {
             serial,
@@ -151,6 +153,7 @@ impl Connection {
             after_operation,
             before_operation,
             secure_download_mode: false,
+            speed,
         }
     }
 
@@ -390,7 +393,7 @@ impl Connection {
     /// Set baud rate for the serial port.
     pub fn set_baud(&mut self, speed: u32) -> Result<(), Error> {
         self.serial.set_baud_rate(speed)?;
-
+        self.speed = speed;
         Ok(())
     }
 
@@ -617,6 +620,13 @@ impl Connection {
 
     pub(crate) fn is_using_usb_serial_jtag(&self) -> bool {
         self.port_info.pid == USB_SERIAL_JTAG_PID
+    }
+
+    pub fn after_operation(&self) -> ResetAfterOperation {
+        self.after_operation
+    }
+    pub fn before_operation(&self) -> ResetBeforeOperation {
+        self.before_operation
     }
 }
 

--- a/espflash/src/connection/mod.rs
+++ b/espflash/src/connection/mod.rs
@@ -135,7 +135,7 @@ pub struct Connection {
     after_operation: ResetAfterOperation,
     before_operation: ResetBeforeOperation,
     pub(crate) secure_download_mode: bool,
-    pub(crate) speed: u32,
+    pub(crate) baud: u32,
 }
 
 impl Connection {
@@ -145,7 +145,7 @@ impl Connection {
         port_info: UsbPortInfo,
         after_operation: ResetAfterOperation,
         before_operation: ResetBeforeOperation,
-        speed: u32,
+        baud: u32,
     ) -> Self {
         Connection {
             serial,
@@ -154,7 +154,7 @@ impl Connection {
             after_operation,
             before_operation,
             secure_download_mode: false,
-            speed,
+            baud,
         }
     }
 
@@ -392,15 +392,15 @@ impl Connection {
     }
 
     /// Set baud rate for the serial port.
-    pub fn set_baud(&mut self, speed: u32) -> Result<(), Error> {
-        self.serial.set_baud_rate(speed)?;
-        self.speed = speed;
+    pub fn set_baud(&mut self, baud: u32) -> Result<(), Error> {
+        self.serial.set_baud_rate(baud)?;
+        self.baud = baud;
         Ok(())
     }
 
     /// Get the current baud rate of the serial port.
-    pub fn speed(&self) -> u32 {
-        self.speed
+    pub fn baud(&self) -> u32 {
+        self.baud
     }
 
     /// Run a command with a timeout defined by the command type.

--- a/espflash/src/flasher/mod.rs
+++ b/espflash/src/flasher/mod.rs
@@ -660,7 +660,7 @@ impl Flasher {
         let detected_chip = if connection.before_operation() != ResetBeforeOperation::NoResetNoSync
         {
             // Detect which chip we are connected to.
-            let detected_chip = detect_chip(&mut connection, use_stub)?;
+            let detected_chip = connection.detect_chip(use_stub)?;
             if let Some(chip) = chip {
                 if chip != detected_chip {
                     return Err(Error::ChipMismatch(
@@ -782,7 +782,7 @@ impl Flasher {
         }?;
 
         // Re-detect chip to check stub is up
-        let chip = detect_chip(&mut self.connection, self.use_stub)?;
+        let chip = self.connection.detect_chip(self.use_stub)?;
         debug!("Re-detected chip: {:?}", chip);
 
         Ok(())
@@ -1373,24 +1373,6 @@ fn security_info(connection: &mut Connection, use_stub: bool) -> Result<Security
             ))
         }
     })
-}
-
-#[cfg(feature = "serialport")]
-fn detect_chip(connection: &mut Connection, use_stub: bool) -> Result<Chip, Error> {
-    match security_info(connection, use_stub) {
-        Ok(info) if info.chip_id.is_some() => {
-            let chip_id = info.chip_id.unwrap() as u16;
-            let chip = Chip::try_from(chip_id)?;
-
-            Ok(chip)
-        }
-        _ => {
-            let magic = connection.read_reg(CHIP_DETECT_MAGIC_REG_ADDR)?;
-            let chip = Chip::from_magic(magic)?;
-
-            Ok(chip)
-        }
-    }
 }
 
 #[cfg(feature = "serialport")]

--- a/espflash/src/flasher/mod.rs
+++ b/espflash/src/flasher/mod.rs
@@ -1355,6 +1355,11 @@ impl Flasher {
 
         Ok(())
     }
+
+    /// Take the serial port out of the flasher, consuming self
+    pub fn into_serial(self) -> Port {
+        self.connection.into_serial()
+    }
 }
 
 #[cfg(feature = "serialport")]

--- a/espflash/src/flasher/mod.rs
+++ b/espflash/src/flasher/mod.rs
@@ -29,7 +29,6 @@ use crate::{
 use crate::{
     connection::{
         Connection,
-        Port,
         command::{Command, CommandType},
         reset::ResetBeforeOperation,
     },
@@ -1133,7 +1132,7 @@ impl Flasher {
         debug!("Change baud to: {}", speed);
 
         let prior_baud = match self.use_stub {
-            true => self.connection.baud()?,
+            true => self.connection.speed(),
             false => 0,
         };
 
@@ -1163,17 +1162,6 @@ impl Flasher {
         Ok(())
     }
 
-    /// Convert the [Flasher] into a [Port] instance.
-    pub fn into_serial(self) -> Port {
-        self.connection.into_serial()
-    }
-
-    /// Get the USB VID of the connected device.
-    pub fn usb_pid(&self) -> u16 {
-        self.connection.usb_pid()
-    }
-
-    /// Erase a region of flash specified by offset and size.
     pub fn erase_region(&mut self, offset: u32, size: u32) -> Result<(), Error> {
         debug!("Erasing region of 0x{:x}B at 0x{:08x}", size, offset);
 
@@ -1356,9 +1344,9 @@ impl Flasher {
         Ok(())
     }
 
-    /// Take the serial port out of the flasher, consuming self
-    pub fn into_serial(self) -> Port {
-        self.connection.into_serial()
+    /// Consume self and return the underlying connection.
+    pub fn into_connection(self) -> Connection {
+        self.connection
     }
 }
 

--- a/espflash/src/flasher/mod.rs
+++ b/espflash/src/flasher/mod.rs
@@ -15,8 +15,6 @@ use md5::{Digest, Md5};
 #[cfg(feature = "serialport")]
 use object::{Endianness, read::elf::ElfFile32 as ElfFile};
 use serde::{Deserialize, Serialize};
-#[cfg(feature = "serialport")]
-use serialport::UsbPortInfo;
 use strum::{Display, EnumIter, IntoEnumIterator, VariantNames};
 
 #[cfg(feature = "serialport")]
@@ -33,7 +31,7 @@ use crate::{
         Connection,
         Port,
         command::{Command, CommandType},
-        reset::{ResetAfterOperation, ResetBeforeOperation},
+        reset::ResetBeforeOperation,
     },
     error::{ConnectionError, ResultExt as _},
     flasher::stubs::{
@@ -645,27 +643,22 @@ impl Flasher {
     /// The serial port's baud rate should be 115_200 to connect. After
     /// connecting, Flasher will change the baud rate to the `speed`
     /// parameter.
-    #[allow(clippy::too_many_arguments)]
     pub fn connect(
-        serial: Port,
-        port_info: UsbPortInfo,
-        speed: Option<u32>,
+        mut connection: Connection,
         use_stub: bool,
         verify: bool,
         skip: bool,
         chip: Option<Chip>,
-        after_operation: ResetAfterOperation,
-        before_operation: ResetBeforeOperation,
     ) -> Result<Self, Error> {
-        // Establish a connection to the device using the default baud rate of 115,200
-        // and timeout of 3 seconds.
-        let mut connection = Connection::new(serial, port_info, after_operation, before_operation);
+        // The connection should already be established with the device using the
+        // default baud rate of 115,200 and timeout of 3 seconds.
         connection.begin()?;
         connection.set_timeout(DEFAULT_TIMEOUT)?;
 
         detect_sdm(&mut connection);
 
-        let detected_chip = if before_operation != ResetBeforeOperation::NoResetNoSync {
+        let detected_chip = if connection.before_operation() != ResetBeforeOperation::NoResetNoSync
+        {
             // Detect which chip we are connected to.
             let detected_chip = detect_chip(&mut connection, use_stub)?;
             if let Some(chip) = chip {
@@ -676,9 +669,10 @@ impl Flasher {
                     ));
                 }
             }
-
             detected_chip
-        } else if before_operation == ResetBeforeOperation::NoResetNoSync && chip.is_some() {
+        } else if connection.before_operation() == ResetBeforeOperation::NoResetNoSync
+            && chip.is_some()
+        {
             chip.unwrap()
         } else {
             return Err(Error::ChipNotProvided);
@@ -694,7 +688,7 @@ impl Flasher {
             skip,
         };
 
-        if before_operation == ResetBeforeOperation::NoResetNoSync {
+        if flasher.connection.before_operation() == ResetBeforeOperation::NoResetNoSync {
             return Ok(flasher);
         }
 
@@ -713,11 +707,9 @@ impl Flasher {
 
         // Now that we have established a connection and detected the chip and flash
         // size, we can set the baud rate of the connection to the configured value.
-        if let Some(baud) = speed {
-            if baud > 115_200 {
-                warn!("Setting baud rate higher than 115,200 can cause issues");
-                flasher.change_baud(baud)?;
-            }
+        if flasher.connection.speed() > 115_200 {
+            warn!("Setting baud rate higher than 115,200 can cause issues");
+            flasher.change_baud(flasher.connection.speed())?;
         }
 
         Ok(flasher)

--- a/espflash/src/flasher/mod.rs
+++ b/espflash/src/flasher/mod.rs
@@ -640,7 +640,7 @@ pub struct Flasher {
 #[cfg(feature = "serialport")]
 impl Flasher {
     /// The serial port's baud rate should be 115_200 to connect. After
-    /// connecting, Flasher will change the baud rate to the `speed`
+    /// connecting, Flasher will change the baud rate to the `baud`
     /// parameter.
     pub fn connect(
         mut connection: Connection,
@@ -706,9 +706,9 @@ impl Flasher {
 
         // Now that we have established a connection and detected the chip and flash
         // size, we can set the baud rate of the connection to the configured value.
-        if flasher.connection.speed() > 115_200 {
+        if flasher.connection.baud() > 115_200 {
             warn!("Setting baud rate higher than 115,200 can cause issues");
-            flasher.change_baud(flasher.connection.speed())?;
+            flasher.change_baud(flasher.connection.baud())?;
         }
 
         Ok(flasher)
@@ -1128,11 +1128,11 @@ impl Flasher {
     }
 
     /// Change the baud rate of the connection.
-    pub fn change_baud(&mut self, speed: u32) -> Result<(), Error> {
-        debug!("Change baud to: {}", speed);
+    pub fn change_baud(&mut self, baud: u32) -> Result<(), Error> {
+        debug!("Change baud to: {}", baud);
 
         let prior_baud = match self.use_stub {
-            true => self.connection.speed(),
+            true => self.connection.baud(),
             false => 0,
         };
 
@@ -1143,7 +1143,7 @@ impl Flasher {
         //
         // The ROM code thinks it uses a 40 MHz XTAL. Recompute the baud rate in order
         // to trick the ROM code to set the correct baud rate for a 26 MHz XTAL.
-        let mut new_baud = speed;
+        let mut new_baud = baud;
         if self.chip == Chip::Esp32c2 && !self.use_stub && xtal_freq == XtalFrequency::_26Mhz {
             new_baud = new_baud * 40 / 26;
         }
@@ -1155,7 +1155,7 @@ impl Flasher {
                     prior_baud,
                 })
             })?;
-        self.connection.set_baud(speed)?;
+        self.connection.set_baud(baud)?;
         sleep(Duration::from_secs_f32(0.05));
         self.connection.flush()?;
 

--- a/espflash/src/image_format/esp_idf.rs
+++ b/espflash/src/image_format/esp_idf.rs
@@ -177,7 +177,7 @@ impl Default for ImageHeader {
 }
 
 impl ImageHeader {
-    /// Updates flash size and speed filed.
+    /// Updates flash size and baud filed.
     pub fn write_flash_config(
         &mut self,
         size: FlashSize,
@@ -185,10 +185,10 @@ impl ImageHeader {
         chip: Chip,
     ) -> Result<(), Error> {
         let flash_size = size.encode_flash_size()?;
-        let flash_speed = freq.encode_flash_frequency(chip)?;
+        let flash_baud = freq.encode_flash_frequency(chip)?;
 
         // bit field
-        self.flash_config = (flash_size << 4) | flash_speed;
+        self.flash_config = (flash_size << 4) | flash_baud;
         Ok(())
     }
 }

--- a/espflash/src/targets/esp32.rs
+++ b/espflash/src/targets/esp32.rs
@@ -149,7 +149,7 @@ impl Target for Esp32 {
     #[cfg(feature = "serialport")]
     fn crystal_freq(&self, connection: &mut Connection) -> Result<XtalFrequency, Error> {
         let uart_div = connection.read_reg(UART_CLKDIV_REG)? & UART_CLKDIV_MASK;
-        let est_xtal = (connection.speed() * uart_div) / 1_000_000 / XTAL_CLK_DIVIDER;
+        let est_xtal = (connection.baud() * uart_div) / 1_000_000 / XTAL_CLK_DIVIDER;
         let norm_xtal = if est_xtal > 33 {
             XtalFrequency::_40Mhz
         } else {

--- a/espflash/src/targets/esp32.rs
+++ b/espflash/src/targets/esp32.rs
@@ -149,7 +149,7 @@ impl Target for Esp32 {
     #[cfg(feature = "serialport")]
     fn crystal_freq(&self, connection: &mut Connection) -> Result<XtalFrequency, Error> {
         let uart_div = connection.read_reg(UART_CLKDIV_REG)? & UART_CLKDIV_MASK;
-        let est_xtal = (connection.baud()? * uart_div) / 1_000_000 / XTAL_CLK_DIVIDER;
+        let est_xtal = (connection.speed() * uart_div) / 1_000_000 / XTAL_CLK_DIVIDER;
         let norm_xtal = if est_xtal > 33 {
             XtalFrequency::_40Mhz
         } else {

--- a/espflash/src/targets/esp32c2.rs
+++ b/espflash/src/targets/esp32c2.rs
@@ -76,7 +76,7 @@ impl Target for Esp32c2 {
     #[cfg(feature = "serialport")]
     fn crystal_freq(&self, connection: &mut Connection) -> Result<XtalFrequency, Error> {
         let uart_div = connection.read_reg(UART_CLKDIV_REG)? & UART_CLKDIV_MASK;
-        let est_xtal = (connection.baud()? * uart_div) / 1_000_000 / XTAL_CLK_DIVIDER;
+        let est_xtal = (connection.speed() * uart_div) / 1_000_000 / XTAL_CLK_DIVIDER;
         let norm_xtal = if est_xtal > 33 {
             XtalFrequency::_40Mhz
         } else {

--- a/espflash/src/targets/esp32c2.rs
+++ b/espflash/src/targets/esp32c2.rs
@@ -76,7 +76,7 @@ impl Target for Esp32c2 {
     #[cfg(feature = "serialport")]
     fn crystal_freq(&self, connection: &mut Connection) -> Result<XtalFrequency, Error> {
         let uart_div = connection.read_reg(UART_CLKDIV_REG)? & UART_CLKDIV_MASK;
-        let est_xtal = (connection.speed() * uart_div) / 1_000_000 / XTAL_CLK_DIVIDER;
+        let est_xtal = (connection.baud() * uart_div) / 1_000_000 / XTAL_CLK_DIVIDER;
         let norm_xtal = if est_xtal > 33 {
             XtalFrequency::_40Mhz
         } else {

--- a/espflash/src/targets/esp32c5.rs
+++ b/espflash/src/targets/esp32c5.rs
@@ -78,7 +78,7 @@ impl Target for Esp32c5 {
     #[cfg(feature = "serialport")]
     fn crystal_freq(&self, connection: &mut Connection) -> Result<XtalFrequency, Error> {
         let uart_div = connection.read_reg(UART_CLKDIV_REG)? & UART_CLKDIV_MASK;
-        let est_xtal = (connection.speed() * uart_div) / 1_000_000 / XTAL_CLK_DIVIDER;
+        let est_xtal = (connection.baud() * uart_div) / 1_000_000 / XTAL_CLK_DIVIDER;
         let norm_xtal = if est_xtal > 45 {
             XtalFrequency::_48Mhz
         } else {

--- a/espflash/src/targets/esp32c5.rs
+++ b/espflash/src/targets/esp32c5.rs
@@ -78,7 +78,7 @@ impl Target for Esp32c5 {
     #[cfg(feature = "serialport")]
     fn crystal_freq(&self, connection: &mut Connection) -> Result<XtalFrequency, Error> {
         let uart_div = connection.read_reg(UART_CLKDIV_REG)? & UART_CLKDIV_MASK;
-        let est_xtal = (connection.baud()? * uart_div) / 1_000_000 / XTAL_CLK_DIVIDER;
+        let est_xtal = (connection.speed() * uart_div) / 1_000_000 / XTAL_CLK_DIVIDER;
         let norm_xtal = if est_xtal > 45 {
             XtalFrequency::_48Mhz
         } else {


### PR DESCRIPTION
This PR implements the first suggestion from https://github.com/esp-rs/espflash/issues/854#issuecomment-2903849411 and enables the creation of a `Connection` outside of `Flasher::connect`.

In general this PR tries to keep the `Connection` specific things, like `sync`ing, baud rate control, reset etc in `Connection` and the flasher related things, like querying spi params, loading the flasher stub etc in `Flasher`. 