### PR TITLE
Only change baud if neccesary

### DIFF
--- a/espflash/src/flasher/mod.rs
+++ b/espflash/src/flasher/mod.rs
@@ -1148,6 +1148,11 @@ impl Flasher {
             new_baud = new_baud * 40 / 26;
         }
 
+        if prior_baud == new_baud {
+            debug!("Baud rate is already set to {}", baud);
+            return Ok(());
+        }
+
         self.connection
             .with_timeout(CommandType::ChangeBaudrate.timeout(), |connection| {
                 connection.command(Command::ChangeBaudrate {


### PR DESCRIPTION
https://github.com/esp-rs/espflash/pull/882/files#diff-e53a42b9f8c1ec16423891fcffa2c2a2fda60d4a70f42ddb0771db4ad11b05c0R709-R711 introduced an issue where it would timeout if we try changing the baud to the same baud that is using. 