### PR TITLE
Make reset operations public so Connection::new can be called

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,7 +73,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed a case where esplash transformed the firmware elf in a way that made it unbootable (#831)
 - The app descriptor is now correctly placed in the front of the bianry (#835)
 - espflash now extracts the MMU page size from the app descriptor (#835)
-- `ResetBeforeOperation` & `ResetAfterOperation` are now public, to allow the creation of a `Connection` (#882)
+- `ResetBeforeOperation` & `ResetAfterOperation` are now public, to allow the creation of a `Connection` (#895)
 
 ### Removed
 

--- a/espflash/src/connection/mod.rs
+++ b/espflash/src/connection/mod.rs
@@ -23,8 +23,6 @@ use self::{
     encoder::SlipEncoder,
     reset::{
         ClassicReset,
-        ResetAfterOperation,
-        ResetBeforeOperation,
         ResetStrategy,
         UsbJtagSerialReset,
         construct_reset_strategy_sequence,
@@ -41,6 +39,8 @@ use crate::{
 
 pub(crate) mod command;
 pub(crate) mod reset;
+
+pub use reset::{ResetAfterOperation, ResetBeforeOperation};
 
 const MAX_CONNECT_ATTEMPTS: usize = 7;
 const MAX_SYNC_ATTEMPTS: usize = 5;


### PR DESCRIPTION
Apparently I rebased the actually change away in https://github.com/esp-rs/espflash/pull/882