### PR TITLE
Make eFuse field definitions public, minor public API cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `Connection::into_serial` to get the underlying port from the connection (#882)
 - All methods on the now removed `Target` & `ReadEFuse`, `UsbOtg` and `RtcWdtReset` traits have been implemented directly on (#891)
 - Update checks can now be skipped by setting the the `ESPFLASH_SKIP_UPDATE_CHECK` environment variable (#900)
+- `flash_write_size` and `max_ram_block_size` functions no longer take a connection parameter and return a Result type (#903)
 
 ### Changed
 
@@ -48,7 +49,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Removed `get_` prefix from any functions which previously had it (#824)
 - Take elf data as bytes rather than `ElfFile` struct when creating an image format (#825)
 - Updated to Rust 2024 edition (#843)
-- Complete rework of reading eFuse field values (#847)
+- Complete rework of reading eFuse field values (#847, #903)
 - Updated bootloaders with `release/v5.4` ones from IDF (#857)
 - Refactor image formatting to allow supporting more image formats in a backward compatible way (#877)
 - Avoid having ESP-IDF format assumptions in the codebase (#877)

--- a/espflash/src/flasher/mod.rs
+++ b/espflash/src/flasher/mod.rs
@@ -19,8 +19,6 @@ use object::{Endianness, read::elf::ElfFile32 as ElfFile};
 use serde::{Deserialize, Serialize};
 use strum::{Display, EnumIter, IntoEnumIterator, VariantNames};
 
-#[cfg(feature = "serialport")]
-pub(crate) use self::stubs::{FLASH_SECTOR_SIZE, FLASH_WRITE_SIZE};
 use crate::{
     Error,
     target::{Chip, XtalFrequency},
@@ -49,6 +47,10 @@ pub(crate) mod stubs;
 #[cfg(feature = "serialport")]
 pub(crate) const TRY_SPI_PARAMS: [SpiAttachParams; 2] =
     [SpiAttachParams::default(), SpiAttachParams::esp32_pico_d4()];
+
+#[cfg(feature = "serialport")]
+pub(crate) const FLASH_SECTOR_SIZE: usize = 0x1000;
+pub(crate) const FLASH_WRITE_SIZE: usize = 0x400;
 
 /// Progress update callbacks
 pub trait ProgressCallbacks {
@@ -748,10 +750,9 @@ impl Flasher {
         // Load flash stub
         let stub = FlashStub::get(self.chip);
 
-        let mut ram_target = self.chip.ram_target(
-            Some(stub.entry()),
-            self.chip.max_ram_block_size(&mut self.connection)?,
-        );
+        let mut ram_target = self
+            .chip
+            .ram_target(Some(stub.entry()), self.chip.max_ram_block_size());
         ram_target.begin(&mut self.connection).flashing()?;
 
         let (text_addr, text) = stub.text();
@@ -1024,7 +1025,7 @@ impl Flasher {
 
         let mut target = self.chip.ram_target(
             Some(elf.elf_header().e_entry.get(Endianness::Little)),
-            self.chip.max_ram_block_size(&mut self.connection)?,
+            self.chip.max_ram_block_size(),
         );
         target.begin(&mut self.connection).flashing()?;
 

--- a/espflash/src/flasher/stubs.rs
+++ b/espflash/src/flasher/stubs.rs
@@ -25,9 +25,6 @@ pub(crate) const CHIP_DETECT_MAGIC_REG_ADDR: u32 = 0x40001000;
 pub(crate) const DEFAULT_TIMEOUT: Duration = Duration::from_secs(3);
 pub(crate) const EXPECTED_STUB_HANDSHAKE: &str = "OHAI";
 
-pub(crate) const FLASH_SECTOR_SIZE: usize = 0x1000;
-pub(crate) const FLASH_WRITE_SIZE: usize = 0x400;
-
 // Include stub objects in binary
 const STUB_32: &str = include_str!("../../resources/stubs/esp32.toml");
 const STUB_32C2: &str = include_str!("../../resources/stubs/esp32c2.toml");

--- a/espflash/src/target/efuse/esp32.rs
+++ b/espflash/src/target/efuse/esp32.rs
@@ -1,6 +1,8 @@
+//! eFuse field definitions for the esp32
+//!
 //! This file was automatically generated, please do not edit it manually!
 //!
-//! Generated: 2025-06-25 09:59
+//! Generated: 2025-06-25 11:06
 //! Version:   369d2d860d34e777c0f7d545a7dfc3c4
 
 #![allow(unused)]

--- a/espflash/src/target/efuse/esp32.rs
+++ b/espflash/src/target/efuse/esp32.rs
@@ -1,6 +1,6 @@
 //! This file was automatically generated, please do not edit it manually!
 //!
-//! Generated: 2025-05-30 12:24
+//! Generated: 2025-06-25 09:59
 //! Version:   369d2d860d34e777c0f7d545a7dfc3c4
 
 #![allow(unused)]
@@ -11,135 +11,135 @@ use super::EfuseField;
 pub(crate) const BLOCK_SIZES: &[u32] = &[28, 32, 32, 32];
 
 /// Efuse write disable mask
-pub(crate) const WR_DIS: EfuseField = EfuseField::new(0, 0, 0, 16);
+pub const WR_DIS: EfuseField = EfuseField::new(0, 0, 0, 16);
 /// Disable reading from BlOCK1-3
-pub(crate) const RD_DIS: EfuseField = EfuseField::new(0, 0, 16, 4);
+pub const RD_DIS: EfuseField = EfuseField::new(0, 0, 16, 4);
 /// Flash encryption is enabled if this field has an odd number of bits set
-pub(crate) const FLASH_CRYPT_CNT: EfuseField = EfuseField::new(0, 0, 20, 7);
+pub const FLASH_CRYPT_CNT: EfuseField = EfuseField::new(0, 0, 20, 7);
 /// Disable UART download mode. Valid for ESP32 V3 and newer; only
-pub(crate) const UART_DOWNLOAD_DIS: EfuseField = EfuseField::new(0, 0, 27, 1);
+pub const UART_DOWNLOAD_DIS: EfuseField = EfuseField::new(0, 0, 27, 1);
 /// reserved
-pub(crate) const RESERVED_0_28: EfuseField = EfuseField::new(0, 0, 28, 4);
+pub const RESERVED_0_28: EfuseField = EfuseField::new(0, 0, 28, 4);
 /// MAC address
-pub(crate) const MAC0: EfuseField = EfuseField::new(0, 1, 32, 32);
+pub const MAC0: EfuseField = EfuseField::new(0, 1, 32, 32);
 /// MAC address
-pub(crate) const MAC1: EfuseField = EfuseField::new(0, 2, 64, 16);
+pub const MAC1: EfuseField = EfuseField::new(0, 2, 64, 16);
 /// CRC8 for MAC address
-pub(crate) const MAC_CRC: EfuseField = EfuseField::new(0, 2, 80, 8);
+pub const MAC_CRC: EfuseField = EfuseField::new(0, 2, 80, 8);
 /// Reserved; it was created by set_missed_fields_in_regs func
-pub(crate) const RESERVE_0_88: EfuseField = EfuseField::new(0, 2, 88, 8);
+pub const RESERVE_0_88: EfuseField = EfuseField::new(0, 2, 88, 8);
 /// Disables APP CPU
-pub(crate) const DISABLE_APP_CPU: EfuseField = EfuseField::new(0, 3, 96, 1);
+pub const DISABLE_APP_CPU: EfuseField = EfuseField::new(0, 3, 96, 1);
 /// Disables Bluetooth
-pub(crate) const DISABLE_BT: EfuseField = EfuseField::new(0, 3, 97, 1);
+pub const DISABLE_BT: EfuseField = EfuseField::new(0, 3, 97, 1);
 /// Chip package identifier #4bit
-pub(crate) const CHIP_PACKAGE_4BIT: EfuseField = EfuseField::new(0, 3, 98, 1);
+pub const CHIP_PACKAGE_4BIT: EfuseField = EfuseField::new(0, 3, 98, 1);
 /// Disables cache
-pub(crate) const DIS_CACHE: EfuseField = EfuseField::new(0, 3, 99, 1);
+pub const DIS_CACHE: EfuseField = EfuseField::new(0, 3, 99, 1);
 /// read for SPI_pad_config_hd
-pub(crate) const SPI_PAD_CONFIG_HD: EfuseField = EfuseField::new(0, 3, 100, 5);
+pub const SPI_PAD_CONFIG_HD: EfuseField = EfuseField::new(0, 3, 100, 5);
 /// Chip package identifier
-pub(crate) const CHIP_PACKAGE: EfuseField = EfuseField::new(0, 3, 105, 3);
+pub const CHIP_PACKAGE: EfuseField = EfuseField::new(0, 3, 105, 3);
 /// If set alongside EFUSE_RD_CHIP_CPU_FREQ_RATED; the ESP32's max CPU frequency
 /// is rated for 160MHz. 240MHz otherwise
-pub(crate) const CHIP_CPU_FREQ_LOW: EfuseField = EfuseField::new(0, 3, 108, 1);
+pub const CHIP_CPU_FREQ_LOW: EfuseField = EfuseField::new(0, 3, 108, 1);
 /// If set; the ESP32's maximum CPU frequency has been rated
-pub(crate) const CHIP_CPU_FREQ_RATED: EfuseField = EfuseField::new(0, 3, 109, 1);
+pub const CHIP_CPU_FREQ_RATED: EfuseField = EfuseField::new(0, 3, 109, 1);
 /// BLOCK3 partially served for ADC calibration data
-pub(crate) const BLK3_PART_RESERVE: EfuseField = EfuseField::new(0, 3, 110, 1);
+pub const BLK3_PART_RESERVE: EfuseField = EfuseField::new(0, 3, 110, 1);
 /// bit is set to 1 for rev1 silicon
-pub(crate) const CHIP_VER_REV1: EfuseField = EfuseField::new(0, 3, 111, 1);
+pub const CHIP_VER_REV1: EfuseField = EfuseField::new(0, 3, 111, 1);
 /// Reserved; it was created by set_missed_fields_in_regs func
-pub(crate) const RESERVE_0_112: EfuseField = EfuseField::new(0, 3, 112, 16);
+pub const RESERVE_0_112: EfuseField = EfuseField::new(0, 3, 112, 16);
 /// 8MHz clock freq override
-pub(crate) const CLK8M_FREQ: EfuseField = EfuseField::new(0, 4, 128, 8);
+pub const CLK8M_FREQ: EfuseField = EfuseField::new(0, 4, 128, 8);
 /// True ADC reference voltage
-pub(crate) const ADC_VREF: EfuseField = EfuseField::new(0, 4, 136, 5);
+pub const ADC_VREF: EfuseField = EfuseField::new(0, 4, 136, 5);
 /// Reserved; it was created by set_missed_fields_in_regs func
-pub(crate) const RESERVE_0_141: EfuseField = EfuseField::new(0, 4, 141, 1);
+pub const RESERVE_0_141: EfuseField = EfuseField::new(0, 4, 141, 1);
 /// read for XPD_SDIO_REG
-pub(crate) const XPD_SDIO_REG: EfuseField = EfuseField::new(0, 4, 142, 1);
+pub const XPD_SDIO_REG: EfuseField = EfuseField::new(0, 4, 142, 1);
 /// If XPD_SDIO_FORCE & XPD_SDIO_REG
-pub(crate) const XPD_SDIO_TIEH: EfuseField = EfuseField::new(0, 4, 143, 1);
+pub const XPD_SDIO_TIEH: EfuseField = EfuseField::new(0, 4, 143, 1);
 /// Ignore MTDI pin (GPIO12) for VDD_SDIO on reset
-pub(crate) const XPD_SDIO_FORCE: EfuseField = EfuseField::new(0, 4, 144, 1);
+pub const XPD_SDIO_FORCE: EfuseField = EfuseField::new(0, 4, 144, 1);
 /// Reserved; it was created by set_missed_fields_in_regs func
-pub(crate) const RESERVE_0_145: EfuseField = EfuseField::new(0, 4, 145, 15);
+pub const RESERVE_0_145: EfuseField = EfuseField::new(0, 4, 145, 15);
 /// Override SD_CLK pad (GPIO6/SPICLK)
-pub(crate) const SPI_PAD_CONFIG_CLK: EfuseField = EfuseField::new(0, 5, 160, 5);
+pub const SPI_PAD_CONFIG_CLK: EfuseField = EfuseField::new(0, 5, 160, 5);
 /// Override SD_DATA_0 pad (GPIO7/SPIQ)
-pub(crate) const SPI_PAD_CONFIG_Q: EfuseField = EfuseField::new(0, 5, 165, 5);
+pub const SPI_PAD_CONFIG_Q: EfuseField = EfuseField::new(0, 5, 165, 5);
 /// Override SD_DATA_1 pad (GPIO8/SPID)
-pub(crate) const SPI_PAD_CONFIG_D: EfuseField = EfuseField::new(0, 5, 170, 5);
+pub const SPI_PAD_CONFIG_D: EfuseField = EfuseField::new(0, 5, 170, 5);
 /// Override SD_CMD pad (GPIO11/SPICS0)
-pub(crate) const SPI_PAD_CONFIG_CS0: EfuseField = EfuseField::new(0, 5, 175, 5);
+pub const SPI_PAD_CONFIG_CS0: EfuseField = EfuseField::new(0, 5, 175, 5);
 ///
-pub(crate) const CHIP_VER_REV2: EfuseField = EfuseField::new(0, 5, 180, 1);
+pub const CHIP_VER_REV2: EfuseField = EfuseField::new(0, 5, 180, 1);
 /// Reserved; it was created by set_missed_fields_in_regs func
-pub(crate) const RESERVE_0_181: EfuseField = EfuseField::new(0, 5, 181, 1);
+pub const RESERVE_0_181: EfuseField = EfuseField::new(0, 5, 181, 1);
 /// This field stores the voltage level for CPU to run at 240 MHz; or for
 /// flash/PSRAM to run at 80 MHz.0x0: level 7; 0x1: level 6; 0x2: level 5; 0x3:
 /// level 4. (RO)
-pub(crate) const VOL_LEVEL_HP_INV: EfuseField = EfuseField::new(0, 5, 182, 2);
+pub const VOL_LEVEL_HP_INV: EfuseField = EfuseField::new(0, 5, 182, 2);
 ///
-pub(crate) const WAFER_VERSION_MINOR: EfuseField = EfuseField::new(0, 5, 184, 2);
+pub const WAFER_VERSION_MINOR: EfuseField = EfuseField::new(0, 5, 184, 2);
 /// Reserved; it was created by set_missed_fields_in_regs func
-pub(crate) const RESERVE_0_186: EfuseField = EfuseField::new(0, 5, 186, 2);
+pub const RESERVE_0_186: EfuseField = EfuseField::new(0, 5, 186, 2);
 /// Flash encryption config (key tweak bits)
-pub(crate) const FLASH_CRYPT_CONFIG: EfuseField = EfuseField::new(0, 5, 188, 4);
+pub const FLASH_CRYPT_CONFIG: EfuseField = EfuseField::new(0, 5, 188, 4);
 /// Efuse variable block length scheme
-pub(crate) const CODING_SCHEME: EfuseField = EfuseField::new(0, 6, 192, 2);
+pub const CODING_SCHEME: EfuseField = EfuseField::new(0, 6, 192, 2);
 /// Disable ROM BASIC interpreter fallback
-pub(crate) const CONSOLE_DEBUG_DISABLE: EfuseField = EfuseField::new(0, 6, 194, 1);
+pub const CONSOLE_DEBUG_DISABLE: EfuseField = EfuseField::new(0, 6, 194, 1);
 ///
-pub(crate) const DISABLE_SDIO_HOST: EfuseField = EfuseField::new(0, 6, 195, 1);
+pub const DISABLE_SDIO_HOST: EfuseField = EfuseField::new(0, 6, 195, 1);
 /// Secure boot V1 is enabled for bootloader image
-pub(crate) const ABS_DONE_0: EfuseField = EfuseField::new(0, 6, 196, 1);
+pub const ABS_DONE_0: EfuseField = EfuseField::new(0, 6, 196, 1);
 /// Secure boot V2 is enabled for bootloader image
-pub(crate) const ABS_DONE_1: EfuseField = EfuseField::new(0, 6, 197, 1);
+pub const ABS_DONE_1: EfuseField = EfuseField::new(0, 6, 197, 1);
 /// Disable JTAG
-pub(crate) const JTAG_DISABLE: EfuseField = EfuseField::new(0, 6, 198, 1);
+pub const JTAG_DISABLE: EfuseField = EfuseField::new(0, 6, 198, 1);
 /// Disable flash encryption in UART bootloader
-pub(crate) const DISABLE_DL_ENCRYPT: EfuseField = EfuseField::new(0, 6, 199, 1);
+pub const DISABLE_DL_ENCRYPT: EfuseField = EfuseField::new(0, 6, 199, 1);
 /// Disable flash decryption in UART bootloader
-pub(crate) const DISABLE_DL_DECRYPT: EfuseField = EfuseField::new(0, 6, 200, 1);
+pub const DISABLE_DL_DECRYPT: EfuseField = EfuseField::new(0, 6, 200, 1);
 /// Disable flash cache in UART bootloader
-pub(crate) const DISABLE_DL_CACHE: EfuseField = EfuseField::new(0, 6, 201, 1);
+pub const DISABLE_DL_CACHE: EfuseField = EfuseField::new(0, 6, 201, 1);
 /// Usage of efuse block 3 (reserved)
-pub(crate) const KEY_STATUS: EfuseField = EfuseField::new(0, 6, 202, 1);
+pub const KEY_STATUS: EfuseField = EfuseField::new(0, 6, 202, 1);
 /// Reserved; it was created by set_missed_fields_in_regs func
-pub(crate) const RESERVE_0_203: EfuseField = EfuseField::new(0, 6, 203, 21);
+pub const RESERVE_0_203: EfuseField = EfuseField::new(0, 6, 203, 21);
 /// Flash encryption key
-pub(crate) const BLOCK1: EfuseField = EfuseField::new(1, 0, 0, 256);
+pub const BLOCK1: EfuseField = EfuseField::new(1, 0, 0, 256);
 /// Security boot key
-pub(crate) const BLOCK2: EfuseField = EfuseField::new(2, 0, 0, 256);
+pub const BLOCK2: EfuseField = EfuseField::new(2, 0, 0, 256);
 /// CRC8 for custom MAC address
-pub(crate) const CUSTOM_MAC_CRC: EfuseField = EfuseField::new(3, 0, 0, 8);
+pub const CUSTOM_MAC_CRC: EfuseField = EfuseField::new(3, 0, 0, 8);
 /// Custom MAC address
-pub(crate) const CUSTOM_MAC: EfuseField = EfuseField::new(3, 0, 8, 48);
+pub const CUSTOM_MAC: EfuseField = EfuseField::new(3, 0, 8, 48);
 /// reserved
-pub(crate) const RESERVED_3_56: EfuseField = EfuseField::new(3, 1, 56, 8);
+pub const RESERVED_3_56: EfuseField = EfuseField::new(3, 1, 56, 8);
 /// read for BLOCK3
-pub(crate) const BLK3_RESERVED_2: EfuseField = EfuseField::new(3, 2, 64, 32);
+pub const BLK3_RESERVED_2: EfuseField = EfuseField::new(3, 2, 64, 32);
 /// ADC1 Two Point calibration low point. Only valid if
 /// EFUSE_RD_BLK3_PART_RESERVE
-pub(crate) const ADC1_TP_LOW: EfuseField = EfuseField::new(3, 3, 96, 7);
+pub const ADC1_TP_LOW: EfuseField = EfuseField::new(3, 3, 96, 7);
 /// ADC1 Two Point calibration high point. Only valid if
 /// EFUSE_RD_BLK3_PART_RESERVE
-pub(crate) const ADC1_TP_HIGH: EfuseField = EfuseField::new(3, 3, 103, 9);
+pub const ADC1_TP_HIGH: EfuseField = EfuseField::new(3, 3, 103, 9);
 /// ADC2 Two Point calibration low point. Only valid if
 /// EFUSE_RD_BLK3_PART_RESERVE
-pub(crate) const ADC2_TP_LOW: EfuseField = EfuseField::new(3, 3, 112, 7);
+pub const ADC2_TP_LOW: EfuseField = EfuseField::new(3, 3, 112, 7);
 /// ADC2 Two Point calibration high point. Only valid if
 /// EFUSE_RD_BLK3_PART_RESERVE
-pub(crate) const ADC2_TP_HIGH: EfuseField = EfuseField::new(3, 3, 119, 9);
+pub const ADC2_TP_HIGH: EfuseField = EfuseField::new(3, 3, 119, 9);
 /// Secure version for anti-rollback
-pub(crate) const SECURE_VERSION: EfuseField = EfuseField::new(3, 4, 128, 32);
+pub const SECURE_VERSION: EfuseField = EfuseField::new(3, 4, 128, 32);
 /// reserved
-pub(crate) const RESERVED_3_160: EfuseField = EfuseField::new(3, 5, 160, 24);
+pub const RESERVED_3_160: EfuseField = EfuseField::new(3, 5, 160, 24);
 /// Version of the MAC field
-pub(crate) const MAC_VERSION: EfuseField = EfuseField::new(3, 5, 184, 8);
+pub const MAC_VERSION: EfuseField = EfuseField::new(3, 5, 184, 8);
 /// read for BLOCK3
-pub(crate) const BLK3_RESERVED_6: EfuseField = EfuseField::new(3, 6, 192, 32);
+pub const BLK3_RESERVED_6: EfuseField = EfuseField::new(3, 6, 192, 32);
 /// read for BLOCK3
-pub(crate) const BLK3_RESERVED_7: EfuseField = EfuseField::new(3, 7, 224, 32);
+pub const BLK3_RESERVED_7: EfuseField = EfuseField::new(3, 7, 224, 32);

--- a/espflash/src/target/efuse/esp32c2.rs
+++ b/espflash/src/target/efuse/esp32c2.rs
@@ -1,6 +1,6 @@
 //! This file was automatically generated, please do not edit it manually!
 //!
-//! Generated: 2025-05-30 12:24
+//! Generated: 2025-06-25 09:59
 //! Version:   897499b0349a608b895d467abbcf006b
 
 #![allow(unused)]
@@ -11,108 +11,108 @@ use super::EfuseField;
 pub(crate) const BLOCK_SIZES: &[u32] = &[8, 11, 32, 32];
 
 /// Disable programming of individual eFuses
-pub(crate) const WR_DIS: EfuseField = EfuseField::new(0, 0, 0, 8);
+pub const WR_DIS: EfuseField = EfuseField::new(0, 0, 0, 8);
 ///
-pub(crate) const RESERVED_0_8: EfuseField = EfuseField::new(0, 0, 8, 24);
+pub const RESERVED_0_8: EfuseField = EfuseField::new(0, 0, 8, 24);
 /// Disable reading from BlOCK3
-pub(crate) const RD_DIS: EfuseField = EfuseField::new(0, 1, 32, 2);
+pub const RD_DIS: EfuseField = EfuseField::new(0, 1, 32, 2);
 /// RTC watchdog timeout threshold; in unit of slow clock cycle
-pub(crate) const WDT_DELAY_SEL: EfuseField = EfuseField::new(0, 1, 34, 2);
+pub const WDT_DELAY_SEL: EfuseField = EfuseField::new(0, 1, 34, 2);
 /// Set this bit to disable pad jtag
-pub(crate) const DIS_PAD_JTAG: EfuseField = EfuseField::new(0, 1, 36, 1);
+pub const DIS_PAD_JTAG: EfuseField = EfuseField::new(0, 1, 36, 1);
 /// The bit be set to disable icache in download mode
-pub(crate) const DIS_DOWNLOAD_ICACHE: EfuseField = EfuseField::new(0, 1, 37, 1);
+pub const DIS_DOWNLOAD_ICACHE: EfuseField = EfuseField::new(0, 1, 37, 1);
 /// The bit be set to disable manual encryption
-pub(crate) const DIS_DOWNLOAD_MANUAL_ENCRYPT: EfuseField = EfuseField::new(0, 1, 38, 1);
+pub const DIS_DOWNLOAD_MANUAL_ENCRYPT: EfuseField = EfuseField::new(0, 1, 38, 1);
 /// Enables flash encryption when 1 or 3 bits are set and disables otherwise
-pub(crate) const SPI_BOOT_CRYPT_CNT: EfuseField = EfuseField::new(0, 1, 39, 3);
+pub const SPI_BOOT_CRYPT_CNT: EfuseField = EfuseField::new(0, 1, 39, 3);
 /// Flash encryption key length
-pub(crate) const XTS_KEY_LENGTH_256: EfuseField = EfuseField::new(0, 1, 42, 1);
+pub const XTS_KEY_LENGTH_256: EfuseField = EfuseField::new(0, 1, 42, 1);
 /// Set the default UARTboot message output mode
-pub(crate) const UART_PRINT_CONTROL: EfuseField = EfuseField::new(0, 1, 43, 2);
+pub const UART_PRINT_CONTROL: EfuseField = EfuseField::new(0, 1, 43, 2);
 /// Set this bit to force ROM code to send a resume command during SPI boot
-pub(crate) const FORCE_SEND_RESUME: EfuseField = EfuseField::new(0, 1, 45, 1);
+pub const FORCE_SEND_RESUME: EfuseField = EfuseField::new(0, 1, 45, 1);
 /// Set this bit to disable download mode (boot_mode[3:0] = 0; 1; 2; 4; 5; 6; 7)
-pub(crate) const DIS_DOWNLOAD_MODE: EfuseField = EfuseField::new(0, 1, 46, 1);
+pub const DIS_DOWNLOAD_MODE: EfuseField = EfuseField::new(0, 1, 46, 1);
 /// This bit set means disable direct_boot mode
-pub(crate) const DIS_DIRECT_BOOT: EfuseField = EfuseField::new(0, 1, 47, 1);
+pub const DIS_DIRECT_BOOT: EfuseField = EfuseField::new(0, 1, 47, 1);
 /// Set this bit to enable secure UART download mode
-pub(crate) const ENABLE_SECURITY_DOWNLOAD: EfuseField = EfuseField::new(0, 1, 48, 1);
+pub const ENABLE_SECURITY_DOWNLOAD: EfuseField = EfuseField::new(0, 1, 48, 1);
 /// Configures flash waiting time after power-up; in unit of ms. If the value is
 /// less than 15; the waiting time is the configurable value.  Otherwise; the
 /// waiting time is twice the configurable value
-pub(crate) const FLASH_TPUW: EfuseField = EfuseField::new(0, 1, 49, 4);
+pub const FLASH_TPUW: EfuseField = EfuseField::new(0, 1, 49, 4);
 /// The bit be set to enable secure boot
-pub(crate) const SECURE_BOOT_EN: EfuseField = EfuseField::new(0, 1, 53, 1);
+pub const SECURE_BOOT_EN: EfuseField = EfuseField::new(0, 1, 53, 1);
 /// Secure version for anti-rollback
-pub(crate) const SECURE_VERSION: EfuseField = EfuseField::new(0, 1, 54, 4);
+pub const SECURE_VERSION: EfuseField = EfuseField::new(0, 1, 54, 4);
 /// True if MAC_CUSTOM is burned
-pub(crate) const CUSTOM_MAC_USED: EfuseField = EfuseField::new(0, 1, 58, 1);
+pub const CUSTOM_MAC_USED: EfuseField = EfuseField::new(0, 1, 58, 1);
 /// Disables check of wafer version major
-pub(crate) const DISABLE_WAFER_VERSION_MAJOR: EfuseField = EfuseField::new(0, 1, 59, 1);
+pub const DISABLE_WAFER_VERSION_MAJOR: EfuseField = EfuseField::new(0, 1, 59, 1);
 /// Disables check of blk version major
-pub(crate) const DISABLE_BLK_VERSION_MAJOR: EfuseField = EfuseField::new(0, 1, 60, 1);
+pub const DISABLE_BLK_VERSION_MAJOR: EfuseField = EfuseField::new(0, 1, 60, 1);
 /// reserved
-pub(crate) const RESERVED_0_61: EfuseField = EfuseField::new(0, 1, 61, 3);
+pub const RESERVED_0_61: EfuseField = EfuseField::new(0, 1, 61, 3);
 /// Custom MAC address
-pub(crate) const CUSTOM_MAC: EfuseField = EfuseField::new(1, 0, 0, 48);
+pub const CUSTOM_MAC: EfuseField = EfuseField::new(1, 0, 0, 48);
 /// reserved
-pub(crate) const RESERVED_1_48: EfuseField = EfuseField::new(1, 1, 48, 16);
+pub const RESERVED_1_48: EfuseField = EfuseField::new(1, 1, 48, 16);
 /// Stores the bits [64:87] of system data
-pub(crate) const SYSTEM_DATA2: EfuseField = EfuseField::new(1, 2, 64, 24);
+pub const SYSTEM_DATA2: EfuseField = EfuseField::new(1, 2, 64, 24);
 /// MAC address
-pub(crate) const MAC0: EfuseField = EfuseField::new(2, 0, 0, 32);
+pub const MAC0: EfuseField = EfuseField::new(2, 0, 0, 32);
 /// MAC address
-pub(crate) const MAC1: EfuseField = EfuseField::new(2, 1, 32, 16);
+pub const MAC1: EfuseField = EfuseField::new(2, 1, 32, 16);
 /// WAFER_VERSION_MINOR
-pub(crate) const WAFER_VERSION_MINOR: EfuseField = EfuseField::new(2, 1, 48, 4);
+pub const WAFER_VERSION_MINOR: EfuseField = EfuseField::new(2, 1, 48, 4);
 /// WAFER_VERSION_MAJOR
-pub(crate) const WAFER_VERSION_MAJOR: EfuseField = EfuseField::new(2, 1, 52, 2);
+pub const WAFER_VERSION_MAJOR: EfuseField = EfuseField::new(2, 1, 52, 2);
 /// EFUSE_PKG_VERSION
-pub(crate) const PKG_VERSION: EfuseField = EfuseField::new(2, 1, 54, 3);
+pub const PKG_VERSION: EfuseField = EfuseField::new(2, 1, 54, 3);
 /// Minor version of BLOCK2
-pub(crate) const BLK_VERSION_MINOR: EfuseField = EfuseField::new(2, 1, 57, 3);
+pub const BLK_VERSION_MINOR: EfuseField = EfuseField::new(2, 1, 57, 3);
 /// Major version of BLOCK2
-pub(crate) const BLK_VERSION_MAJOR: EfuseField = EfuseField::new(2, 1, 60, 2);
+pub const BLK_VERSION_MAJOR: EfuseField = EfuseField::new(2, 1, 60, 2);
 /// OCode
-pub(crate) const OCODE: EfuseField = EfuseField::new(2, 1, 62, 7);
+pub const OCODE: EfuseField = EfuseField::new(2, 1, 62, 7);
 /// Temperature calibration data
-pub(crate) const TEMP_CALIB: EfuseField = EfuseField::new(2, 2, 69, 9);
+pub const TEMP_CALIB: EfuseField = EfuseField::new(2, 2, 69, 9);
 /// ADC1 init code at atten0
-pub(crate) const ADC1_INIT_CODE_ATTEN0: EfuseField = EfuseField::new(2, 2, 78, 8);
+pub const ADC1_INIT_CODE_ATTEN0: EfuseField = EfuseField::new(2, 2, 78, 8);
 /// ADC1 init code at atten3
-pub(crate) const ADC1_INIT_CODE_ATTEN3: EfuseField = EfuseField::new(2, 2, 86, 5);
+pub const ADC1_INIT_CODE_ATTEN3: EfuseField = EfuseField::new(2, 2, 86, 5);
 /// ADC1 calibration voltage at atten0
-pub(crate) const ADC1_CAL_VOL_ATTEN0: EfuseField = EfuseField::new(2, 2, 91, 8);
+pub const ADC1_CAL_VOL_ATTEN0: EfuseField = EfuseField::new(2, 2, 91, 8);
 /// ADC1 calibration voltage at atten3
-pub(crate) const ADC1_CAL_VOL_ATTEN3: EfuseField = EfuseField::new(2, 3, 99, 6);
+pub const ADC1_CAL_VOL_ATTEN3: EfuseField = EfuseField::new(2, 3, 99, 6);
 /// BLOCK2 digital dbias when hvt
-pub(crate) const DIG_DBIAS_HVT: EfuseField = EfuseField::new(2, 3, 105, 5);
+pub const DIG_DBIAS_HVT: EfuseField = EfuseField::new(2, 3, 105, 5);
 /// BLOCK2 DIG_LDO_DBG0_DBIAS2
-pub(crate) const DIG_LDO_SLP_DBIAS2: EfuseField = EfuseField::new(2, 3, 110, 7);
+pub const DIG_LDO_SLP_DBIAS2: EfuseField = EfuseField::new(2, 3, 110, 7);
 /// BLOCK2 DIG_LDO_DBG0_DBIAS26
-pub(crate) const DIG_LDO_SLP_DBIAS26: EfuseField = EfuseField::new(2, 3, 117, 8);
+pub const DIG_LDO_SLP_DBIAS26: EfuseField = EfuseField::new(2, 3, 117, 8);
 /// BLOCK2 DIG_LDO_ACT_DBIAS26
-pub(crate) const DIG_LDO_ACT_DBIAS26: EfuseField = EfuseField::new(2, 3, 125, 6);
+pub const DIG_LDO_ACT_DBIAS26: EfuseField = EfuseField::new(2, 3, 125, 6);
 /// BLOCK2 DIG_LDO_ACT_STEPD10
-pub(crate) const DIG_LDO_ACT_STEPD10: EfuseField = EfuseField::new(2, 4, 131, 4);
+pub const DIG_LDO_ACT_STEPD10: EfuseField = EfuseField::new(2, 4, 131, 4);
 /// BLOCK2 DIG_LDO_SLP_DBIAS13
-pub(crate) const RTC_LDO_SLP_DBIAS13: EfuseField = EfuseField::new(2, 4, 135, 7);
+pub const RTC_LDO_SLP_DBIAS13: EfuseField = EfuseField::new(2, 4, 135, 7);
 /// BLOCK2 DIG_LDO_SLP_DBIAS29
-pub(crate) const RTC_LDO_SLP_DBIAS29: EfuseField = EfuseField::new(2, 4, 142, 9);
+pub const RTC_LDO_SLP_DBIAS29: EfuseField = EfuseField::new(2, 4, 142, 9);
 /// BLOCK2 DIG_LDO_SLP_DBIAS31
-pub(crate) const RTC_LDO_SLP_DBIAS31: EfuseField = EfuseField::new(2, 4, 151, 6);
+pub const RTC_LDO_SLP_DBIAS31: EfuseField = EfuseField::new(2, 4, 151, 6);
 /// BLOCK2 DIG_LDO_ACT_DBIAS31
-pub(crate) const RTC_LDO_ACT_DBIAS31: EfuseField = EfuseField::new(2, 4, 157, 6);
+pub const RTC_LDO_ACT_DBIAS31: EfuseField = EfuseField::new(2, 4, 157, 6);
 /// BLOCK2 DIG_LDO_ACT_DBIAS13
-pub(crate) const RTC_LDO_ACT_DBIAS13: EfuseField = EfuseField::new(2, 5, 163, 8);
+pub const RTC_LDO_ACT_DBIAS13: EfuseField = EfuseField::new(2, 5, 163, 8);
 /// reserved
-pub(crate) const RESERVED_2_171: EfuseField = EfuseField::new(2, 5, 171, 21);
+pub const RESERVED_2_171: EfuseField = EfuseField::new(2, 5, 171, 21);
 /// Store the bit [86:96] of ADC calibration data
-pub(crate) const ADC_CALIBRATION_3: EfuseField = EfuseField::new(2, 6, 192, 11);
+pub const ADC_CALIBRATION_3: EfuseField = EfuseField::new(2, 6, 192, 11);
 /// Store the bit [0:20] of block2 reserved data
-pub(crate) const BLK2_RESERVED_DATA_0: EfuseField = EfuseField::new(2, 6, 203, 21);
+pub const BLK2_RESERVED_DATA_0: EfuseField = EfuseField::new(2, 6, 203, 21);
 /// Store the bit [21:52] of block2 reserved data
-pub(crate) const BLK2_RESERVED_DATA_1: EfuseField = EfuseField::new(2, 7, 224, 32);
+pub const BLK2_RESERVED_DATA_1: EfuseField = EfuseField::new(2, 7, 224, 32);
 /// BLOCK_KEY0 - 256-bits. 256-bit key of Flash Encryption
-pub(crate) const BLOCK_KEY0: EfuseField = EfuseField::new(3, 0, 0, 256);
+pub const BLOCK_KEY0: EfuseField = EfuseField::new(3, 0, 0, 256);

--- a/espflash/src/target/efuse/esp32c2.rs
+++ b/espflash/src/target/efuse/esp32c2.rs
@@ -1,6 +1,8 @@
+//! eFuse field definitions for the esp32c2
+//!
 //! This file was automatically generated, please do not edit it manually!
 //!
-//! Generated: 2025-06-25 09:59
+//! Generated: 2025-06-25 11:06
 //! Version:   897499b0349a608b895d467abbcf006b
 
 #![allow(unused)]

--- a/espflash/src/target/efuse/esp32c3.rs
+++ b/espflash/src/target/efuse/esp32c3.rs
@@ -1,6 +1,8 @@
+//! eFuse field definitions for the esp32c3
+//!
 //! This file was automatically generated, please do not edit it manually!
 //!
-//! Generated: 2025-06-25 09:59
+//! Generated: 2025-06-25 11:06
 //! Version:   4622cf9245401eca0eb1df8122449a6d
 
 #![allow(unused)]

--- a/espflash/src/target/efuse/esp32c3.rs
+++ b/espflash/src/target/efuse/esp32c3.rs
@@ -1,6 +1,6 @@
 //! This file was automatically generated, please do not edit it manually!
 //!
-//! Generated: 2025-05-30 12:24
+//! Generated: 2025-06-25 09:59
 //! Version:   4622cf9245401eca0eb1df8122449a6d
 
 #![allow(unused)]
@@ -11,233 +11,233 @@ use super::EfuseField;
 pub(crate) const BLOCK_SIZES: &[u32] = &[23, 24, 32, 32, 32, 32, 32, 32, 32, 32, 32];
 
 /// Disable programming of individual eFuses
-pub(crate) const WR_DIS: EfuseField = EfuseField::new(0, 0, 0, 32);
+pub const WR_DIS: EfuseField = EfuseField::new(0, 0, 0, 32);
 /// Disable reading from BlOCK4-10
-pub(crate) const RD_DIS: EfuseField = EfuseField::new(0, 1, 32, 7);
+pub const RD_DIS: EfuseField = EfuseField::new(0, 1, 32, 7);
 /// Set this bit to disable boot from RTC RAM
-pub(crate) const DIS_RTC_RAM_BOOT: EfuseField = EfuseField::new(0, 1, 39, 1);
+pub const DIS_RTC_RAM_BOOT: EfuseField = EfuseField::new(0, 1, 39, 1);
 /// Set this bit to disable Icache
-pub(crate) const DIS_ICACHE: EfuseField = EfuseField::new(0, 1, 40, 1);
+pub const DIS_ICACHE: EfuseField = EfuseField::new(0, 1, 40, 1);
 /// Set this bit to disable function of usb switch to jtag in module of usb
 /// device
-pub(crate) const DIS_USB_JTAG: EfuseField = EfuseField::new(0, 1, 41, 1);
+pub const DIS_USB_JTAG: EfuseField = EfuseField::new(0, 1, 41, 1);
 /// Set this bit to disable Icache in download mode (boot_mode[3:0] is 0; 1; 2;
 /// 3; 6; 7)
-pub(crate) const DIS_DOWNLOAD_ICACHE: EfuseField = EfuseField::new(0, 1, 42, 1);
+pub const DIS_DOWNLOAD_ICACHE: EfuseField = EfuseField::new(0, 1, 42, 1);
 /// USB-Serial-JTAG
-pub(crate) const DIS_USB_SERIAL_JTAG: EfuseField = EfuseField::new(0, 1, 43, 1);
+pub const DIS_USB_SERIAL_JTAG: EfuseField = EfuseField::new(0, 1, 43, 1);
 /// Set this bit to disable the function that forces chip into download mode
-pub(crate) const DIS_FORCE_DOWNLOAD: EfuseField = EfuseField::new(0, 1, 44, 1);
+pub const DIS_FORCE_DOWNLOAD: EfuseField = EfuseField::new(0, 1, 44, 1);
 /// Reserved (used for four backups method)
-pub(crate) const RPT4_RESERVED6: EfuseField = EfuseField::new(0, 1, 45, 1);
+pub const RPT4_RESERVED6: EfuseField = EfuseField::new(0, 1, 45, 1);
 /// Set this bit to disable CAN function
-pub(crate) const DIS_TWAI: EfuseField = EfuseField::new(0, 1, 46, 1);
+pub const DIS_TWAI: EfuseField = EfuseField::new(0, 1, 46, 1);
 /// Set this bit to enable selection between usb_to_jtag and pad_to_jtag through
 /// strapping gpio10 when both reg_dis_usb_jtag and reg_dis_pad_jtag are equal
 /// to 0
-pub(crate) const JTAG_SEL_ENABLE: EfuseField = EfuseField::new(0, 1, 47, 1);
+pub const JTAG_SEL_ENABLE: EfuseField = EfuseField::new(0, 1, 47, 1);
 /// Set these bits to disable JTAG in the soft way (odd number 1 means disable
 /// ). JTAG can be enabled in HMAC module
-pub(crate) const SOFT_DIS_JTAG: EfuseField = EfuseField::new(0, 1, 48, 3);
+pub const SOFT_DIS_JTAG: EfuseField = EfuseField::new(0, 1, 48, 3);
 /// Set this bit to disable JTAG in the hard way. JTAG is disabled permanently
-pub(crate) const DIS_PAD_JTAG: EfuseField = EfuseField::new(0, 1, 51, 1);
+pub const DIS_PAD_JTAG: EfuseField = EfuseField::new(0, 1, 51, 1);
 /// Set this bit to disable flash encryption when in download boot modes
-pub(crate) const DIS_DOWNLOAD_MANUAL_ENCRYPT: EfuseField = EfuseField::new(0, 1, 52, 1);
+pub const DIS_DOWNLOAD_MANUAL_ENCRYPT: EfuseField = EfuseField::new(0, 1, 52, 1);
 /// Controls single-end input threshold vrefh; 1.76 V to 2 V with step of 80 mV;
 /// stored in eFuse
-pub(crate) const USB_DREFH: EfuseField = EfuseField::new(0, 1, 53, 2);
+pub const USB_DREFH: EfuseField = EfuseField::new(0, 1, 53, 2);
 /// Controls single-end input threshold vrefl; 0.8 V to 1.04 V with step of 80
 /// mV; stored in eFuse
-pub(crate) const USB_DREFL: EfuseField = EfuseField::new(0, 1, 55, 2);
+pub const USB_DREFL: EfuseField = EfuseField::new(0, 1, 55, 2);
 /// Set this bit to exchange USB D+ and D- pins
-pub(crate) const USB_EXCHG_PINS: EfuseField = EfuseField::new(0, 1, 57, 1);
+pub const USB_EXCHG_PINS: EfuseField = EfuseField::new(0, 1, 57, 1);
 /// Set this bit to vdd spi pin function as gpio
-pub(crate) const VDD_SPI_AS_GPIO: EfuseField = EfuseField::new(0, 1, 58, 1);
+pub const VDD_SPI_AS_GPIO: EfuseField = EfuseField::new(0, 1, 58, 1);
 /// Enable btlc gpio
-pub(crate) const BTLC_GPIO_ENABLE: EfuseField = EfuseField::new(0, 1, 59, 2);
+pub const BTLC_GPIO_ENABLE: EfuseField = EfuseField::new(0, 1, 59, 2);
 /// Set this bit to enable power glitch function
-pub(crate) const POWERGLITCH_EN: EfuseField = EfuseField::new(0, 1, 61, 1);
+pub const POWERGLITCH_EN: EfuseField = EfuseField::new(0, 1, 61, 1);
 /// Sample delay configuration of power glitch
-pub(crate) const POWER_GLITCH_DSENSE: EfuseField = EfuseField::new(0, 1, 62, 2);
+pub const POWER_GLITCH_DSENSE: EfuseField = EfuseField::new(0, 1, 62, 2);
 /// Reserved (used for four backups method)
-pub(crate) const RPT4_RESERVED2: EfuseField = EfuseField::new(0, 2, 64, 16);
+pub const RPT4_RESERVED2: EfuseField = EfuseField::new(0, 2, 64, 16);
 /// RTC watchdog timeout threshold; in unit of slow clock cycle
-pub(crate) const WDT_DELAY_SEL: EfuseField = EfuseField::new(0, 2, 80, 2);
+pub const WDT_DELAY_SEL: EfuseField = EfuseField::new(0, 2, 80, 2);
 /// Enables flash encryption when 1 or 3 bits are set and disables otherwise
-pub(crate) const SPI_BOOT_CRYPT_CNT: EfuseField = EfuseField::new(0, 2, 82, 3);
+pub const SPI_BOOT_CRYPT_CNT: EfuseField = EfuseField::new(0, 2, 82, 3);
 /// Revoke 1st secure boot key
-pub(crate) const SECURE_BOOT_KEY_REVOKE0: EfuseField = EfuseField::new(0, 2, 85, 1);
+pub const SECURE_BOOT_KEY_REVOKE0: EfuseField = EfuseField::new(0, 2, 85, 1);
 /// Revoke 2nd secure boot key
-pub(crate) const SECURE_BOOT_KEY_REVOKE1: EfuseField = EfuseField::new(0, 2, 86, 1);
+pub const SECURE_BOOT_KEY_REVOKE1: EfuseField = EfuseField::new(0, 2, 86, 1);
 /// Revoke 3rd secure boot key
-pub(crate) const SECURE_BOOT_KEY_REVOKE2: EfuseField = EfuseField::new(0, 2, 87, 1);
+pub const SECURE_BOOT_KEY_REVOKE2: EfuseField = EfuseField::new(0, 2, 87, 1);
 /// Purpose of Key0
-pub(crate) const KEY_PURPOSE_0: EfuseField = EfuseField::new(0, 2, 88, 4);
+pub const KEY_PURPOSE_0: EfuseField = EfuseField::new(0, 2, 88, 4);
 /// Purpose of Key1
-pub(crate) const KEY_PURPOSE_1: EfuseField = EfuseField::new(0, 2, 92, 4);
+pub const KEY_PURPOSE_1: EfuseField = EfuseField::new(0, 2, 92, 4);
 /// Purpose of Key2
-pub(crate) const KEY_PURPOSE_2: EfuseField = EfuseField::new(0, 3, 96, 4);
+pub const KEY_PURPOSE_2: EfuseField = EfuseField::new(0, 3, 96, 4);
 /// Purpose of Key3
-pub(crate) const KEY_PURPOSE_3: EfuseField = EfuseField::new(0, 3, 100, 4);
+pub const KEY_PURPOSE_3: EfuseField = EfuseField::new(0, 3, 100, 4);
 /// Purpose of Key4
-pub(crate) const KEY_PURPOSE_4: EfuseField = EfuseField::new(0, 3, 104, 4);
+pub const KEY_PURPOSE_4: EfuseField = EfuseField::new(0, 3, 104, 4);
 /// Purpose of Key5
-pub(crate) const KEY_PURPOSE_5: EfuseField = EfuseField::new(0, 3, 108, 4);
+pub const KEY_PURPOSE_5: EfuseField = EfuseField::new(0, 3, 108, 4);
 /// Reserved (used for four backups method)
-pub(crate) const RPT4_RESERVED3: EfuseField = EfuseField::new(0, 3, 112, 4);
+pub const RPT4_RESERVED3: EfuseField = EfuseField::new(0, 3, 112, 4);
 /// Set this bit to enable secure boot
-pub(crate) const SECURE_BOOT_EN: EfuseField = EfuseField::new(0, 3, 116, 1);
+pub const SECURE_BOOT_EN: EfuseField = EfuseField::new(0, 3, 116, 1);
 /// Set this bit to enable revoking aggressive secure boot
-pub(crate) const SECURE_BOOT_AGGRESSIVE_REVOKE: EfuseField = EfuseField::new(0, 3, 117, 1);
+pub const SECURE_BOOT_AGGRESSIVE_REVOKE: EfuseField = EfuseField::new(0, 3, 117, 1);
 /// Reserved (used for four backups method)
-pub(crate) const RPT4_RESERVED0: EfuseField = EfuseField::new(0, 3, 118, 6);
+pub const RPT4_RESERVED0: EfuseField = EfuseField::new(0, 3, 118, 6);
 /// Configures flash waiting time after power-up; in unit of ms. If the value is
 /// less than 15; the waiting time is the configurable value; Otherwise; the
 /// waiting time is twice the configurable value
-pub(crate) const FLASH_TPUW: EfuseField = EfuseField::new(0, 3, 124, 4);
+pub const FLASH_TPUW: EfuseField = EfuseField::new(0, 3, 124, 4);
 /// Set this bit to disable download mode (boot_mode[3:0] = 0; 1; 2; 3; 6; 7)
-pub(crate) const DIS_DOWNLOAD_MODE: EfuseField = EfuseField::new(0, 4, 128, 1);
+pub const DIS_DOWNLOAD_MODE: EfuseField = EfuseField::new(0, 4, 128, 1);
 /// Disable direct boot mode
-pub(crate) const DIS_DIRECT_BOOT: EfuseField = EfuseField::new(0, 4, 129, 1);
+pub const DIS_DIRECT_BOOT: EfuseField = EfuseField::new(0, 4, 129, 1);
 /// USB printing
-pub(crate) const DIS_USB_SERIAL_JTAG_ROM_PRINT: EfuseField = EfuseField::new(0, 4, 130, 1);
+pub const DIS_USB_SERIAL_JTAG_ROM_PRINT: EfuseField = EfuseField::new(0, 4, 130, 1);
 /// ECC mode in ROM
-pub(crate) const FLASH_ECC_MODE: EfuseField = EfuseField::new(0, 4, 131, 1);
+pub const FLASH_ECC_MODE: EfuseField = EfuseField::new(0, 4, 131, 1);
 /// Disable UART download mode through USB-Serial-JTAG
-pub(crate) const DIS_USB_SERIAL_JTAG_DOWNLOAD_MODE: EfuseField = EfuseField::new(0, 4, 132, 1);
+pub const DIS_USB_SERIAL_JTAG_DOWNLOAD_MODE: EfuseField = EfuseField::new(0, 4, 132, 1);
 /// Set this bit to enable secure UART download mode
-pub(crate) const ENABLE_SECURITY_DOWNLOAD: EfuseField = EfuseField::new(0, 4, 133, 1);
+pub const ENABLE_SECURITY_DOWNLOAD: EfuseField = EfuseField::new(0, 4, 133, 1);
 /// Set the default UARTboot message output mode
-pub(crate) const UART_PRINT_CONTROL: EfuseField = EfuseField::new(0, 4, 134, 2);
+pub const UART_PRINT_CONTROL: EfuseField = EfuseField::new(0, 4, 134, 2);
 /// GPIO33-GPIO37 power supply selection in ROM code
-pub(crate) const PIN_POWER_SELECTION: EfuseField = EfuseField::new(0, 4, 136, 1);
+pub const PIN_POWER_SELECTION: EfuseField = EfuseField::new(0, 4, 136, 1);
 /// Maximum lines of SPI flash
-pub(crate) const FLASH_TYPE: EfuseField = EfuseField::new(0, 4, 137, 1);
+pub const FLASH_TYPE: EfuseField = EfuseField::new(0, 4, 137, 1);
 /// Set Flash page size
-pub(crate) const FLASH_PAGE_SIZE: EfuseField = EfuseField::new(0, 4, 138, 2);
+pub const FLASH_PAGE_SIZE: EfuseField = EfuseField::new(0, 4, 138, 2);
 /// Set 1 to enable ECC for flash boot
-pub(crate) const FLASH_ECC_EN: EfuseField = EfuseField::new(0, 4, 140, 1);
+pub const FLASH_ECC_EN: EfuseField = EfuseField::new(0, 4, 140, 1);
 /// Set this bit to force ROM code to send a resume command during SPI boot
-pub(crate) const FORCE_SEND_RESUME: EfuseField = EfuseField::new(0, 4, 141, 1);
+pub const FORCE_SEND_RESUME: EfuseField = EfuseField::new(0, 4, 141, 1);
 /// Secure version (used by ESP-IDF anti-rollback feature)
-pub(crate) const SECURE_VERSION: EfuseField = EfuseField::new(0, 4, 142, 16);
+pub const SECURE_VERSION: EfuseField = EfuseField::new(0, 4, 142, 16);
 /// reserved
-pub(crate) const RESERVED_0_158: EfuseField = EfuseField::new(0, 4, 158, 1);
+pub const RESERVED_0_158: EfuseField = EfuseField::new(0, 4, 158, 1);
 /// Use BLOCK0 to check error record registers
-pub(crate) const ERR_RST_ENABLE: EfuseField = EfuseField::new(0, 4, 159, 1);
+pub const ERR_RST_ENABLE: EfuseField = EfuseField::new(0, 4, 159, 1);
 /// Disables check of wafer version major
-pub(crate) const DISABLE_WAFER_VERSION_MAJOR: EfuseField = EfuseField::new(0, 5, 160, 1);
+pub const DISABLE_WAFER_VERSION_MAJOR: EfuseField = EfuseField::new(0, 5, 160, 1);
 /// Disables check of blk version major
-pub(crate) const DISABLE_BLK_VERSION_MAJOR: EfuseField = EfuseField::new(0, 5, 161, 1);
+pub const DISABLE_BLK_VERSION_MAJOR: EfuseField = EfuseField::new(0, 5, 161, 1);
 /// reserved
-pub(crate) const RESERVED_0_162: EfuseField = EfuseField::new(0, 5, 162, 22);
+pub const RESERVED_0_162: EfuseField = EfuseField::new(0, 5, 162, 22);
 /// MAC address
-pub(crate) const MAC0: EfuseField = EfuseField::new(1, 0, 0, 32);
+pub const MAC0: EfuseField = EfuseField::new(1, 0, 0, 32);
 /// MAC address
-pub(crate) const MAC1: EfuseField = EfuseField::new(1, 1, 32, 16);
+pub const MAC1: EfuseField = EfuseField::new(1, 1, 32, 16);
 /// SPI PAD CLK
-pub(crate) const SPI_PAD_CONFIG_CLK: EfuseField = EfuseField::new(1, 1, 48, 6);
+pub const SPI_PAD_CONFIG_CLK: EfuseField = EfuseField::new(1, 1, 48, 6);
 /// SPI PAD Q(D1)
-pub(crate) const SPI_PAD_CONFIG_Q: EfuseField = EfuseField::new(1, 1, 54, 6);
+pub const SPI_PAD_CONFIG_Q: EfuseField = EfuseField::new(1, 1, 54, 6);
 /// SPI PAD D(D0)
-pub(crate) const SPI_PAD_CONFIG_D: EfuseField = EfuseField::new(1, 1, 60, 6);
+pub const SPI_PAD_CONFIG_D: EfuseField = EfuseField::new(1, 1, 60, 6);
 /// SPI PAD CS
-pub(crate) const SPI_PAD_CONFIG_CS: EfuseField = EfuseField::new(1, 2, 66, 6);
+pub const SPI_PAD_CONFIG_CS: EfuseField = EfuseField::new(1, 2, 66, 6);
 /// SPI PAD HD(D3)
-pub(crate) const SPI_PAD_CONFIG_HD: EfuseField = EfuseField::new(1, 2, 72, 6);
+pub const SPI_PAD_CONFIG_HD: EfuseField = EfuseField::new(1, 2, 72, 6);
 /// SPI PAD WP(D2)
-pub(crate) const SPI_PAD_CONFIG_WP: EfuseField = EfuseField::new(1, 2, 78, 6);
+pub const SPI_PAD_CONFIG_WP: EfuseField = EfuseField::new(1, 2, 78, 6);
 /// SPI PAD DQS
-pub(crate) const SPI_PAD_CONFIG_DQS: EfuseField = EfuseField::new(1, 2, 84, 6);
+pub const SPI_PAD_CONFIG_DQS: EfuseField = EfuseField::new(1, 2, 84, 6);
 /// SPI PAD D4
-pub(crate) const SPI_PAD_CONFIG_D4: EfuseField = EfuseField::new(1, 2, 90, 6);
+pub const SPI_PAD_CONFIG_D4: EfuseField = EfuseField::new(1, 2, 90, 6);
 /// SPI PAD D5
-pub(crate) const SPI_PAD_CONFIG_D5: EfuseField = EfuseField::new(1, 3, 96, 6);
+pub const SPI_PAD_CONFIG_D5: EfuseField = EfuseField::new(1, 3, 96, 6);
 /// SPI PAD D6
-pub(crate) const SPI_PAD_CONFIG_D6: EfuseField = EfuseField::new(1, 3, 102, 6);
+pub const SPI_PAD_CONFIG_D6: EfuseField = EfuseField::new(1, 3, 102, 6);
 /// SPI PAD D7
-pub(crate) const SPI_PAD_CONFIG_D7: EfuseField = EfuseField::new(1, 3, 108, 6);
+pub const SPI_PAD_CONFIG_D7: EfuseField = EfuseField::new(1, 3, 108, 6);
 /// WAFER_VERSION_MINOR least significant bits
-pub(crate) const WAFER_VERSION_MINOR_LO: EfuseField = EfuseField::new(1, 3, 114, 3);
+pub const WAFER_VERSION_MINOR_LO: EfuseField = EfuseField::new(1, 3, 114, 3);
 /// Package version
-pub(crate) const PKG_VERSION: EfuseField = EfuseField::new(1, 3, 117, 3);
+pub const PKG_VERSION: EfuseField = EfuseField::new(1, 3, 117, 3);
 /// BLK_VERSION_MINOR
-pub(crate) const BLK_VERSION_MINOR: EfuseField = EfuseField::new(1, 3, 120, 3);
+pub const BLK_VERSION_MINOR: EfuseField = EfuseField::new(1, 3, 120, 3);
 /// Flash capacity
-pub(crate) const FLASH_CAP: EfuseField = EfuseField::new(1, 3, 123, 3);
+pub const FLASH_CAP: EfuseField = EfuseField::new(1, 3, 123, 3);
 /// Flash temperature
-pub(crate) const FLASH_TEMP: EfuseField = EfuseField::new(1, 3, 126, 2);
+pub const FLASH_TEMP: EfuseField = EfuseField::new(1, 3, 126, 2);
 /// Flash vendor
-pub(crate) const FLASH_VENDOR: EfuseField = EfuseField::new(1, 4, 128, 3);
+pub const FLASH_VENDOR: EfuseField = EfuseField::new(1, 4, 128, 3);
 /// reserved
-pub(crate) const RESERVED_1_131: EfuseField = EfuseField::new(1, 4, 131, 4);
+pub const RESERVED_1_131: EfuseField = EfuseField::new(1, 4, 131, 4);
 /// BLOCK1 K_RTC_LDO
-pub(crate) const K_RTC_LDO: EfuseField = EfuseField::new(1, 4, 135, 7);
+pub const K_RTC_LDO: EfuseField = EfuseField::new(1, 4, 135, 7);
 /// BLOCK1 K_DIG_LDO
-pub(crate) const K_DIG_LDO: EfuseField = EfuseField::new(1, 4, 142, 7);
+pub const K_DIG_LDO: EfuseField = EfuseField::new(1, 4, 142, 7);
 /// BLOCK1 voltage of rtc dbias20
-pub(crate) const V_RTC_DBIAS20: EfuseField = EfuseField::new(1, 4, 149, 8);
+pub const V_RTC_DBIAS20: EfuseField = EfuseField::new(1, 4, 149, 8);
 /// BLOCK1 voltage of digital dbias20
-pub(crate) const V_DIG_DBIAS20: EfuseField = EfuseField::new(1, 4, 157, 8);
+pub const V_DIG_DBIAS20: EfuseField = EfuseField::new(1, 4, 157, 8);
 /// BLOCK1 digital dbias when hvt
-pub(crate) const DIG_DBIAS_HVT: EfuseField = EfuseField::new(1, 5, 165, 5);
+pub const DIG_DBIAS_HVT: EfuseField = EfuseField::new(1, 5, 165, 5);
 /// BLOCK1 pvt threshold when hvt
-pub(crate) const THRES_HVT: EfuseField = EfuseField::new(1, 5, 170, 10);
+pub const THRES_HVT: EfuseField = EfuseField::new(1, 5, 170, 10);
 /// reserved
-pub(crate) const RESERVED_1_180: EfuseField = EfuseField::new(1, 5, 180, 3);
+pub const RESERVED_1_180: EfuseField = EfuseField::new(1, 5, 180, 3);
 /// WAFER_VERSION_MINOR most significant bit
-pub(crate) const WAFER_VERSION_MINOR_HI: EfuseField = EfuseField::new(1, 5, 183, 1);
+pub const WAFER_VERSION_MINOR_HI: EfuseField = EfuseField::new(1, 5, 183, 1);
 /// WAFER_VERSION_MAJOR
-pub(crate) const WAFER_VERSION_MAJOR: EfuseField = EfuseField::new(1, 5, 184, 2);
+pub const WAFER_VERSION_MAJOR: EfuseField = EfuseField::new(1, 5, 184, 2);
 /// reserved
-pub(crate) const RESERVED_1_186: EfuseField = EfuseField::new(1, 5, 186, 6);
+pub const RESERVED_1_186: EfuseField = EfuseField::new(1, 5, 186, 6);
 /// Optional unique 128-bit ID
-pub(crate) const OPTIONAL_UNIQUE_ID: EfuseField = EfuseField::new(2, 0, 0, 128);
+pub const OPTIONAL_UNIQUE_ID: EfuseField = EfuseField::new(2, 0, 0, 128);
 /// BLK_VERSION_MAJOR of BLOCK2
-pub(crate) const BLK_VERSION_MAJOR: EfuseField = EfuseField::new(2, 4, 128, 2);
+pub const BLK_VERSION_MAJOR: EfuseField = EfuseField::new(2, 4, 128, 2);
 /// reserved
-pub(crate) const RESERVED_2_130: EfuseField = EfuseField::new(2, 4, 130, 1);
+pub const RESERVED_2_130: EfuseField = EfuseField::new(2, 4, 130, 1);
 /// Temperature calibration data
-pub(crate) const TEMP_CALIB: EfuseField = EfuseField::new(2, 4, 131, 9);
+pub const TEMP_CALIB: EfuseField = EfuseField::new(2, 4, 131, 9);
 /// ADC OCode
-pub(crate) const OCODE: EfuseField = EfuseField::new(2, 4, 140, 8);
+pub const OCODE: EfuseField = EfuseField::new(2, 4, 140, 8);
 /// ADC1 init code at atten0
-pub(crate) const ADC1_INIT_CODE_ATTEN0: EfuseField = EfuseField::new(2, 4, 148, 10);
+pub const ADC1_INIT_CODE_ATTEN0: EfuseField = EfuseField::new(2, 4, 148, 10);
 /// ADC1 init code at atten1
-pub(crate) const ADC1_INIT_CODE_ATTEN1: EfuseField = EfuseField::new(2, 4, 158, 10);
+pub const ADC1_INIT_CODE_ATTEN1: EfuseField = EfuseField::new(2, 4, 158, 10);
 /// ADC1 init code at atten2
-pub(crate) const ADC1_INIT_CODE_ATTEN2: EfuseField = EfuseField::new(2, 5, 168, 10);
+pub const ADC1_INIT_CODE_ATTEN2: EfuseField = EfuseField::new(2, 5, 168, 10);
 /// ADC1 init code at atten3
-pub(crate) const ADC1_INIT_CODE_ATTEN3: EfuseField = EfuseField::new(2, 5, 178, 10);
+pub const ADC1_INIT_CODE_ATTEN3: EfuseField = EfuseField::new(2, 5, 178, 10);
 /// ADC1 calibration voltage at atten0
-pub(crate) const ADC1_CAL_VOL_ATTEN0: EfuseField = EfuseField::new(2, 5, 188, 10);
+pub const ADC1_CAL_VOL_ATTEN0: EfuseField = EfuseField::new(2, 5, 188, 10);
 /// ADC1 calibration voltage at atten1
-pub(crate) const ADC1_CAL_VOL_ATTEN1: EfuseField = EfuseField::new(2, 6, 198, 10);
+pub const ADC1_CAL_VOL_ATTEN1: EfuseField = EfuseField::new(2, 6, 198, 10);
 /// ADC1 calibration voltage at atten2
-pub(crate) const ADC1_CAL_VOL_ATTEN2: EfuseField = EfuseField::new(2, 6, 208, 10);
+pub const ADC1_CAL_VOL_ATTEN2: EfuseField = EfuseField::new(2, 6, 208, 10);
 /// ADC1 calibration voltage at atten3
-pub(crate) const ADC1_CAL_VOL_ATTEN3: EfuseField = EfuseField::new(2, 6, 218, 10);
+pub const ADC1_CAL_VOL_ATTEN3: EfuseField = EfuseField::new(2, 6, 218, 10);
 /// reserved
-pub(crate) const RESERVED_2_228: EfuseField = EfuseField::new(2, 7, 228, 28);
+pub const RESERVED_2_228: EfuseField = EfuseField::new(2, 7, 228, 28);
 /// User data
-pub(crate) const BLOCK_USR_DATA: EfuseField = EfuseField::new(3, 0, 0, 192);
+pub const BLOCK_USR_DATA: EfuseField = EfuseField::new(3, 0, 0, 192);
 /// reserved
-pub(crate) const RESERVED_3_192: EfuseField = EfuseField::new(3, 6, 192, 8);
+pub const RESERVED_3_192: EfuseField = EfuseField::new(3, 6, 192, 8);
 /// Custom MAC address
-pub(crate) const CUSTOM_MAC: EfuseField = EfuseField::new(3, 6, 200, 48);
+pub const CUSTOM_MAC: EfuseField = EfuseField::new(3, 6, 200, 48);
 /// reserved
-pub(crate) const RESERVED_3_248: EfuseField = EfuseField::new(3, 7, 248, 8);
+pub const RESERVED_3_248: EfuseField = EfuseField::new(3, 7, 248, 8);
 /// Key0 or user data
-pub(crate) const BLOCK_KEY0: EfuseField = EfuseField::new(4, 0, 0, 256);
+pub const BLOCK_KEY0: EfuseField = EfuseField::new(4, 0, 0, 256);
 /// Key1 or user data
-pub(crate) const BLOCK_KEY1: EfuseField = EfuseField::new(5, 0, 0, 256);
+pub const BLOCK_KEY1: EfuseField = EfuseField::new(5, 0, 0, 256);
 /// Key2 or user data
-pub(crate) const BLOCK_KEY2: EfuseField = EfuseField::new(6, 0, 0, 256);
+pub const BLOCK_KEY2: EfuseField = EfuseField::new(6, 0, 0, 256);
 /// Key3 or user data
-pub(crate) const BLOCK_KEY3: EfuseField = EfuseField::new(7, 0, 0, 256);
+pub const BLOCK_KEY3: EfuseField = EfuseField::new(7, 0, 0, 256);
 /// Key4 or user data
-pub(crate) const BLOCK_KEY4: EfuseField = EfuseField::new(8, 0, 0, 256);
+pub const BLOCK_KEY4: EfuseField = EfuseField::new(8, 0, 0, 256);
 /// Key5 or user data
-pub(crate) const BLOCK_KEY5: EfuseField = EfuseField::new(9, 0, 0, 256);
+pub const BLOCK_KEY5: EfuseField = EfuseField::new(9, 0, 0, 256);
 /// System data part 2 (reserved)
-pub(crate) const BLOCK_SYS_DATA2: EfuseField = EfuseField::new(10, 0, 0, 256);
+pub const BLOCK_SYS_DATA2: EfuseField = EfuseField::new(10, 0, 0, 256);

--- a/espflash/src/target/efuse/esp32c5.rs
+++ b/espflash/src/target/efuse/esp32c5.rs
@@ -1,6 +1,8 @@
+//! eFuse field definitions for the esp32c5
+//!
 //! This file was automatically generated, please do not edit it manually!
 //!
-//! Generated: 2025-06-25 09:59
+//! Generated: 2025-06-25 11:06
 //! Version:   31c7fe3f5f4e0a55b178a57126c0aca7
 
 #![allow(unused)]

--- a/espflash/src/target/efuse/esp32c5.rs
+++ b/espflash/src/target/efuse/esp32c5.rs
@@ -1,6 +1,6 @@
 //! This file was automatically generated, please do not edit it manually!
 //!
-//! Generated: 2025-05-30 12:24
+//! Generated: 2025-06-25 09:59
 //! Version:   31c7fe3f5f4e0a55b178a57126c0aca7
 
 #![allow(unused)]
@@ -11,35 +11,34 @@ use super::EfuseField;
 pub(crate) const BLOCK_SIZES: &[u32] = &[24, 24, 32, 32, 32, 32, 32, 32, 32, 32, 32];
 
 /// Disable programming of individual eFuses
-pub(crate) const WR_DIS: EfuseField = EfuseField::new(0, 0, 0, 32);
+pub const WR_DIS: EfuseField = EfuseField::new(0, 0, 0, 32);
 /// Disable reading from BlOCK4-10
-pub(crate) const RD_DIS: EfuseField = EfuseField::new(0, 1, 32, 7);
+pub const RD_DIS: EfuseField = EfuseField::new(0, 1, 32, 7);
 /// Represents the anti-rollback secure version of the 2nd stage bootloader used
 /// by the ROM bootloader (the high part of the field)
-pub(crate) const BOOTLOADER_ANTI_ROLLBACK_SECURE_VERSION_HI: EfuseField =
-    EfuseField::new(0, 1, 39, 1);
+pub const BOOTLOADER_ANTI_ROLLBACK_SECURE_VERSION_HI: EfuseField = EfuseField::new(0, 1, 39, 1);
 /// Represents whether cache is disabled. 1: Disabled 0: Enabled
-pub(crate) const DIS_ICACHE: EfuseField = EfuseField::new(0, 1, 40, 1);
+pub const DIS_ICACHE: EfuseField = EfuseField::new(0, 1, 40, 1);
 /// Represents whether the USB-to-JTAG function in USB Serial/JTAG is disabled.
 /// Note that \hyperref[fielddesc:EFUSEDISUSBJTAG]{EFUSE\_DIS\_USB\_JTAG} is
 /// available only when
 /// \hyperref[fielddesc:EFUSEDISUSBSERIALJTAG]{EFUSE\_DIS\_USB\_SERIAL\_JTAG} is
 /// configured to 0. For more information; please refer to Chapter
 /// \ref{mod:bootctrl} \textit{\nameref{mod:bootctrl}}.1: Disabled0: Enabled
-pub(crate) const DIS_USB_JTAG: EfuseField = EfuseField::new(0, 1, 41, 1);
+pub const DIS_USB_JTAG: EfuseField = EfuseField::new(0, 1, 41, 1);
 /// Represents whether the ani-rollback check for the 2nd stage bootloader is
 /// enabled.1: Enabled0: Disabled
-pub(crate) const BOOTLOADER_ANTI_ROLLBACK_EN: EfuseField = EfuseField::new(0, 1, 42, 1);
+pub const BOOTLOADER_ANTI_ROLLBACK_EN: EfuseField = EfuseField::new(0, 1, 42, 1);
 /// Represents whether USB Serial/JTAG is disabled.1: Disabled0: Enabled
-pub(crate) const DIS_USB_SERIAL_JTAG: EfuseField = EfuseField::new(0, 1, 43, 1);
+pub const DIS_USB_SERIAL_JTAG: EfuseField = EfuseField::new(0, 1, 43, 1);
 /// Represents whether the function that forces chip into Download mode is
 /// disabled. 1: Disabled0: Enabled
-pub(crate) const DIS_FORCE_DOWNLOAD: EfuseField = EfuseField::new(0, 1, 44, 1);
+pub const DIS_FORCE_DOWNLOAD: EfuseField = EfuseField::new(0, 1, 44, 1);
 /// Represents whether SPI0 controller during boot\_mode\_download is
 /// disabled.0: Enabled1: Disabled
-pub(crate) const SPI_DOWNLOAD_MSPI_DIS: EfuseField = EfuseField::new(0, 1, 45, 1);
+pub const SPI_DOWNLOAD_MSPI_DIS: EfuseField = EfuseField::new(0, 1, 45, 1);
 /// Represents whether TWAI$^®$ function is disabled.1: Disabled0: Enabled
-pub(crate) const DIS_TWAI: EfuseField = EfuseField::new(0, 1, 46, 1);
+pub const DIS_TWAI: EfuseField = EfuseField::new(0, 1, 46, 1);
 /// Represents whether the selection of a JTAG signal source through the
 /// strapping pin value is enabled when all of
 /// \hyperref[fielddesc:EFUSEDISPADJTAG]{EFUSE\_DIS\_PAD\_JTAG};
@@ -47,52 +46,51 @@ pub(crate) const DIS_TWAI: EfuseField = EfuseField::new(0, 1, 46, 1);
 /// \hyperref[fielddesc:EFUSEDISUSBSERIALJTAG]{EFUSE\_DIS\_USB\_SERIAL\_JTAG}
 /// are configured to 0. For more information; please refer to Chapter
 /// \ref{mod:bootctrl} \textit{\nameref{mod:bootctrl}}.1: Enabled0: Disabled
-pub(crate) const JTAG_SEL_ENABLE: EfuseField = EfuseField::new(0, 1, 47, 1);
+pub const JTAG_SEL_ENABLE: EfuseField = EfuseField::new(0, 1, 47, 1);
 /// Represents whether PAD JTAG is disabled in the soft way. It can be restarted
 /// via HMAC. Odd count of bits with a value of 1: DisabledEven count of bits
 /// with a value of 1: Enabled
-pub(crate) const SOFT_DIS_JTAG: EfuseField = EfuseField::new(0, 1, 48, 3);
+pub const SOFT_DIS_JTAG: EfuseField = EfuseField::new(0, 1, 48, 3);
 /// Represents whether PAD JTAG is disabled in the hard way (permanently).1:
 /// Disabled0: Enabled
-pub(crate) const DIS_PAD_JTAG: EfuseField = EfuseField::new(0, 1, 51, 1);
+pub const DIS_PAD_JTAG: EfuseField = EfuseField::new(0, 1, 51, 1);
 /// Represents whether flash encryption is disabled (except in SPI boot mode).1:
 /// Disabled0: Enabled
-pub(crate) const DIS_DOWNLOAD_MANUAL_ENCRYPT: EfuseField = EfuseField::new(0, 1, 52, 1);
+pub const DIS_DOWNLOAD_MANUAL_ENCRYPT: EfuseField = EfuseField::new(0, 1, 52, 1);
 /// Represents the single-end input threshold vrefh; 1.76 V to 2 V with step of
 /// 80 mV
-pub(crate) const USB_DREFH: EfuseField = EfuseField::new(0, 1, 53, 2);
+pub const USB_DREFH: EfuseField = EfuseField::new(0, 1, 53, 2);
 /// Represents the single-end input threshold vrefl; 1.76 V to 2 V with step of
 /// 80 mV
-pub(crate) const USB_DREFL: EfuseField = EfuseField::new(0, 1, 55, 2);
+pub const USB_DREFL: EfuseField = EfuseField::new(0, 1, 55, 2);
 /// Represents whether the D+ and D- pins is exchanged.1: Exchanged0: Not
 /// exchanged
-pub(crate) const USB_EXCHG_PINS: EfuseField = EfuseField::new(0, 1, 57, 1);
+pub const USB_EXCHG_PINS: EfuseField = EfuseField::new(0, 1, 57, 1);
 /// Represents whether VDD SPI pin is functioned as GPIO.1: Functioned0: Not
 /// functioned
-pub(crate) const VDD_SPI_AS_GPIO: EfuseField = EfuseField::new(0, 1, 58, 1);
+pub const VDD_SPI_AS_GPIO: EfuseField = EfuseField::new(0, 1, 58, 1);
 /// Represents RTC watchdog timeout threshold.0: The originally configured STG0
 /// threshold × 21: The originally configured STG0 threshold × 42: The
 /// originally configured STG0 threshold × 83: The originally configured STG0
 /// threshold × 16
-pub(crate) const WDT_DELAY_SEL: EfuseField = EfuseField::new(0, 1, 59, 2);
+pub const WDT_DELAY_SEL: EfuseField = EfuseField::new(0, 1, 59, 2);
 /// Represents the anti-rollback secure version of the 2nd stage bootloader used
 /// by the ROM bootloader (the low part of the field)
-pub(crate) const BOOTLOADER_ANTI_ROLLBACK_SECURE_VERSION_LO: EfuseField =
-    EfuseField::new(0, 1, 61, 3);
+pub const BOOTLOADER_ANTI_ROLLBACK_SECURE_VERSION_LO: EfuseField = EfuseField::new(0, 1, 61, 3);
 /// Represents whether the new key deployment of key manager is disabled. Bit0:
 /// Represents whether the new ECDSA key deployment is disabled0: Enabled1:
 /// DisabledBit1: Represents whether the new XTS-AES (flash and PSRAM) key
 /// deployment is disabled0: Enabled1: DisabledBit2: Represents whether the new
 /// HMAC key deployment is disabled0: Enabled1: DisabledBit3: Represents whether
 /// the new DS key deployment is disabled0: Enabled1: Disabled
-pub(crate) const KM_DISABLE_DEPLOY_MODE: EfuseField = EfuseField::new(0, 2, 64, 4);
+pub const KM_DISABLE_DEPLOY_MODE: EfuseField = EfuseField::new(0, 2, 64, 4);
 /// Represents the cycle at which the Key Manager switches random numbers.0:
 /// Controlled by the
 /// \hyperref[fielddesc:KEYMNGRNDSWITCHCYCLE]{KEYMNG\_RND\_SWITCH\_CYCLE}
 /// register. For more information; please refer to Chapter \ref{mod:keymng}
 /// \textit{\nameref{mod:keymng}}1: 8 Key Manager clock cycles2: 16 Key Manager
 /// clock cycles3: 32 Key Manager clock cycles
-pub(crate) const KM_RND_SWITCH_CYCLE: EfuseField = EfuseField::new(0, 2, 68, 2);
+pub const KM_RND_SWITCH_CYCLE: EfuseField = EfuseField::new(0, 2, 68, 2);
 /// Represents whether the corresponding key can be deployed only once.Bit0:
 /// Represents whether the ECDSA key can be deployed only once0: The key can be
 /// deployed multiple times1: The key can be deployed only onceBit1: Represents
@@ -102,7 +100,7 @@ pub(crate) const KM_RND_SWITCH_CYCLE: EfuseField = EfuseField::new(0, 2, 68, 2);
 /// deployed multiple times1: The key can be deployed only onceBit3: Represents
 /// whether the DS key can be deployed only once0: The key can be deployed
 /// multiple times1: The key can be deployed only once
-pub(crate) const KM_DEPLOY_ONLY_ONCE: EfuseField = EfuseField::new(0, 2, 70, 4);
+pub const KM_DEPLOY_ONLY_ONCE: EfuseField = EfuseField::new(0, 2, 70, 4);
 /// Represents whether the corresponding key must come from Key Manager. Bit0:
 /// Represents whether the ECDSA key must come from Key Manager.0: The key does
 /// not need to come from Key Manager1: The key must come from Key ManagerBit1:
@@ -113,33 +111,33 @@ pub(crate) const KM_DEPLOY_ONLY_ONCE: EfuseField = EfuseField::new(0, 2, 70, 4);
 /// come from Key ManagerBit3: Represents whether the DS key must come from Key
 /// Manager.0: The key does not need to come from Key Manager1: The key must
 /// come from Key Manager
-pub(crate) const FORCE_USE_KEY_MANAGER_KEY: EfuseField = EfuseField::new(0, 2, 74, 4);
+pub const FORCE_USE_KEY_MANAGER_KEY: EfuseField = EfuseField::new(0, 2, 74, 4);
 /// Represents whether to disable the use of the initialization key written by
 /// software and instead force use efuse\_init\_key.0: Enable1: Disable
-pub(crate) const FORCE_DISABLE_SW_INIT_KEY: EfuseField = EfuseField::new(0, 2, 78, 1);
+pub const FORCE_DISABLE_SW_INIT_KEY: EfuseField = EfuseField::new(0, 2, 78, 1);
 /// Represents whether the ani-rollback SECURE_VERSION will be updated from the
 /// ROM bootloader.1: Enable0: Disable
-pub(crate) const BOOTLOADER_ANTI_ROLLBACK_UPDATE_IN_ROM: EfuseField = EfuseField::new(0, 2, 79, 1);
+pub const BOOTLOADER_ANTI_ROLLBACK_UPDATE_IN_ROM: EfuseField = EfuseField::new(0, 2, 79, 1);
 /// Enables flash encryption when 1 or 3 bits are set and disables otherwise
-pub(crate) const SPI_BOOT_CRYPT_CNT: EfuseField = EfuseField::new(0, 2, 80, 3);
+pub const SPI_BOOT_CRYPT_CNT: EfuseField = EfuseField::new(0, 2, 80, 3);
 /// Revoke 1st secure boot key
-pub(crate) const SECURE_BOOT_KEY_REVOKE0: EfuseField = EfuseField::new(0, 2, 83, 1);
+pub const SECURE_BOOT_KEY_REVOKE0: EfuseField = EfuseField::new(0, 2, 83, 1);
 /// Revoke 2nd secure boot key
-pub(crate) const SECURE_BOOT_KEY_REVOKE1: EfuseField = EfuseField::new(0, 2, 84, 1);
+pub const SECURE_BOOT_KEY_REVOKE1: EfuseField = EfuseField::new(0, 2, 84, 1);
 /// Revoke 3rd secure boot key
-pub(crate) const SECURE_BOOT_KEY_REVOKE2: EfuseField = EfuseField::new(0, 2, 85, 1);
+pub const SECURE_BOOT_KEY_REVOKE2: EfuseField = EfuseField::new(0, 2, 85, 1);
 /// Represents the purpose of Key0. See Table \ref{tab:efuse-key-purpose}
-pub(crate) const KEY_PURPOSE_0: EfuseField = EfuseField::new(0, 2, 86, 5);
+pub const KEY_PURPOSE_0: EfuseField = EfuseField::new(0, 2, 86, 5);
 /// Represents the purpose of Key1. See Table \ref{tab:efuse-key-purpose}
-pub(crate) const KEY_PURPOSE_1: EfuseField = EfuseField::new(0, 2, 91, 5);
+pub const KEY_PURPOSE_1: EfuseField = EfuseField::new(0, 2, 91, 5);
 /// Represents the purpose of Key2. See Table \ref{tab:efuse-key-purpose}
-pub(crate) const KEY_PURPOSE_2: EfuseField = EfuseField::new(0, 3, 96, 5);
+pub const KEY_PURPOSE_2: EfuseField = EfuseField::new(0, 3, 96, 5);
 /// Represents the purpose of Key3. See Table \ref{tab:efuse-key-purpose}
-pub(crate) const KEY_PURPOSE_3: EfuseField = EfuseField::new(0, 3, 101, 5);
+pub const KEY_PURPOSE_3: EfuseField = EfuseField::new(0, 3, 101, 5);
 /// Represents the purpose of Key4. See Table \ref{tab:efuse-key-purpose}
-pub(crate) const KEY_PURPOSE_4: EfuseField = EfuseField::new(0, 3, 106, 5);
+pub const KEY_PURPOSE_4: EfuseField = EfuseField::new(0, 3, 106, 5);
 /// Represents the purpose of Key5. See Table \ref{tab:efuse-key-purpose}
-pub(crate) const KEY_PURPOSE_5: EfuseField = EfuseField::new(0, 3, 111, 5);
+pub const KEY_PURPOSE_5: EfuseField = EfuseField::new(0, 3, 111, 5);
 /// Represents the security level of anti-DPA attack. The level is adjusted by
 /// configuring the clock random frequency division mode.0: Security level is
 /// SEC\_DPA\_OFF1: Security level is SEC\_DPA\_LOW2: Security level is
@@ -147,200 +145,200 @@ pub(crate) const KEY_PURPOSE_5: EfuseField = EfuseField::new(0, 3, 111, 5);
 /// please refer to Chapter \ref{mod:sysreg} \textit{\nameref{mod:sysreg}} >
 /// Section \ref{sec:sysreg-anti-dpa-attack-security-control}
 /// \textit{\nameref{sec:sysreg-anti-dpa-attack-security-control}}.
-pub(crate) const SEC_DPA_LEVEL: EfuseField = EfuseField::new(0, 3, 116, 2);
+pub const SEC_DPA_LEVEL: EfuseField = EfuseField::new(0, 3, 116, 2);
 /// Represents the starting flash sector (flash sector size is 0x1000) of the
 /// recovery bootloader used by the ROM bootloader If the primary bootloader
 /// fails. 0 and 0xFFF - this feature is disabled. (The high part of the field)
-pub(crate) const RECOVERY_BOOTLOADER_FLASH_SECTOR_HI: EfuseField = EfuseField::new(0, 3, 118, 3);
+pub const RECOVERY_BOOTLOADER_FLASH_SECTOR_HI: EfuseField = EfuseField::new(0, 3, 118, 3);
 /// Represents whether Secure Boot is enabled.1: Enabled0: Disabled
-pub(crate) const SECURE_BOOT_EN: EfuseField = EfuseField::new(0, 3, 121, 1);
+pub const SECURE_BOOT_EN: EfuseField = EfuseField::new(0, 3, 121, 1);
 /// Represents whether aggressive revocation of Secure Boot is enabled.1:
 /// Enabled0: Disabled
-pub(crate) const SECURE_BOOT_AGGRESSIVE_REVOKE: EfuseField = EfuseField::new(0, 3, 122, 1);
+pub const SECURE_BOOT_AGGRESSIVE_REVOKE: EfuseField = EfuseField::new(0, 3, 122, 1);
 /// Represents which key flash encryption uses.0: XTS-AES-256 key1: XTS-AES-128
 /// key
-pub(crate) const KM_XTS_KEY_LENGTH_256: EfuseField = EfuseField::new(0, 3, 123, 1);
+pub const KM_XTS_KEY_LENGTH_256: EfuseField = EfuseField::new(0, 3, 123, 1);
 /// Represents the flash waiting time after power-up. Measurement unit: ms. When
 /// the value is less than 15; the waiting time is the programmed value.
 /// Otherwise; the waiting time is a fixed value; i.e. 30 ms
-pub(crate) const FLASH_TPUW: EfuseField = EfuseField::new(0, 3, 124, 4);
+pub const FLASH_TPUW: EfuseField = EfuseField::new(0, 3, 124, 4);
 /// Represents whether Download mode is disable or enable. 1. Disable 0: Enable
-pub(crate) const DIS_DOWNLOAD_MODE: EfuseField = EfuseField::new(0, 4, 128, 1);
+pub const DIS_DOWNLOAD_MODE: EfuseField = EfuseField::new(0, 4, 128, 1);
 /// Represents whether direct boot mode is disabled or enabled. 1. Disable 0:
 /// Enable
-pub(crate) const DIS_DIRECT_BOOT: EfuseField = EfuseField::new(0, 4, 129, 1);
+pub const DIS_DIRECT_BOOT: EfuseField = EfuseField::new(0, 4, 129, 1);
 /// Represents whether print from USB-Serial-JTAG is disabled or enabled. 1.
 /// Disable 0: Enable
-pub(crate) const DIS_USB_SERIAL_JTAG_ROM_PRINT: EfuseField = EfuseField::new(0, 4, 130, 1);
+pub const DIS_USB_SERIAL_JTAG_ROM_PRINT: EfuseField = EfuseField::new(0, 4, 130, 1);
 /// Represents whether the keys in the Key Manager are locked after
 /// deployment.0: Not locked1: Locked
-pub(crate) const LOCK_KM_KEY: EfuseField = EfuseField::new(0, 4, 131, 1);
+pub const LOCK_KM_KEY: EfuseField = EfuseField::new(0, 4, 131, 1);
 /// Represents whether the USB-Serial-JTAG download function is disabled or
 /// enabled. 1: Disable 0: Enable
-pub(crate) const DIS_USB_SERIAL_JTAG_DOWNLOAD_MODE: EfuseField = EfuseField::new(0, 4, 132, 1);
+pub const DIS_USB_SERIAL_JTAG_DOWNLOAD_MODE: EfuseField = EfuseField::new(0, 4, 132, 1);
 /// Represents whether security download is enabled. Only downloading into flash
 /// is supported. Reading/writing RAM or registers is not supported (i.e. stub
 /// download is not supported).1: Enabled0: Disabled
-pub(crate) const ENABLE_SECURITY_DOWNLOAD: EfuseField = EfuseField::new(0, 4, 133, 1);
+pub const ENABLE_SECURITY_DOWNLOAD: EfuseField = EfuseField::new(0, 4, 133, 1);
 /// Set the default UARTboot message output mode
-pub(crate) const UART_PRINT_CONTROL: EfuseField = EfuseField::new(0, 4, 134, 2);
+pub const UART_PRINT_CONTROL: EfuseField = EfuseField::new(0, 4, 134, 2);
 /// Represents whether ROM code is forced to send a resume command during SPI
 /// boot.1: Forced. 0: Not forced.
-pub(crate) const FORCE_SEND_RESUME: EfuseField = EfuseField::new(0, 4, 136, 1);
+pub const FORCE_SEND_RESUME: EfuseField = EfuseField::new(0, 4, 136, 1);
 /// Represents the app secure version used by ESP-IDF anti-rollback feature
-pub(crate) const SECURE_VERSION: EfuseField = EfuseField::new(0, 4, 137, 9);
+pub const SECURE_VERSION: EfuseField = EfuseField::new(0, 4, 137, 9);
 /// Reserved; it was created by set_missed_fields_in_regs func
-pub(crate) const RESERVE_0_146: EfuseField = EfuseField::new(0, 4, 146, 7);
+pub const RESERVE_0_146: EfuseField = EfuseField::new(0, 4, 146, 7);
 /// Represents whether FAST VERIFY ON WAKE is disabled when Secure Boot is
 /// enabled.1: Disabled0: Enabled
-pub(crate) const SECURE_BOOT_DISABLE_FAST_WAKE: EfuseField = EfuseField::new(0, 4, 153, 1);
+pub const SECURE_BOOT_DISABLE_FAST_WAKE: EfuseField = EfuseField::new(0, 4, 153, 1);
 /// Represents whether the hysteresis function of PAD0 – PAD27 is enabled.1:
 /// Enabled0: Disabled
-pub(crate) const HYS_EN_PAD: EfuseField = EfuseField::new(0, 4, 154, 1);
+pub const HYS_EN_PAD: EfuseField = EfuseField::new(0, 4, 154, 1);
 /// Represents the pseudo round level of XTS-AES anti-DPA attack.0: Disabled1:
 /// Low2: Moderate3: High
-pub(crate) const XTS_DPA_PSEUDO_LEVEL: EfuseField = EfuseField::new(0, 4, 155, 2);
+pub const XTS_DPA_PSEUDO_LEVEL: EfuseField = EfuseField::new(0, 4, 155, 2);
 /// Represents whether XTS-AES anti-DPA attack clock is enabled.0: Disable1:
 /// Enabled
-pub(crate) const XTS_DPA_CLK_ENABLE: EfuseField = EfuseField::new(0, 4, 157, 1);
+pub const XTS_DPA_CLK_ENABLE: EfuseField = EfuseField::new(0, 4, 157, 1);
 /// Reserved; it was created by set_missed_fields_in_regs func
-pub(crate) const RESERVE_0_158: EfuseField = EfuseField::new(0, 4, 158, 1);
+pub const RESERVE_0_158: EfuseField = EfuseField::new(0, 4, 158, 1);
 /// Represents if the chip supports Secure Boot using SHA-384
-pub(crate) const SECURE_BOOT_SHA384_EN: EfuseField = EfuseField::new(0, 4, 159, 1);
+pub const SECURE_BOOT_SHA384_EN: EfuseField = EfuseField::new(0, 4, 159, 1);
 /// Represents whether the HUK generate mode is valid.Odd count of bits with a
 /// value of 1: InvalidEven count of bits with a value of 1: Valid
-pub(crate) const HUK_GEN_STATE: EfuseField = EfuseField::new(0, 5, 160, 9);
+pub const HUK_GEN_STATE: EfuseField = EfuseField::new(0, 5, 160, 9);
 /// Represents whether XTAL frequency is 48MHz or not. If not; 40MHz XTAL will
 /// be used. If this field contains Odd number bit 1: Enable 48MHz XTAL\ Even
 /// number bit 1: Enable 40MHz XTAL
-pub(crate) const XTAL_48M_SEL: EfuseField = EfuseField::new(0, 5, 169, 3);
+pub const XTAL_48M_SEL: EfuseField = EfuseField::new(0, 5, 169, 3);
 /// Represents what determines the XTAL frequency in \textbf{Joint Download
 /// Boot} mode.  For more information; please refer to Chapter
 /// \ref{mod:bootctrl} \textit{\nameref{mod:bootctrl}}.0: Strapping PAD state1:
 /// \hyperref[fielddesc:EFUSEXTAL48MSEL]{EFUSE\_XTAL\_48M\_SEL} in eFuse
-pub(crate) const XTAL_48M_SEL_MODE: EfuseField = EfuseField::new(0, 5, 172, 1);
+pub const XTAL_48M_SEL_MODE: EfuseField = EfuseField::new(0, 5, 172, 1);
 /// Represents whether to force ECC to use constant-time mode for point
 /// multiplication calculation. 0: Not force1: Force
-pub(crate) const ECC_FORCE_CONST_TIME: EfuseField = EfuseField::new(0, 5, 173, 1);
+pub const ECC_FORCE_CONST_TIME: EfuseField = EfuseField::new(0, 5, 173, 1);
 /// Represents the starting flash sector (flash sector size is 0x1000) of the
 /// recovery bootloader used by the ROM bootloader If the primary bootloader
 /// fails. 0 and 0xFFF - this feature is disabled. (The low part of the field)
-pub(crate) const RECOVERY_BOOTLOADER_FLASH_SECTOR_LO: EfuseField = EfuseField::new(0, 5, 174, 9);
+pub const RECOVERY_BOOTLOADER_FLASH_SECTOR_LO: EfuseField = EfuseField::new(0, 5, 174, 9);
 /// Reserved; it was created by set_missed_fields_in_regs func
-pub(crate) const RESERVE_0_183: EfuseField = EfuseField::new(0, 5, 183, 9);
+pub const RESERVE_0_183: EfuseField = EfuseField::new(0, 5, 183, 9);
 /// MAC address
-pub(crate) const MAC0: EfuseField = EfuseField::new(1, 0, 0, 32);
+pub const MAC0: EfuseField = EfuseField::new(1, 0, 0, 32);
 /// MAC address
-pub(crate) const MAC1: EfuseField = EfuseField::new(1, 1, 32, 16);
+pub const MAC1: EfuseField = EfuseField::new(1, 1, 32, 16);
 /// Represents the extended bits of MAC address
-pub(crate) const MAC_EXT: EfuseField = EfuseField::new(1, 1, 48, 16);
+pub const MAC_EXT: EfuseField = EfuseField::new(1, 1, 48, 16);
 /// Minor chip version
-pub(crate) const WAFER_VERSION_MINOR: EfuseField = EfuseField::new(1, 2, 64, 4);
+pub const WAFER_VERSION_MINOR: EfuseField = EfuseField::new(1, 2, 64, 4);
 /// Minor chip version
-pub(crate) const WAFER_VERSION_MAJOR: EfuseField = EfuseField::new(1, 2, 68, 2);
+pub const WAFER_VERSION_MAJOR: EfuseField = EfuseField::new(1, 2, 68, 2);
 /// Disables check of wafer version major
-pub(crate) const DISABLE_WAFER_VERSION_MAJOR: EfuseField = EfuseField::new(1, 2, 70, 1);
+pub const DISABLE_WAFER_VERSION_MAJOR: EfuseField = EfuseField::new(1, 2, 70, 1);
 /// Disables check of blk version major
-pub(crate) const DISABLE_BLK_VERSION_MAJOR: EfuseField = EfuseField::new(1, 2, 71, 1);
+pub const DISABLE_BLK_VERSION_MAJOR: EfuseField = EfuseField::new(1, 2, 71, 1);
 /// BLK_VERSION_MINOR of BLOCK2
-pub(crate) const BLK_VERSION_MINOR: EfuseField = EfuseField::new(1, 2, 72, 3);
+pub const BLK_VERSION_MINOR: EfuseField = EfuseField::new(1, 2, 72, 3);
 /// BLK_VERSION_MAJOR of BLOCK2
-pub(crate) const BLK_VERSION_MAJOR: EfuseField = EfuseField::new(1, 2, 75, 2);
+pub const BLK_VERSION_MAJOR: EfuseField = EfuseField::new(1, 2, 75, 2);
 /// Flash capacity
-pub(crate) const FLASH_CAP: EfuseField = EfuseField::new(1, 2, 77, 3);
+pub const FLASH_CAP: EfuseField = EfuseField::new(1, 2, 77, 3);
 /// Flash vendor
-pub(crate) const FLASH_VENDOR: EfuseField = EfuseField::new(1, 2, 80, 3);
+pub const FLASH_VENDOR: EfuseField = EfuseField::new(1, 2, 80, 3);
 /// Psram capacity
-pub(crate) const PSRAM_CAP: EfuseField = EfuseField::new(1, 2, 83, 3);
+pub const PSRAM_CAP: EfuseField = EfuseField::new(1, 2, 83, 3);
 /// Psram vendor
-pub(crate) const PSRAM_VENDOR: EfuseField = EfuseField::new(1, 2, 86, 2);
+pub const PSRAM_VENDOR: EfuseField = EfuseField::new(1, 2, 86, 2);
 /// Temp (die embedded inside)
-pub(crate) const TEMP: EfuseField = EfuseField::new(1, 2, 88, 2);
+pub const TEMP: EfuseField = EfuseField::new(1, 2, 88, 2);
 /// Package version
-pub(crate) const PKG_VERSION: EfuseField = EfuseField::new(1, 2, 90, 3);
+pub const PKG_VERSION: EfuseField = EfuseField::new(1, 2, 90, 3);
 /// PADC CAL PA trim version
-pub(crate) const PA_TRIM_VERSION: EfuseField = EfuseField::new(1, 2, 93, 3);
+pub const PA_TRIM_VERSION: EfuseField = EfuseField::new(1, 2, 93, 3);
 /// PADC CAL N bias
-pub(crate) const TRIM_N_BIAS: EfuseField = EfuseField::new(1, 3, 96, 5);
+pub const TRIM_N_BIAS: EfuseField = EfuseField::new(1, 3, 96, 5);
 /// PADC CAL P bias
-pub(crate) const TRIM_P_BIAS: EfuseField = EfuseField::new(1, 3, 101, 5);
+pub const TRIM_P_BIAS: EfuseField = EfuseField::new(1, 3, 101, 5);
 /// Active HP DBIAS of fixed voltage
-pub(crate) const ACTIVE_HP_DBIAS: EfuseField = EfuseField::new(1, 3, 106, 4);
+pub const ACTIVE_HP_DBIAS: EfuseField = EfuseField::new(1, 3, 106, 4);
 /// Active LP DBIAS of fixed voltage
-pub(crate) const ACTIVE_LP_DBIAS: EfuseField = EfuseField::new(1, 3, 110, 4);
+pub const ACTIVE_LP_DBIAS: EfuseField = EfuseField::new(1, 3, 110, 4);
 /// LSLP HP DBG of fixed voltage
-pub(crate) const LSLP_HP_DBG: EfuseField = EfuseField::new(1, 3, 114, 2);
+pub const LSLP_HP_DBG: EfuseField = EfuseField::new(1, 3, 114, 2);
 /// LSLP HP DBIAS of fixed voltage
-pub(crate) const LSLP_HP_DBIAS: EfuseField = EfuseField::new(1, 3, 116, 4);
+pub const LSLP_HP_DBIAS: EfuseField = EfuseField::new(1, 3, 116, 4);
 /// DSLP LP DBG of fixed voltage
-pub(crate) const DSLP_LP_DBG: EfuseField = EfuseField::new(1, 3, 120, 4);
+pub const DSLP_LP_DBG: EfuseField = EfuseField::new(1, 3, 120, 4);
 /// DSLP LP DBIAS of fixed voltage
-pub(crate) const DSLP_LP_DBIAS: EfuseField = EfuseField::new(1, 3, 124, 5);
+pub const DSLP_LP_DBIAS: EfuseField = EfuseField::new(1, 3, 124, 5);
 /// DBIAS gap between LP and HP
-pub(crate) const LP_HP_DBIAS_VOL_GAP: EfuseField = EfuseField::new(1, 4, 129, 5);
+pub const LP_HP_DBIAS_VOL_GAP: EfuseField = EfuseField::new(1, 4, 129, 5);
 /// REF PADC Calibration Curr
-pub(crate) const REF_CURR_CODE: EfuseField = EfuseField::new(1, 4, 134, 4);
+pub const REF_CURR_CODE: EfuseField = EfuseField::new(1, 4, 134, 4);
 /// RES PADC Calibration Tune
-pub(crate) const RES_TUNE_CODE: EfuseField = EfuseField::new(1, 4, 138, 5);
+pub const RES_TUNE_CODE: EfuseField = EfuseField::new(1, 4, 138, 5);
 /// reserved
-pub(crate) const RESERVED_1_143: EfuseField = EfuseField::new(1, 4, 143, 17);
+pub const RESERVED_1_143: EfuseField = EfuseField::new(1, 4, 143, 17);
 /// Represents the third 32-bit of zeroth part of system data
-pub(crate) const SYS_DATA_PART0_2: EfuseField = EfuseField::new(1, 5, 160, 32);
+pub const SYS_DATA_PART0_2: EfuseField = EfuseField::new(1, 5, 160, 32);
 /// Optional unique 128-bit ID
-pub(crate) const OPTIONAL_UNIQUE_ID: EfuseField = EfuseField::new(2, 0, 0, 128);
+pub const OPTIONAL_UNIQUE_ID: EfuseField = EfuseField::new(2, 0, 0, 128);
 /// Temperature calibration data
-pub(crate) const TEMPERATURE_SENSOR: EfuseField = EfuseField::new(2, 4, 128, 9);
+pub const TEMPERATURE_SENSOR: EfuseField = EfuseField::new(2, 4, 128, 9);
 /// ADC OCode
-pub(crate) const OCODE: EfuseField = EfuseField::new(2, 4, 137, 8);
+pub const OCODE: EfuseField = EfuseField::new(2, 4, 137, 8);
 /// Average initcode of ADC1 atten0
-pub(crate) const ADC1_AVE_INITCODE_ATTEN0: EfuseField = EfuseField::new(2, 4, 145, 10);
+pub const ADC1_AVE_INITCODE_ATTEN0: EfuseField = EfuseField::new(2, 4, 145, 10);
 /// Average initcode of ADC1 atten0
-pub(crate) const ADC1_AVE_INITCODE_ATTEN1: EfuseField = EfuseField::new(2, 4, 155, 10);
+pub const ADC1_AVE_INITCODE_ATTEN1: EfuseField = EfuseField::new(2, 4, 155, 10);
 /// Average initcode of ADC1 atten0
-pub(crate) const ADC1_AVE_INITCODE_ATTEN2: EfuseField = EfuseField::new(2, 5, 165, 10);
+pub const ADC1_AVE_INITCODE_ATTEN2: EfuseField = EfuseField::new(2, 5, 165, 10);
 /// Average initcode of ADC1 atten0
-pub(crate) const ADC1_AVE_INITCODE_ATTEN3: EfuseField = EfuseField::new(2, 5, 175, 10);
+pub const ADC1_AVE_INITCODE_ATTEN3: EfuseField = EfuseField::new(2, 5, 175, 10);
 /// HI DOUT of ADC1 atten0
-pub(crate) const ADC1_HI_DOUT_ATTEN0: EfuseField = EfuseField::new(2, 5, 185, 10);
+pub const ADC1_HI_DOUT_ATTEN0: EfuseField = EfuseField::new(2, 5, 185, 10);
 /// HI DOUT of ADC1 atten1
-pub(crate) const ADC1_HI_DOUT_ATTEN1: EfuseField = EfuseField::new(2, 6, 195, 10);
+pub const ADC1_HI_DOUT_ATTEN1: EfuseField = EfuseField::new(2, 6, 195, 10);
 /// HI DOUT of ADC1 atten2
-pub(crate) const ADC1_HI_DOUT_ATTEN2: EfuseField = EfuseField::new(2, 6, 205, 10);
+pub const ADC1_HI_DOUT_ATTEN2: EfuseField = EfuseField::new(2, 6, 205, 10);
 /// HI DOUT of ADC1 atten3
-pub(crate) const ADC1_HI_DOUT_ATTEN3: EfuseField = EfuseField::new(2, 6, 215, 10);
+pub const ADC1_HI_DOUT_ATTEN3: EfuseField = EfuseField::new(2, 6, 215, 10);
 /// Gap between ADC1 CH0 and average initcode
-pub(crate) const ADC1_CH0_ATTEN0_INITCODE_DIFF: EfuseField = EfuseField::new(2, 7, 225, 4);
+pub const ADC1_CH0_ATTEN0_INITCODE_DIFF: EfuseField = EfuseField::new(2, 7, 225, 4);
 /// Gap between ADC1 CH1 and average initcode
-pub(crate) const ADC1_CH1_ATTEN0_INITCODE_DIFF: EfuseField = EfuseField::new(2, 7, 229, 4);
+pub const ADC1_CH1_ATTEN0_INITCODE_DIFF: EfuseField = EfuseField::new(2, 7, 229, 4);
 /// Gap between ADC1 CH2 and average initcode
-pub(crate) const ADC1_CH2_ATTEN0_INITCODE_DIFF: EfuseField = EfuseField::new(2, 7, 233, 4);
+pub const ADC1_CH2_ATTEN0_INITCODE_DIFF: EfuseField = EfuseField::new(2, 7, 233, 4);
 /// Gap between ADC1 CH3 and average initcode
-pub(crate) const ADC1_CH3_ATTEN0_INITCODE_DIFF: EfuseField = EfuseField::new(2, 7, 237, 4);
+pub const ADC1_CH3_ATTEN0_INITCODE_DIFF: EfuseField = EfuseField::new(2, 7, 237, 4);
 /// Gap between ADC1 CH4 and average initcode
-pub(crate) const ADC1_CH4_ATTEN0_INITCODE_DIFF: EfuseField = EfuseField::new(2, 7, 241, 4);
+pub const ADC1_CH4_ATTEN0_INITCODE_DIFF: EfuseField = EfuseField::new(2, 7, 241, 4);
 /// Gap between ADC1 CH5 and average initcode
-pub(crate) const ADC1_CH5_ATTEN0_INITCODE_DIFF: EfuseField = EfuseField::new(2, 7, 245, 4);
+pub const ADC1_CH5_ATTEN0_INITCODE_DIFF: EfuseField = EfuseField::new(2, 7, 245, 4);
 /// reserved
-pub(crate) const RESERVED_2_249: EfuseField = EfuseField::new(2, 7, 249, 7);
+pub const RESERVED_2_249: EfuseField = EfuseField::new(2, 7, 249, 7);
 /// User data
-pub(crate) const BLOCK_USR_DATA: EfuseField = EfuseField::new(3, 0, 0, 192);
+pub const BLOCK_USR_DATA: EfuseField = EfuseField::new(3, 0, 0, 192);
 /// reserved
-pub(crate) const RESERVED_3_192: EfuseField = EfuseField::new(3, 6, 192, 8);
+pub const RESERVED_3_192: EfuseField = EfuseField::new(3, 6, 192, 8);
 /// Custom MAC
-pub(crate) const CUSTOM_MAC: EfuseField = EfuseField::new(3, 6, 200, 48);
+pub const CUSTOM_MAC: EfuseField = EfuseField::new(3, 6, 200, 48);
 /// reserved
-pub(crate) const RESERVED_3_248: EfuseField = EfuseField::new(3, 7, 248, 8);
+pub const RESERVED_3_248: EfuseField = EfuseField::new(3, 7, 248, 8);
 /// Key0 or user data
-pub(crate) const BLOCK_KEY0: EfuseField = EfuseField::new(4, 0, 0, 256);
+pub const BLOCK_KEY0: EfuseField = EfuseField::new(4, 0, 0, 256);
 /// Key1 or user data
-pub(crate) const BLOCK_KEY1: EfuseField = EfuseField::new(5, 0, 0, 256);
+pub const BLOCK_KEY1: EfuseField = EfuseField::new(5, 0, 0, 256);
 /// Key2 or user data
-pub(crate) const BLOCK_KEY2: EfuseField = EfuseField::new(6, 0, 0, 256);
+pub const BLOCK_KEY2: EfuseField = EfuseField::new(6, 0, 0, 256);
 /// Key3 or user data
-pub(crate) const BLOCK_KEY3: EfuseField = EfuseField::new(7, 0, 0, 256);
+pub const BLOCK_KEY3: EfuseField = EfuseField::new(7, 0, 0, 256);
 /// Key4 or user data
-pub(crate) const BLOCK_KEY4: EfuseField = EfuseField::new(8, 0, 0, 256);
+pub const BLOCK_KEY4: EfuseField = EfuseField::new(8, 0, 0, 256);
 /// Key5 or user data
-pub(crate) const BLOCK_KEY5: EfuseField = EfuseField::new(9, 0, 0, 256);
+pub const BLOCK_KEY5: EfuseField = EfuseField::new(9, 0, 0, 256);
 /// System data part 2 (reserved)
-pub(crate) const BLOCK_SYS_DATA2: EfuseField = EfuseField::new(10, 0, 0, 256);
+pub const BLOCK_SYS_DATA2: EfuseField = EfuseField::new(10, 0, 0, 256);

--- a/espflash/src/target/efuse/esp32c6.rs
+++ b/espflash/src/target/efuse/esp32c6.rs
@@ -1,6 +1,6 @@
 //! This file was automatically generated, please do not edit it manually!
 //!
-//! Generated: 2025-05-30 12:24
+//! Generated: 2025-06-25 09:59
 //! Version:   df46b69f0ed3913114ba53d3a0b2b843
 
 #![allow(unused)]
@@ -11,252 +11,252 @@ use super::EfuseField;
 pub(crate) const BLOCK_SIZES: &[u32] = &[24, 24, 32, 32, 32, 32, 32, 32, 32, 32, 32];
 
 /// Disable programming of individual eFuses
-pub(crate) const WR_DIS: EfuseField = EfuseField::new(0, 0, 0, 32);
+pub const WR_DIS: EfuseField = EfuseField::new(0, 0, 0, 32);
 /// Disable reading from BlOCK4-10
-pub(crate) const RD_DIS: EfuseField = EfuseField::new(0, 1, 32, 7);
+pub const RD_DIS: EfuseField = EfuseField::new(0, 1, 32, 7);
 /// Represents whether pad of uart and sdio is swapped or not. 1: swapped. 0:
 /// not swapped
-pub(crate) const SWAP_UART_SDIO_EN: EfuseField = EfuseField::new(0, 1, 39, 1);
+pub const SWAP_UART_SDIO_EN: EfuseField = EfuseField::new(0, 1, 39, 1);
 /// Represents whether icache is disabled or enabled. 1: disabled. 0: enabled
-pub(crate) const DIS_ICACHE: EfuseField = EfuseField::new(0, 1, 40, 1);
+pub const DIS_ICACHE: EfuseField = EfuseField::new(0, 1, 40, 1);
 /// Represents whether the function of usb switch to jtag is disabled or
 /// enabled. 1: disabled. 0: enabled
-pub(crate) const DIS_USB_JTAG: EfuseField = EfuseField::new(0, 1, 41, 1);
+pub const DIS_USB_JTAG: EfuseField = EfuseField::new(0, 1, 41, 1);
 /// Represents whether icache is disabled or enabled in Download mode. 1:
 /// disabled. 0: enabled
-pub(crate) const DIS_DOWNLOAD_ICACHE: EfuseField = EfuseField::new(0, 1, 42, 1);
+pub const DIS_DOWNLOAD_ICACHE: EfuseField = EfuseField::new(0, 1, 42, 1);
 /// Represents whether USB-Serial-JTAG is disabled or enabled. 1: disabled. 0:
 /// enabled
-pub(crate) const DIS_USB_SERIAL_JTAG: EfuseField = EfuseField::new(0, 1, 43, 1);
+pub const DIS_USB_SERIAL_JTAG: EfuseField = EfuseField::new(0, 1, 43, 1);
 /// Represents whether the function that forces chip into download mode is
 /// disabled or enabled. 1: disabled. 0: enabled
-pub(crate) const DIS_FORCE_DOWNLOAD: EfuseField = EfuseField::new(0, 1, 44, 1);
+pub const DIS_FORCE_DOWNLOAD: EfuseField = EfuseField::new(0, 1, 44, 1);
 /// Represents whether SPI0 controller during boot_mode_download is disabled or
 /// enabled. 1: disabled. 0: enabled
-pub(crate) const SPI_DOWNLOAD_MSPI_DIS: EfuseField = EfuseField::new(0, 1, 45, 1);
+pub const SPI_DOWNLOAD_MSPI_DIS: EfuseField = EfuseField::new(0, 1, 45, 1);
 /// Represents whether TWAI function is disabled or enabled. 1: disabled. 0:
 /// enabled
-pub(crate) const DIS_TWAI: EfuseField = EfuseField::new(0, 1, 46, 1);
+pub const DIS_TWAI: EfuseField = EfuseField::new(0, 1, 46, 1);
 /// Represents whether the selection between usb_to_jtag and pad_to_jtag through
 /// strapping gpio15 when both EFUSE_DIS_PAD_JTAG and EFUSE_DIS_USB_JTAG are
 /// equal to 0 is enabled or disabled. 1: enabled. 0: disabled
-pub(crate) const JTAG_SEL_ENABLE: EfuseField = EfuseField::new(0, 1, 47, 1);
+pub const JTAG_SEL_ENABLE: EfuseField = EfuseField::new(0, 1, 47, 1);
 /// Represents whether JTAG is disabled in soft way. Odd number: disabled. Even
 /// number: enabled
-pub(crate) const SOFT_DIS_JTAG: EfuseField = EfuseField::new(0, 1, 48, 3);
+pub const SOFT_DIS_JTAG: EfuseField = EfuseField::new(0, 1, 48, 3);
 /// Represents whether JTAG is disabled in the hard way(permanently). 1:
 /// disabled. 0: enabled
-pub(crate) const DIS_PAD_JTAG: EfuseField = EfuseField::new(0, 1, 51, 1);
+pub const DIS_PAD_JTAG: EfuseField = EfuseField::new(0, 1, 51, 1);
 /// Represents whether flash encrypt function is disabled or enabled(except in
 /// SPI boot mode). 1: disabled. 0: enabled
-pub(crate) const DIS_DOWNLOAD_MANUAL_ENCRYPT: EfuseField = EfuseField::new(0, 1, 52, 1);
+pub const DIS_DOWNLOAD_MANUAL_ENCRYPT: EfuseField = EfuseField::new(0, 1, 52, 1);
 /// Represents the single-end input threshold vrefh; 1.76 V to 2 V with step of
 /// 80 mV
-pub(crate) const USB_DREFH: EfuseField = EfuseField::new(0, 1, 53, 2);
+pub const USB_DREFH: EfuseField = EfuseField::new(0, 1, 53, 2);
 /// Represents the single-end input threshold vrefl; 1.76 V to 2 V with step of
 /// 80 mV
-pub(crate) const USB_DREFL: EfuseField = EfuseField::new(0, 1, 55, 2);
+pub const USB_DREFL: EfuseField = EfuseField::new(0, 1, 55, 2);
 /// Represents whether the D+ and D- pins is exchanged. 1: exchanged. 0: not
 /// exchanged
-pub(crate) const USB_EXCHG_PINS: EfuseField = EfuseField::new(0, 1, 57, 1);
+pub const USB_EXCHG_PINS: EfuseField = EfuseField::new(0, 1, 57, 1);
 /// Represents whether vdd spi pin is functioned as gpio. 1: functioned. 0: not
 /// functioned
-pub(crate) const VDD_SPI_AS_GPIO: EfuseField = EfuseField::new(0, 1, 58, 1);
+pub const VDD_SPI_AS_GPIO: EfuseField = EfuseField::new(0, 1, 58, 1);
 /// Reserved
-pub(crate) const RPT4_RESERVED0_2: EfuseField = EfuseField::new(0, 1, 59, 2);
+pub const RPT4_RESERVED0_2: EfuseField = EfuseField::new(0, 1, 59, 2);
 /// Reserved
-pub(crate) const RPT4_RESERVED0_1: EfuseField = EfuseField::new(0, 1, 61, 1);
+pub const RPT4_RESERVED0_1: EfuseField = EfuseField::new(0, 1, 61, 1);
 /// Reserved
-pub(crate) const RPT4_RESERVED0_0: EfuseField = EfuseField::new(0, 1, 62, 2);
+pub const RPT4_RESERVED0_0: EfuseField = EfuseField::new(0, 1, 62, 2);
 /// Reserved
-pub(crate) const RPT4_RESERVED1_0: EfuseField = EfuseField::new(0, 2, 64, 16);
+pub const RPT4_RESERVED1_0: EfuseField = EfuseField::new(0, 2, 64, 16);
 /// Represents whether RTC watchdog timeout threshold is selected at startup. 1:
 /// selected. 0: not selected
-pub(crate) const WDT_DELAY_SEL: EfuseField = EfuseField::new(0, 2, 80, 2);
+pub const WDT_DELAY_SEL: EfuseField = EfuseField::new(0, 2, 80, 2);
 /// Enables flash encryption when 1 or 3 bits are set and disables otherwise
-pub(crate) const SPI_BOOT_CRYPT_CNT: EfuseField = EfuseField::new(0, 2, 82, 3);
+pub const SPI_BOOT_CRYPT_CNT: EfuseField = EfuseField::new(0, 2, 82, 3);
 /// Revoke 1st secure boot key
-pub(crate) const SECURE_BOOT_KEY_REVOKE0: EfuseField = EfuseField::new(0, 2, 85, 1);
+pub const SECURE_BOOT_KEY_REVOKE0: EfuseField = EfuseField::new(0, 2, 85, 1);
 /// Revoke 2nd secure boot key
-pub(crate) const SECURE_BOOT_KEY_REVOKE1: EfuseField = EfuseField::new(0, 2, 86, 1);
+pub const SECURE_BOOT_KEY_REVOKE1: EfuseField = EfuseField::new(0, 2, 86, 1);
 /// Revoke 3rd secure boot key
-pub(crate) const SECURE_BOOT_KEY_REVOKE2: EfuseField = EfuseField::new(0, 2, 87, 1);
+pub const SECURE_BOOT_KEY_REVOKE2: EfuseField = EfuseField::new(0, 2, 87, 1);
 /// Represents the purpose of Key0
-pub(crate) const KEY_PURPOSE_0: EfuseField = EfuseField::new(0, 2, 88, 4);
+pub const KEY_PURPOSE_0: EfuseField = EfuseField::new(0, 2, 88, 4);
 /// Represents the purpose of Key1
-pub(crate) const KEY_PURPOSE_1: EfuseField = EfuseField::new(0, 2, 92, 4);
+pub const KEY_PURPOSE_1: EfuseField = EfuseField::new(0, 2, 92, 4);
 /// Represents the purpose of Key2
-pub(crate) const KEY_PURPOSE_2: EfuseField = EfuseField::new(0, 3, 96, 4);
+pub const KEY_PURPOSE_2: EfuseField = EfuseField::new(0, 3, 96, 4);
 /// Represents the purpose of Key3
-pub(crate) const KEY_PURPOSE_3: EfuseField = EfuseField::new(0, 3, 100, 4);
+pub const KEY_PURPOSE_3: EfuseField = EfuseField::new(0, 3, 100, 4);
 /// Represents the purpose of Key4
-pub(crate) const KEY_PURPOSE_4: EfuseField = EfuseField::new(0, 3, 104, 4);
+pub const KEY_PURPOSE_4: EfuseField = EfuseField::new(0, 3, 104, 4);
 /// Represents the purpose of Key5
-pub(crate) const KEY_PURPOSE_5: EfuseField = EfuseField::new(0, 3, 108, 4);
+pub const KEY_PURPOSE_5: EfuseField = EfuseField::new(0, 3, 108, 4);
 /// Represents the spa secure level by configuring the clock random divide mode
-pub(crate) const SEC_DPA_LEVEL: EfuseField = EfuseField::new(0, 3, 112, 2);
+pub const SEC_DPA_LEVEL: EfuseField = EfuseField::new(0, 3, 112, 2);
 /// Represents whether anti-dpa attack is enabled. 1:enabled. 0: disabled
-pub(crate) const CRYPT_DPA_ENABLE: EfuseField = EfuseField::new(0, 3, 114, 1);
+pub const CRYPT_DPA_ENABLE: EfuseField = EfuseField::new(0, 3, 114, 1);
 /// Reserved
-pub(crate) const RPT4_RESERVED2_1: EfuseField = EfuseField::new(0, 3, 115, 1);
+pub const RPT4_RESERVED2_1: EfuseField = EfuseField::new(0, 3, 115, 1);
 /// Represents whether secure boot is enabled or disabled. 1: enabled. 0:
 /// disabled
-pub(crate) const SECURE_BOOT_EN: EfuseField = EfuseField::new(0, 3, 116, 1);
+pub const SECURE_BOOT_EN: EfuseField = EfuseField::new(0, 3, 116, 1);
 /// Represents whether revoking aggressive secure boot is enabled or disabled.
 /// 1: enabled. 0: disabled
-pub(crate) const SECURE_BOOT_AGGRESSIVE_REVOKE: EfuseField = EfuseField::new(0, 3, 117, 1);
+pub const SECURE_BOOT_AGGRESSIVE_REVOKE: EfuseField = EfuseField::new(0, 3, 117, 1);
 /// Reserved
-pub(crate) const RPT4_RESERVED2_0: EfuseField = EfuseField::new(0, 3, 118, 6);
+pub const RPT4_RESERVED2_0: EfuseField = EfuseField::new(0, 3, 118, 6);
 /// Represents the flash waiting time after power-up; in unit of ms. When the
 /// value less than 15; the waiting time is the programmed value. Otherwise; the
 /// waiting time is 2 times the programmed value
-pub(crate) const FLASH_TPUW: EfuseField = EfuseField::new(0, 3, 124, 4);
+pub const FLASH_TPUW: EfuseField = EfuseField::new(0, 3, 124, 4);
 /// Represents whether Download mode is disabled or enabled. 1: disabled. 0:
 /// enabled
-pub(crate) const DIS_DOWNLOAD_MODE: EfuseField = EfuseField::new(0, 4, 128, 1);
+pub const DIS_DOWNLOAD_MODE: EfuseField = EfuseField::new(0, 4, 128, 1);
 /// Represents whether direct boot mode is disabled or enabled. 1: disabled. 0:
 /// enabled
-pub(crate) const DIS_DIRECT_BOOT: EfuseField = EfuseField::new(0, 4, 129, 1);
+pub const DIS_DIRECT_BOOT: EfuseField = EfuseField::new(0, 4, 129, 1);
 /// Represents whether print from USB-Serial-JTAG is disabled or enabled. 1:
 /// disabled. 0: enabled
-pub(crate) const DIS_USB_SERIAL_JTAG_ROM_PRINT: EfuseField = EfuseField::new(0, 4, 130, 1);
+pub const DIS_USB_SERIAL_JTAG_ROM_PRINT: EfuseField = EfuseField::new(0, 4, 130, 1);
 /// Reserved
-pub(crate) const RPT4_RESERVED3_5: EfuseField = EfuseField::new(0, 4, 131, 1);
+pub const RPT4_RESERVED3_5: EfuseField = EfuseField::new(0, 4, 131, 1);
 /// Represents whether the USB-Serial-JTAG download function is disabled or
 /// enabled. 1: disabled. 0: enabled
-pub(crate) const DIS_USB_SERIAL_JTAG_DOWNLOAD_MODE: EfuseField = EfuseField::new(0, 4, 132, 1);
+pub const DIS_USB_SERIAL_JTAG_DOWNLOAD_MODE: EfuseField = EfuseField::new(0, 4, 132, 1);
 /// Represents whether security download is enabled or disabled. 1: enabled. 0:
 /// disabled
-pub(crate) const ENABLE_SECURITY_DOWNLOAD: EfuseField = EfuseField::new(0, 4, 133, 1);
+pub const ENABLE_SECURITY_DOWNLOAD: EfuseField = EfuseField::new(0, 4, 133, 1);
 /// Set the default UARTboot message output mode
-pub(crate) const UART_PRINT_CONTROL: EfuseField = EfuseField::new(0, 4, 134, 2);
+pub const UART_PRINT_CONTROL: EfuseField = EfuseField::new(0, 4, 134, 2);
 /// Reserved
-pub(crate) const RPT4_RESERVED3_4: EfuseField = EfuseField::new(0, 4, 136, 1);
+pub const RPT4_RESERVED3_4: EfuseField = EfuseField::new(0, 4, 136, 1);
 /// Reserved
-pub(crate) const RPT4_RESERVED3_3: EfuseField = EfuseField::new(0, 4, 137, 1);
+pub const RPT4_RESERVED3_3: EfuseField = EfuseField::new(0, 4, 137, 1);
 /// Reserved
-pub(crate) const RPT4_RESERVED3_2: EfuseField = EfuseField::new(0, 4, 138, 2);
+pub const RPT4_RESERVED3_2: EfuseField = EfuseField::new(0, 4, 138, 2);
 /// Reserved
-pub(crate) const RPT4_RESERVED3_1: EfuseField = EfuseField::new(0, 4, 140, 1);
+pub const RPT4_RESERVED3_1: EfuseField = EfuseField::new(0, 4, 140, 1);
 /// Represents whether ROM code is forced to send a resume command during SPI
 /// boot. 1: forced. 0:not forced
-pub(crate) const FORCE_SEND_RESUME: EfuseField = EfuseField::new(0, 4, 141, 1);
+pub const FORCE_SEND_RESUME: EfuseField = EfuseField::new(0, 4, 141, 1);
 /// Represents the version used by ESP-IDF anti-rollback feature
-pub(crate) const SECURE_VERSION: EfuseField = EfuseField::new(0, 4, 142, 16);
+pub const SECURE_VERSION: EfuseField = EfuseField::new(0, 4, 142, 16);
 /// Represents whether FAST VERIFY ON WAKE is disabled or enabled when Secure
 /// Boot is enabled. 1: disabled. 0: enabled
-pub(crate) const SECURE_BOOT_DISABLE_FAST_WAKE: EfuseField = EfuseField::new(0, 4, 158, 1);
+pub const SECURE_BOOT_DISABLE_FAST_WAKE: EfuseField = EfuseField::new(0, 4, 158, 1);
 /// Reserved
-pub(crate) const RPT4_RESERVED3_0: EfuseField = EfuseField::new(0, 4, 159, 1);
+pub const RPT4_RESERVED3_0: EfuseField = EfuseField::new(0, 4, 159, 1);
 /// Disables check of wafer version major
-pub(crate) const DISABLE_WAFER_VERSION_MAJOR: EfuseField = EfuseField::new(0, 5, 160, 1);
+pub const DISABLE_WAFER_VERSION_MAJOR: EfuseField = EfuseField::new(0, 5, 160, 1);
 /// Disables check of blk version major
-pub(crate) const DISABLE_BLK_VERSION_MAJOR: EfuseField = EfuseField::new(0, 5, 161, 1);
+pub const DISABLE_BLK_VERSION_MAJOR: EfuseField = EfuseField::new(0, 5, 161, 1);
 /// reserved
-pub(crate) const RESERVED_0_162: EfuseField = EfuseField::new(0, 5, 162, 22);
+pub const RESERVED_0_162: EfuseField = EfuseField::new(0, 5, 162, 22);
 /// Reserved
-pub(crate) const RPT4_RESERVED4_0: EfuseField = EfuseField::new(0, 5, 184, 8);
+pub const RPT4_RESERVED4_0: EfuseField = EfuseField::new(0, 5, 184, 8);
 /// MAC address
-pub(crate) const MAC0: EfuseField = EfuseField::new(1, 0, 0, 32);
+pub const MAC0: EfuseField = EfuseField::new(1, 0, 0, 32);
 /// MAC address
-pub(crate) const MAC1: EfuseField = EfuseField::new(1, 1, 32, 16);
+pub const MAC1: EfuseField = EfuseField::new(1, 1, 32, 16);
 /// Stores the extended bits of MAC address
-pub(crate) const MAC_EXT: EfuseField = EfuseField::new(1, 1, 48, 16);
+pub const MAC_EXT: EfuseField = EfuseField::new(1, 1, 48, 16);
 /// Stores the active hp dbias
-pub(crate) const ACTIVE_HP_DBIAS: EfuseField = EfuseField::new(1, 2, 64, 5);
+pub const ACTIVE_HP_DBIAS: EfuseField = EfuseField::new(1, 2, 64, 5);
 /// Stores the active lp dbias
-pub(crate) const ACTIVE_LP_DBIAS: EfuseField = EfuseField::new(1, 2, 69, 5);
+pub const ACTIVE_LP_DBIAS: EfuseField = EfuseField::new(1, 2, 69, 5);
 /// Stores the lslp hp dbg
-pub(crate) const LSLP_HP_DBG: EfuseField = EfuseField::new(1, 2, 74, 2);
+pub const LSLP_HP_DBG: EfuseField = EfuseField::new(1, 2, 74, 2);
 /// Stores the lslp hp dbias
-pub(crate) const LSLP_HP_DBIAS: EfuseField = EfuseField::new(1, 2, 76, 4);
+pub const LSLP_HP_DBIAS: EfuseField = EfuseField::new(1, 2, 76, 4);
 /// Stores the dslp lp dbg
-pub(crate) const DSLP_LP_DBG: EfuseField = EfuseField::new(1, 2, 80, 3);
+pub const DSLP_LP_DBG: EfuseField = EfuseField::new(1, 2, 80, 3);
 /// Stores the dslp lp dbias
-pub(crate) const DSLP_LP_DBIAS: EfuseField = EfuseField::new(1, 2, 83, 4);
+pub const DSLP_LP_DBIAS: EfuseField = EfuseField::new(1, 2, 83, 4);
 /// Stores the hp and lp dbias vol gap
-pub(crate) const DBIAS_VOL_GAP: EfuseField = EfuseField::new(1, 2, 87, 5);
+pub const DBIAS_VOL_GAP: EfuseField = EfuseField::new(1, 2, 87, 5);
 /// Stores the first part of SPI_PAD_CONF
-pub(crate) const SPI_PAD_CONF_1: EfuseField = EfuseField::new(1, 2, 92, 4);
+pub const SPI_PAD_CONF_1: EfuseField = EfuseField::new(1, 2, 92, 4);
 /// Stores the second part of SPI_PAD_CONF
-pub(crate) const SPI_PAD_CONF_2: EfuseField = EfuseField::new(1, 3, 96, 18);
+pub const SPI_PAD_CONF_2: EfuseField = EfuseField::new(1, 3, 96, 18);
 ///
-pub(crate) const WAFER_VERSION_MINOR: EfuseField = EfuseField::new(1, 3, 114, 4);
+pub const WAFER_VERSION_MINOR: EfuseField = EfuseField::new(1, 3, 114, 4);
 ///
-pub(crate) const WAFER_VERSION_MAJOR: EfuseField = EfuseField::new(1, 3, 118, 2);
+pub const WAFER_VERSION_MAJOR: EfuseField = EfuseField::new(1, 3, 118, 2);
 /// Package version
-pub(crate) const PKG_VERSION: EfuseField = EfuseField::new(1, 3, 120, 3);
+pub const PKG_VERSION: EfuseField = EfuseField::new(1, 3, 120, 3);
 /// BLK_VERSION_MINOR of BLOCK2
-pub(crate) const BLK_VERSION_MINOR: EfuseField = EfuseField::new(1, 3, 123, 3);
+pub const BLK_VERSION_MINOR: EfuseField = EfuseField::new(1, 3, 123, 3);
 /// BLK_VERSION_MAJOR of BLOCK2
-pub(crate) const BLK_VERSION_MAJOR: EfuseField = EfuseField::new(1, 3, 126, 2);
+pub const BLK_VERSION_MAJOR: EfuseField = EfuseField::new(1, 3, 126, 2);
 ///
-pub(crate) const FLASH_CAP: EfuseField = EfuseField::new(1, 4, 128, 3);
+pub const FLASH_CAP: EfuseField = EfuseField::new(1, 4, 128, 3);
 ///
-pub(crate) const FLASH_TEMP: EfuseField = EfuseField::new(1, 4, 131, 2);
+pub const FLASH_TEMP: EfuseField = EfuseField::new(1, 4, 131, 2);
 ///
-pub(crate) const FLASH_VENDOR: EfuseField = EfuseField::new(1, 4, 133, 3);
+pub const FLASH_VENDOR: EfuseField = EfuseField::new(1, 4, 133, 3);
 /// reserved
-pub(crate) const RESERVED_1_136: EfuseField = EfuseField::new(1, 4, 136, 24);
+pub const RESERVED_1_136: EfuseField = EfuseField::new(1, 4, 136, 24);
 /// Stores the second 32 bits of the zeroth part of system data
-pub(crate) const SYS_DATA_PART0_2: EfuseField = EfuseField::new(1, 5, 160, 32);
+pub const SYS_DATA_PART0_2: EfuseField = EfuseField::new(1, 5, 160, 32);
 /// Optional unique 128-bit ID
-pub(crate) const OPTIONAL_UNIQUE_ID: EfuseField = EfuseField::new(2, 0, 0, 128);
+pub const OPTIONAL_UNIQUE_ID: EfuseField = EfuseField::new(2, 0, 0, 128);
 /// Temperature calibration data
-pub(crate) const TEMP_CALIB: EfuseField = EfuseField::new(2, 4, 128, 9);
+pub const TEMP_CALIB: EfuseField = EfuseField::new(2, 4, 128, 9);
 /// ADC OCode
-pub(crate) const OCODE: EfuseField = EfuseField::new(2, 4, 137, 8);
+pub const OCODE: EfuseField = EfuseField::new(2, 4, 137, 8);
 /// ADC1 init code at atten0
-pub(crate) const ADC1_INIT_CODE_ATTEN0: EfuseField = EfuseField::new(2, 4, 145, 10);
+pub const ADC1_INIT_CODE_ATTEN0: EfuseField = EfuseField::new(2, 4, 145, 10);
 /// ADC1 init code at atten1
-pub(crate) const ADC1_INIT_CODE_ATTEN1: EfuseField = EfuseField::new(2, 4, 155, 10);
+pub const ADC1_INIT_CODE_ATTEN1: EfuseField = EfuseField::new(2, 4, 155, 10);
 /// ADC1 init code at atten2
-pub(crate) const ADC1_INIT_CODE_ATTEN2: EfuseField = EfuseField::new(2, 5, 165, 10);
+pub const ADC1_INIT_CODE_ATTEN2: EfuseField = EfuseField::new(2, 5, 165, 10);
 /// ADC1 init code at atten3
-pub(crate) const ADC1_INIT_CODE_ATTEN3: EfuseField = EfuseField::new(2, 5, 175, 10);
+pub const ADC1_INIT_CODE_ATTEN3: EfuseField = EfuseField::new(2, 5, 175, 10);
 /// ADC1 calibration voltage at atten0
-pub(crate) const ADC1_CAL_VOL_ATTEN0: EfuseField = EfuseField::new(2, 5, 185, 10);
+pub const ADC1_CAL_VOL_ATTEN0: EfuseField = EfuseField::new(2, 5, 185, 10);
 /// ADC1 calibration voltage at atten1
-pub(crate) const ADC1_CAL_VOL_ATTEN1: EfuseField = EfuseField::new(2, 6, 195, 10);
+pub const ADC1_CAL_VOL_ATTEN1: EfuseField = EfuseField::new(2, 6, 195, 10);
 /// ADC1 calibration voltage at atten2
-pub(crate) const ADC1_CAL_VOL_ATTEN2: EfuseField = EfuseField::new(2, 6, 205, 10);
+pub const ADC1_CAL_VOL_ATTEN2: EfuseField = EfuseField::new(2, 6, 205, 10);
 /// ADC1 calibration voltage at atten3
-pub(crate) const ADC1_CAL_VOL_ATTEN3: EfuseField = EfuseField::new(2, 6, 215, 10);
+pub const ADC1_CAL_VOL_ATTEN3: EfuseField = EfuseField::new(2, 6, 215, 10);
 /// ADC1 init code at atten0 ch0
-pub(crate) const ADC1_INIT_CODE_ATTEN0_CH0: EfuseField = EfuseField::new(2, 7, 225, 4);
+pub const ADC1_INIT_CODE_ATTEN0_CH0: EfuseField = EfuseField::new(2, 7, 225, 4);
 /// ADC1 init code at atten0 ch1
-pub(crate) const ADC1_INIT_CODE_ATTEN0_CH1: EfuseField = EfuseField::new(2, 7, 229, 4);
+pub const ADC1_INIT_CODE_ATTEN0_CH1: EfuseField = EfuseField::new(2, 7, 229, 4);
 /// ADC1 init code at atten0 ch2
-pub(crate) const ADC1_INIT_CODE_ATTEN0_CH2: EfuseField = EfuseField::new(2, 7, 233, 4);
+pub const ADC1_INIT_CODE_ATTEN0_CH2: EfuseField = EfuseField::new(2, 7, 233, 4);
 /// ADC1 init code at atten0 ch3
-pub(crate) const ADC1_INIT_CODE_ATTEN0_CH3: EfuseField = EfuseField::new(2, 7, 237, 4);
+pub const ADC1_INIT_CODE_ATTEN0_CH3: EfuseField = EfuseField::new(2, 7, 237, 4);
 /// ADC1 init code at atten0 ch4
-pub(crate) const ADC1_INIT_CODE_ATTEN0_CH4: EfuseField = EfuseField::new(2, 7, 241, 4);
+pub const ADC1_INIT_CODE_ATTEN0_CH4: EfuseField = EfuseField::new(2, 7, 241, 4);
 /// ADC1 init code at atten0 ch5
-pub(crate) const ADC1_INIT_CODE_ATTEN0_CH5: EfuseField = EfuseField::new(2, 7, 245, 4);
+pub const ADC1_INIT_CODE_ATTEN0_CH5: EfuseField = EfuseField::new(2, 7, 245, 4);
 /// ADC1 init code at atten0 ch6
-pub(crate) const ADC1_INIT_CODE_ATTEN0_CH6: EfuseField = EfuseField::new(2, 7, 249, 4);
+pub const ADC1_INIT_CODE_ATTEN0_CH6: EfuseField = EfuseField::new(2, 7, 249, 4);
 /// reserved
-pub(crate) const RESERVED_2_253: EfuseField = EfuseField::new(2, 7, 253, 3);
+pub const RESERVED_2_253: EfuseField = EfuseField::new(2, 7, 253, 3);
 /// User data
-pub(crate) const BLOCK_USR_DATA: EfuseField = EfuseField::new(3, 0, 0, 192);
+pub const BLOCK_USR_DATA: EfuseField = EfuseField::new(3, 0, 0, 192);
 /// reserved
-pub(crate) const RESERVED_3_192: EfuseField = EfuseField::new(3, 6, 192, 8);
+pub const RESERVED_3_192: EfuseField = EfuseField::new(3, 6, 192, 8);
 /// Custom MAC
-pub(crate) const CUSTOM_MAC: EfuseField = EfuseField::new(3, 6, 200, 48);
+pub const CUSTOM_MAC: EfuseField = EfuseField::new(3, 6, 200, 48);
 /// reserved
-pub(crate) const RESERVED_3_248: EfuseField = EfuseField::new(3, 7, 248, 8);
+pub const RESERVED_3_248: EfuseField = EfuseField::new(3, 7, 248, 8);
 /// Key0 or user data
-pub(crate) const BLOCK_KEY0: EfuseField = EfuseField::new(4, 0, 0, 256);
+pub const BLOCK_KEY0: EfuseField = EfuseField::new(4, 0, 0, 256);
 /// Key1 or user data
-pub(crate) const BLOCK_KEY1: EfuseField = EfuseField::new(5, 0, 0, 256);
+pub const BLOCK_KEY1: EfuseField = EfuseField::new(5, 0, 0, 256);
 /// Key2 or user data
-pub(crate) const BLOCK_KEY2: EfuseField = EfuseField::new(6, 0, 0, 256);
+pub const BLOCK_KEY2: EfuseField = EfuseField::new(6, 0, 0, 256);
 /// Key3 or user data
-pub(crate) const BLOCK_KEY3: EfuseField = EfuseField::new(7, 0, 0, 256);
+pub const BLOCK_KEY3: EfuseField = EfuseField::new(7, 0, 0, 256);
 /// Key4 or user data
-pub(crate) const BLOCK_KEY4: EfuseField = EfuseField::new(8, 0, 0, 256);
+pub const BLOCK_KEY4: EfuseField = EfuseField::new(8, 0, 0, 256);
 /// Key5 or user data
-pub(crate) const BLOCK_KEY5: EfuseField = EfuseField::new(9, 0, 0, 256);
+pub const BLOCK_KEY5: EfuseField = EfuseField::new(9, 0, 0, 256);
 /// System data part 2 (reserved)
-pub(crate) const BLOCK_SYS_DATA2: EfuseField = EfuseField::new(10, 0, 0, 256);
+pub const BLOCK_SYS_DATA2: EfuseField = EfuseField::new(10, 0, 0, 256);

--- a/espflash/src/target/efuse/esp32c6.rs
+++ b/espflash/src/target/efuse/esp32c6.rs
@@ -1,6 +1,8 @@
+//! eFuse field definitions for the esp32c6
+//!
 //! This file was automatically generated, please do not edit it manually!
 //!
-//! Generated: 2025-06-25 09:59
+//! Generated: 2025-06-25 11:06
 //! Version:   df46b69f0ed3913114ba53d3a0b2b843
 
 #![allow(unused)]

--- a/espflash/src/target/efuse/esp32h2.rs
+++ b/espflash/src/target/efuse/esp32h2.rs
@@ -1,6 +1,8 @@
+//! eFuse field definitions for the esp32h2
+//!
 //! This file was automatically generated, please do not edit it manually!
 //!
-//! Generated: 2025-06-25 09:59
+//! Generated: 2025-06-25 11:06
 //! Version:   44563d2af4ebdba4db6c0a34a50c94f9
 
 #![allow(unused)]

--- a/espflash/src/target/efuse/esp32h2.rs
+++ b/espflash/src/target/efuse/esp32h2.rs
@@ -1,6 +1,6 @@
 //! This file was automatically generated, please do not edit it manually!
 //!
-//! Generated: 2025-05-30 12:24
+//! Generated: 2025-06-25 09:59
 //! Version:   44563d2af4ebdba4db6c0a34a50c94f9
 
 #![allow(unused)]
@@ -11,242 +11,242 @@ use super::EfuseField;
 pub(crate) const BLOCK_SIZES: &[u32] = &[24, 24, 32, 32, 32, 32, 32, 32, 32, 32, 32];
 
 /// Disable programming of individual eFuses
-pub(crate) const WR_DIS: EfuseField = EfuseField::new(0, 0, 0, 32);
+pub const WR_DIS: EfuseField = EfuseField::new(0, 0, 0, 32);
 /// Disable reading from BlOCK4-10
-pub(crate) const RD_DIS: EfuseField = EfuseField::new(0, 1, 32, 7);
+pub const RD_DIS: EfuseField = EfuseField::new(0, 1, 32, 7);
 /// Reserved
-pub(crate) const RPT4_RESERVED0_4: EfuseField = EfuseField::new(0, 1, 39, 1);
+pub const RPT4_RESERVED0_4: EfuseField = EfuseField::new(0, 1, 39, 1);
 /// Represents whether icache is disabled or enabled. 1: disabled. 0: enabled
-pub(crate) const DIS_ICACHE: EfuseField = EfuseField::new(0, 1, 40, 1);
+pub const DIS_ICACHE: EfuseField = EfuseField::new(0, 1, 40, 1);
 /// Represents whether the function of usb switch to jtag is disabled or
 /// enabled. 1: disabled. 0: enabled
-pub(crate) const DIS_USB_JTAG: EfuseField = EfuseField::new(0, 1, 41, 1);
+pub const DIS_USB_JTAG: EfuseField = EfuseField::new(0, 1, 41, 1);
 /// Represents whether power glitch function is enabled. 1: enabled. 0: disabled
-pub(crate) const POWERGLITCH_EN: EfuseField = EfuseField::new(0, 1, 42, 1);
+pub const POWERGLITCH_EN: EfuseField = EfuseField::new(0, 1, 42, 1);
 /// Represents whether USB-Serial-JTAG is disabled or enabled. 1: disabled. 0:
 /// enabled
-pub(crate) const DIS_USB_SERIAL_JTAG: EfuseField = EfuseField::new(0, 1, 43, 1);
+pub const DIS_USB_SERIAL_JTAG: EfuseField = EfuseField::new(0, 1, 43, 1);
 /// Represents whether the function that forces chip into download mode is
 /// disabled or enabled. 1: disabled. 0: enabled
-pub(crate) const DIS_FORCE_DOWNLOAD: EfuseField = EfuseField::new(0, 1, 44, 1);
+pub const DIS_FORCE_DOWNLOAD: EfuseField = EfuseField::new(0, 1, 44, 1);
 /// Represents whether SPI0 controller during boot_mode_download is disabled or
 /// enabled. 1: disabled. 0: enabled
-pub(crate) const SPI_DOWNLOAD_MSPI_DIS: EfuseField = EfuseField::new(0, 1, 45, 1);
+pub const SPI_DOWNLOAD_MSPI_DIS: EfuseField = EfuseField::new(0, 1, 45, 1);
 /// Represents whether TWAI function is disabled or enabled. 1: disabled. 0:
 /// enabled
-pub(crate) const DIS_TWAI: EfuseField = EfuseField::new(0, 1, 46, 1);
+pub const DIS_TWAI: EfuseField = EfuseField::new(0, 1, 46, 1);
 /// Set this bit to enable selection between usb_to_jtag and pad_to_jtag through
 /// strapping gpio25 when both EFUSE_DIS_PAD_JTAG and EFUSE_DIS_USB_JTAG are
 /// equal to 0
-pub(crate) const JTAG_SEL_ENABLE: EfuseField = EfuseField::new(0, 1, 47, 1);
+pub const JTAG_SEL_ENABLE: EfuseField = EfuseField::new(0, 1, 47, 1);
 /// Represents whether JTAG is disabled in soft way. Odd number: disabled. Even
 /// number: enabled
-pub(crate) const SOFT_DIS_JTAG: EfuseField = EfuseField::new(0, 1, 48, 3);
+pub const SOFT_DIS_JTAG: EfuseField = EfuseField::new(0, 1, 48, 3);
 /// Represents whether JTAG is disabled in the hard way(permanently). 1:
 /// disabled. 0: enabled
-pub(crate) const DIS_PAD_JTAG: EfuseField = EfuseField::new(0, 1, 51, 1);
+pub const DIS_PAD_JTAG: EfuseField = EfuseField::new(0, 1, 51, 1);
 /// Represents whether flash encrypt function is disabled or enabled(except in
 /// SPI boot mode). 1: disabled. 0: enabled
-pub(crate) const DIS_DOWNLOAD_MANUAL_ENCRYPT: EfuseField = EfuseField::new(0, 1, 52, 1);
+pub const DIS_DOWNLOAD_MANUAL_ENCRYPT: EfuseField = EfuseField::new(0, 1, 52, 1);
 /// Represents the single-end input threshold vrefh; 1.76 V to 2 V with step of
 /// 80 mV
-pub(crate) const USB_DREFH: EfuseField = EfuseField::new(0, 1, 53, 2);
+pub const USB_DREFH: EfuseField = EfuseField::new(0, 1, 53, 2);
 /// Represents the single-end input threshold vrefl; 1.76 V to 2 V with step of
 /// 80 mV
-pub(crate) const USB_DREFL: EfuseField = EfuseField::new(0, 1, 55, 2);
+pub const USB_DREFL: EfuseField = EfuseField::new(0, 1, 55, 2);
 /// Represents whether the D+ and D- pins is exchanged. 1: exchanged. 0: not
 /// exchanged
-pub(crate) const USB_EXCHG_PINS: EfuseField = EfuseField::new(0, 1, 57, 1);
+pub const USB_EXCHG_PINS: EfuseField = EfuseField::new(0, 1, 57, 1);
 /// Represents whether vdd spi pin is functioned as gpio. 1: functioned. 0: not
 /// functioned
-pub(crate) const VDD_SPI_AS_GPIO: EfuseField = EfuseField::new(0, 1, 58, 1);
+pub const VDD_SPI_AS_GPIO: EfuseField = EfuseField::new(0, 1, 58, 1);
 /// Configures the curve of ECDSA calculation: 0: only enable P256. 1: only
 /// enable P192. 2: both enable P256 and P192. 3: only enable P256
-pub(crate) const ECDSA_CURVE_MODE: EfuseField = EfuseField::new(0, 1, 59, 2);
+pub const ECDSA_CURVE_MODE: EfuseField = EfuseField::new(0, 1, 59, 2);
 /// Set this bit to permanently turn on ECC const-time mode
-pub(crate) const ECC_FORCE_CONST_TIME: EfuseField = EfuseField::new(0, 1, 61, 1);
+pub const ECC_FORCE_CONST_TIME: EfuseField = EfuseField::new(0, 1, 61, 1);
 /// Set this bit to control the xts pseudo-round anti-dpa attack function: 0:
 /// controlled by register. 1-3: the higher the value is; the more pseudo-rounds
 /// are inserted to the xts-aes calculation
-pub(crate) const XTS_DPA_PSEUDO_LEVEL: EfuseField = EfuseField::new(0, 1, 62, 2);
+pub const XTS_DPA_PSEUDO_LEVEL: EfuseField = EfuseField::new(0, 1, 62, 2);
 /// Reserved
-pub(crate) const RPT4_RESERVED1_1: EfuseField = EfuseField::new(0, 2, 64, 16);
+pub const RPT4_RESERVED1_1: EfuseField = EfuseField::new(0, 2, 64, 16);
 /// Represents whether RTC watchdog timeout threshold is selected at startup. 1:
 /// selected. 0: not selected
-pub(crate) const WDT_DELAY_SEL: EfuseField = EfuseField::new(0, 2, 80, 2);
+pub const WDT_DELAY_SEL: EfuseField = EfuseField::new(0, 2, 80, 2);
 /// Enables flash encryption when 1 or 3 bits are set and disables otherwise
-pub(crate) const SPI_BOOT_CRYPT_CNT: EfuseField = EfuseField::new(0, 2, 82, 3);
+pub const SPI_BOOT_CRYPT_CNT: EfuseField = EfuseField::new(0, 2, 82, 3);
 /// Revoke 1st secure boot key
-pub(crate) const SECURE_BOOT_KEY_REVOKE0: EfuseField = EfuseField::new(0, 2, 85, 1);
+pub const SECURE_BOOT_KEY_REVOKE0: EfuseField = EfuseField::new(0, 2, 85, 1);
 /// Revoke 2nd secure boot key
-pub(crate) const SECURE_BOOT_KEY_REVOKE1: EfuseField = EfuseField::new(0, 2, 86, 1);
+pub const SECURE_BOOT_KEY_REVOKE1: EfuseField = EfuseField::new(0, 2, 86, 1);
 /// Revoke 3rd secure boot key
-pub(crate) const SECURE_BOOT_KEY_REVOKE2: EfuseField = EfuseField::new(0, 2, 87, 1);
+pub const SECURE_BOOT_KEY_REVOKE2: EfuseField = EfuseField::new(0, 2, 87, 1);
 /// Represents the purpose of Key0
-pub(crate) const KEY_PURPOSE_0: EfuseField = EfuseField::new(0, 2, 88, 4);
+pub const KEY_PURPOSE_0: EfuseField = EfuseField::new(0, 2, 88, 4);
 /// Represents the purpose of Key1
-pub(crate) const KEY_PURPOSE_1: EfuseField = EfuseField::new(0, 2, 92, 4);
+pub const KEY_PURPOSE_1: EfuseField = EfuseField::new(0, 2, 92, 4);
 /// Represents the purpose of Key2
-pub(crate) const KEY_PURPOSE_2: EfuseField = EfuseField::new(0, 3, 96, 4);
+pub const KEY_PURPOSE_2: EfuseField = EfuseField::new(0, 3, 96, 4);
 /// Represents the purpose of Key3
-pub(crate) const KEY_PURPOSE_3: EfuseField = EfuseField::new(0, 3, 100, 4);
+pub const KEY_PURPOSE_3: EfuseField = EfuseField::new(0, 3, 100, 4);
 /// Represents the purpose of Key4
-pub(crate) const KEY_PURPOSE_4: EfuseField = EfuseField::new(0, 3, 104, 4);
+pub const KEY_PURPOSE_4: EfuseField = EfuseField::new(0, 3, 104, 4);
 /// Represents the purpose of Key5
-pub(crate) const KEY_PURPOSE_5: EfuseField = EfuseField::new(0, 3, 108, 4);
+pub const KEY_PURPOSE_5: EfuseField = EfuseField::new(0, 3, 108, 4);
 /// Represents the spa secure level by configuring the clock random divide mode
-pub(crate) const SEC_DPA_LEVEL: EfuseField = EfuseField::new(0, 3, 112, 2);
+pub const SEC_DPA_LEVEL: EfuseField = EfuseField::new(0, 3, 112, 2);
 /// Reserved
-pub(crate) const RESERVE_0_114: EfuseField = EfuseField::new(0, 3, 114, 1);
+pub const RESERVE_0_114: EfuseField = EfuseField::new(0, 3, 114, 1);
 /// Represents whether anti-dpa attack is enabled. 1:enabled. 0: disabled
-pub(crate) const CRYPT_DPA_ENABLE: EfuseField = EfuseField::new(0, 3, 115, 1);
+pub const CRYPT_DPA_ENABLE: EfuseField = EfuseField::new(0, 3, 115, 1);
 /// Represents whether secure boot is enabled or disabled. 1: enabled. 0:
 /// disabled
-pub(crate) const SECURE_BOOT_EN: EfuseField = EfuseField::new(0, 3, 116, 1);
+pub const SECURE_BOOT_EN: EfuseField = EfuseField::new(0, 3, 116, 1);
 /// Represents whether revoking aggressive secure boot is enabled or disabled.
 /// 1: enabled. 0: disabled
-pub(crate) const SECURE_BOOT_AGGRESSIVE_REVOKE: EfuseField = EfuseField::new(0, 3, 117, 1);
+pub const SECURE_BOOT_AGGRESSIVE_REVOKE: EfuseField = EfuseField::new(0, 3, 117, 1);
 /// Set these bits to enable power glitch function when chip power on
-pub(crate) const POWERGLITCH_EN1: EfuseField = EfuseField::new(0, 3, 118, 5);
+pub const POWERGLITCH_EN1: EfuseField = EfuseField::new(0, 3, 118, 5);
 /// reserved
-pub(crate) const RESERVED_0_123: EfuseField = EfuseField::new(0, 3, 123, 1);
+pub const RESERVED_0_123: EfuseField = EfuseField::new(0, 3, 123, 1);
 /// Represents the flash waiting time after power-up; in unit of ms. When the
 /// value less than 15; the waiting time is the programmed value. Otherwise; the
 /// waiting time is 2 times the programmed value
-pub(crate) const FLASH_TPUW: EfuseField = EfuseField::new(0, 3, 124, 4);
+pub const FLASH_TPUW: EfuseField = EfuseField::new(0, 3, 124, 4);
 /// Represents whether Download mode is disabled or enabled. 1: disabled. 0:
 /// enabled
-pub(crate) const DIS_DOWNLOAD_MODE: EfuseField = EfuseField::new(0, 4, 128, 1);
+pub const DIS_DOWNLOAD_MODE: EfuseField = EfuseField::new(0, 4, 128, 1);
 /// Represents whether direct boot mode is disabled or enabled. 1: disabled. 0:
 /// enabled
-pub(crate) const DIS_DIRECT_BOOT: EfuseField = EfuseField::new(0, 4, 129, 1);
+pub const DIS_DIRECT_BOOT: EfuseField = EfuseField::new(0, 4, 129, 1);
 /// Set this bit to disable USB-Serial-JTAG print during rom boot
-pub(crate) const DIS_USB_SERIAL_JTAG_ROM_PRINT: EfuseField = EfuseField::new(0, 4, 130, 1);
+pub const DIS_USB_SERIAL_JTAG_ROM_PRINT: EfuseField = EfuseField::new(0, 4, 130, 1);
 /// Reserved
-pub(crate) const RPT4_RESERVED3_5: EfuseField = EfuseField::new(0, 4, 131, 1);
+pub const RPT4_RESERVED3_5: EfuseField = EfuseField::new(0, 4, 131, 1);
 /// Represents whether the USB-Serial-JTAG download function is disabled or
 /// enabled. 1: disabled. 0: enabled
-pub(crate) const DIS_USB_SERIAL_JTAG_DOWNLOAD_MODE: EfuseField = EfuseField::new(0, 4, 132, 1);
+pub const DIS_USB_SERIAL_JTAG_DOWNLOAD_MODE: EfuseField = EfuseField::new(0, 4, 132, 1);
 /// Represents whether security download is enabled or disabled. 1: enabled. 0:
 /// disabled
-pub(crate) const ENABLE_SECURITY_DOWNLOAD: EfuseField = EfuseField::new(0, 4, 133, 1);
+pub const ENABLE_SECURITY_DOWNLOAD: EfuseField = EfuseField::new(0, 4, 133, 1);
 /// Set the default UARTboot message output mode
-pub(crate) const UART_PRINT_CONTROL: EfuseField = EfuseField::new(0, 4, 134, 2);
+pub const UART_PRINT_CONTROL: EfuseField = EfuseField::new(0, 4, 134, 2);
 /// Represents whether ROM code is forced to send a resume command during SPI
 /// boot. 1: forced. 0:not forced
-pub(crate) const FORCE_SEND_RESUME: EfuseField = EfuseField::new(0, 4, 136, 1);
+pub const FORCE_SEND_RESUME: EfuseField = EfuseField::new(0, 4, 136, 1);
 /// Represents the version used by ESP-IDF anti-rollback feature
-pub(crate) const SECURE_VERSION: EfuseField = EfuseField::new(0, 4, 137, 16);
+pub const SECURE_VERSION: EfuseField = EfuseField::new(0, 4, 137, 16);
 /// Represents whether FAST VERIFY ON WAKE is disabled or enabled when Secure
 /// Boot is enabled. 1: disabled. 0: enabled
-pub(crate) const SECURE_BOOT_DISABLE_FAST_WAKE: EfuseField = EfuseField::new(0, 4, 153, 1);
+pub const SECURE_BOOT_DISABLE_FAST_WAKE: EfuseField = EfuseField::new(0, 4, 153, 1);
 /// Set bits to enable hysteresis function of PAD0~5
-pub(crate) const HYS_EN_PAD0: EfuseField = EfuseField::new(0, 4, 154, 6);
+pub const HYS_EN_PAD0: EfuseField = EfuseField::new(0, 4, 154, 6);
 /// Set bits to enable hysteresis function of PAD6~27
-pub(crate) const HYS_EN_PAD1: EfuseField = EfuseField::new(0, 5, 160, 22);
+pub const HYS_EN_PAD1: EfuseField = EfuseField::new(0, 5, 160, 22);
 /// Reserved
-pub(crate) const RPT4_RESERVED4_1: EfuseField = EfuseField::new(0, 5, 182, 2);
+pub const RPT4_RESERVED4_1: EfuseField = EfuseField::new(0, 5, 182, 2);
 /// Reserved
-pub(crate) const RPT4_RESERVED4_0: EfuseField = EfuseField::new(0, 5, 184, 8);
+pub const RPT4_RESERVED4_0: EfuseField = EfuseField::new(0, 5, 184, 8);
 /// MAC address
-pub(crate) const MAC0: EfuseField = EfuseField::new(1, 0, 0, 32);
+pub const MAC0: EfuseField = EfuseField::new(1, 0, 0, 32);
 /// MAC address
-pub(crate) const MAC1: EfuseField = EfuseField::new(1, 1, 32, 16);
+pub const MAC1: EfuseField = EfuseField::new(1, 1, 32, 16);
 /// Stores the extended bits of MAC address
-pub(crate) const MAC_EXT: EfuseField = EfuseField::new(1, 1, 48, 16);
+pub const MAC_EXT: EfuseField = EfuseField::new(1, 1, 48, 16);
 /// Stores RF Calibration data. RXIQ version
-pub(crate) const RXIQ_VERSION: EfuseField = EfuseField::new(1, 2, 64, 3);
+pub const RXIQ_VERSION: EfuseField = EfuseField::new(1, 2, 64, 3);
 /// Stores RF Calibration data. RXIQ data 0
-pub(crate) const RXIQ_0: EfuseField = EfuseField::new(1, 2, 67, 7);
+pub const RXIQ_0: EfuseField = EfuseField::new(1, 2, 67, 7);
 /// Stores RF Calibration data. RXIQ data 1
-pub(crate) const RXIQ_1: EfuseField = EfuseField::new(1, 2, 74, 7);
+pub const RXIQ_1: EfuseField = EfuseField::new(1, 2, 74, 7);
 /// Stores the PMU active hp dbias
-pub(crate) const ACTIVE_HP_DBIAS: EfuseField = EfuseField::new(1, 2, 81, 5);
+pub const ACTIVE_HP_DBIAS: EfuseField = EfuseField::new(1, 2, 81, 5);
 /// Stores the PMU active lp dbias
-pub(crate) const ACTIVE_LP_DBIAS: EfuseField = EfuseField::new(1, 2, 86, 5);
+pub const ACTIVE_LP_DBIAS: EfuseField = EfuseField::new(1, 2, 86, 5);
 /// Stores the PMU sleep dbias
-pub(crate) const DSLP_DBIAS: EfuseField = EfuseField::new(1, 2, 91, 4);
+pub const DSLP_DBIAS: EfuseField = EfuseField::new(1, 2, 91, 4);
 /// Stores the low 1 bit of dbias_vol_gap
-pub(crate) const DBIAS_VOL_GAP: EfuseField = EfuseField::new(1, 2, 95, 5);
+pub const DBIAS_VOL_GAP: EfuseField = EfuseField::new(1, 2, 95, 5);
 /// Reserved
-pub(crate) const MAC_RESERVED_2: EfuseField = EfuseField::new(1, 3, 100, 14);
+pub const MAC_RESERVED_2: EfuseField = EfuseField::new(1, 3, 100, 14);
 /// Stores the wafer version minor
-pub(crate) const WAFER_VERSION_MINOR: EfuseField = EfuseField::new(1, 3, 114, 3);
+pub const WAFER_VERSION_MINOR: EfuseField = EfuseField::new(1, 3, 114, 3);
 /// Stores the wafer version major
-pub(crate) const WAFER_VERSION_MAJOR: EfuseField = EfuseField::new(1, 3, 117, 2);
+pub const WAFER_VERSION_MAJOR: EfuseField = EfuseField::new(1, 3, 117, 2);
 /// Disables check of wafer version major
-pub(crate) const DISABLE_WAFER_VERSION_MAJOR: EfuseField = EfuseField::new(1, 3, 119, 1);
+pub const DISABLE_WAFER_VERSION_MAJOR: EfuseField = EfuseField::new(1, 3, 119, 1);
 /// Stores the flash cap
-pub(crate) const FLASH_CAP: EfuseField = EfuseField::new(1, 3, 120, 3);
+pub const FLASH_CAP: EfuseField = EfuseField::new(1, 3, 120, 3);
 /// Stores the flash temp
-pub(crate) const FLASH_TEMP: EfuseField = EfuseField::new(1, 3, 123, 2);
+pub const FLASH_TEMP: EfuseField = EfuseField::new(1, 3, 123, 2);
 /// Stores the flash vendor
-pub(crate) const FLASH_VENDOR: EfuseField = EfuseField::new(1, 3, 125, 3);
+pub const FLASH_VENDOR: EfuseField = EfuseField::new(1, 3, 125, 3);
 /// Package version
-pub(crate) const PKG_VERSION: EfuseField = EfuseField::new(1, 4, 128, 3);
+pub const PKG_VERSION: EfuseField = EfuseField::new(1, 4, 128, 3);
 /// reserved
-pub(crate) const RESERVED_1_131: EfuseField = EfuseField::new(1, 4, 131, 29);
+pub const RESERVED_1_131: EfuseField = EfuseField::new(1, 4, 131, 29);
 /// Stores the second 32 bits of the zeroth part of system data
-pub(crate) const SYS_DATA_PART0_2: EfuseField = EfuseField::new(1, 5, 160, 32);
+pub const SYS_DATA_PART0_2: EfuseField = EfuseField::new(1, 5, 160, 32);
 /// Optional unique 128-bit ID
-pub(crate) const OPTIONAL_UNIQUE_ID: EfuseField = EfuseField::new(2, 0, 0, 128);
+pub const OPTIONAL_UNIQUE_ID: EfuseField = EfuseField::new(2, 0, 0, 128);
 /// reserved
-pub(crate) const RESERVED_2_128: EfuseField = EfuseField::new(2, 4, 128, 2);
+pub const RESERVED_2_128: EfuseField = EfuseField::new(2, 4, 128, 2);
 /// BLK_VERSION_MINOR of BLOCK2. 1: RF Calibration data in BLOCK1
-pub(crate) const BLK_VERSION_MINOR: EfuseField = EfuseField::new(2, 4, 130, 3);
+pub const BLK_VERSION_MINOR: EfuseField = EfuseField::new(2, 4, 130, 3);
 /// BLK_VERSION_MAJOR of BLOCK2
-pub(crate) const BLK_VERSION_MAJOR: EfuseField = EfuseField::new(2, 4, 133, 2);
+pub const BLK_VERSION_MAJOR: EfuseField = EfuseField::new(2, 4, 133, 2);
 /// Disables check of blk version major
-pub(crate) const DISABLE_BLK_VERSION_MAJOR: EfuseField = EfuseField::new(2, 4, 135, 1);
+pub const DISABLE_BLK_VERSION_MAJOR: EfuseField = EfuseField::new(2, 4, 135, 1);
 /// Temperature calibration data
-pub(crate) const TEMP_CALIB: EfuseField = EfuseField::new(2, 4, 136, 9);
+pub const TEMP_CALIB: EfuseField = EfuseField::new(2, 4, 136, 9);
 /// ADC1 calibration data
-pub(crate) const ADC1_AVE_INITCODE_ATTEN0: EfuseField = EfuseField::new(2, 4, 145, 10);
+pub const ADC1_AVE_INITCODE_ATTEN0: EfuseField = EfuseField::new(2, 4, 145, 10);
 /// ADC1 calibration data
-pub(crate) const ADC1_AVE_INITCODE_ATTEN1: EfuseField = EfuseField::new(2, 4, 155, 10);
+pub const ADC1_AVE_INITCODE_ATTEN1: EfuseField = EfuseField::new(2, 4, 155, 10);
 /// ADC1 calibration data
-pub(crate) const ADC1_AVE_INITCODE_ATTEN2: EfuseField = EfuseField::new(2, 5, 165, 10);
+pub const ADC1_AVE_INITCODE_ATTEN2: EfuseField = EfuseField::new(2, 5, 165, 10);
 /// ADC1 calibration data
-pub(crate) const ADC1_AVE_INITCODE_ATTEN3: EfuseField = EfuseField::new(2, 5, 175, 10);
+pub const ADC1_AVE_INITCODE_ATTEN3: EfuseField = EfuseField::new(2, 5, 175, 10);
 /// ADC1 calibration data
-pub(crate) const ADC1_HI_DOUT_ATTEN0: EfuseField = EfuseField::new(2, 5, 185, 10);
+pub const ADC1_HI_DOUT_ATTEN0: EfuseField = EfuseField::new(2, 5, 185, 10);
 /// ADC1 calibration data
-pub(crate) const ADC1_HI_DOUT_ATTEN1: EfuseField = EfuseField::new(2, 6, 195, 10);
+pub const ADC1_HI_DOUT_ATTEN1: EfuseField = EfuseField::new(2, 6, 195, 10);
 /// ADC1 calibration data
-pub(crate) const ADC1_HI_DOUT_ATTEN2: EfuseField = EfuseField::new(2, 6, 205, 10);
+pub const ADC1_HI_DOUT_ATTEN2: EfuseField = EfuseField::new(2, 6, 205, 10);
 /// ADC1 calibration data
-pub(crate) const ADC1_HI_DOUT_ATTEN3: EfuseField = EfuseField::new(2, 6, 215, 10);
+pub const ADC1_HI_DOUT_ATTEN3: EfuseField = EfuseField::new(2, 6, 215, 10);
 /// ADC1 calibration data
-pub(crate) const ADC1_CH0_ATTEN0_INITCODE_DIFF: EfuseField = EfuseField::new(2, 7, 225, 4);
+pub const ADC1_CH0_ATTEN0_INITCODE_DIFF: EfuseField = EfuseField::new(2, 7, 225, 4);
 /// ADC1 calibration data
-pub(crate) const ADC1_CH1_ATTEN0_INITCODE_DIFF: EfuseField = EfuseField::new(2, 7, 229, 4);
+pub const ADC1_CH1_ATTEN0_INITCODE_DIFF: EfuseField = EfuseField::new(2, 7, 229, 4);
 /// ADC1 calibration data
-pub(crate) const ADC1_CH2_ATTEN0_INITCODE_DIFF: EfuseField = EfuseField::new(2, 7, 233, 4);
+pub const ADC1_CH2_ATTEN0_INITCODE_DIFF: EfuseField = EfuseField::new(2, 7, 233, 4);
 /// ADC1 calibration data
-pub(crate) const ADC1_CH3_ATTEN0_INITCODE_DIFF: EfuseField = EfuseField::new(2, 7, 237, 4);
+pub const ADC1_CH3_ATTEN0_INITCODE_DIFF: EfuseField = EfuseField::new(2, 7, 237, 4);
 /// ADC1 calibration data
-pub(crate) const ADC1_CH4_ATTEN0_INITCODE_DIFF: EfuseField = EfuseField::new(2, 7, 241, 4);
+pub const ADC1_CH4_ATTEN0_INITCODE_DIFF: EfuseField = EfuseField::new(2, 7, 241, 4);
 /// reserved
-pub(crate) const RESERVED_2_245: EfuseField = EfuseField::new(2, 7, 245, 11);
+pub const RESERVED_2_245: EfuseField = EfuseField::new(2, 7, 245, 11);
 /// User data
-pub(crate) const BLOCK_USR_DATA: EfuseField = EfuseField::new(3, 0, 0, 192);
+pub const BLOCK_USR_DATA: EfuseField = EfuseField::new(3, 0, 0, 192);
 /// reserved
-pub(crate) const RESERVED_3_192: EfuseField = EfuseField::new(3, 6, 192, 8);
+pub const RESERVED_3_192: EfuseField = EfuseField::new(3, 6, 192, 8);
 /// Custom MAC
-pub(crate) const CUSTOM_MAC: EfuseField = EfuseField::new(3, 6, 200, 48);
+pub const CUSTOM_MAC: EfuseField = EfuseField::new(3, 6, 200, 48);
 /// reserved
-pub(crate) const RESERVED_3_248: EfuseField = EfuseField::new(3, 7, 248, 8);
+pub const RESERVED_3_248: EfuseField = EfuseField::new(3, 7, 248, 8);
 /// Key0 or user data
-pub(crate) const BLOCK_KEY0: EfuseField = EfuseField::new(4, 0, 0, 256);
+pub const BLOCK_KEY0: EfuseField = EfuseField::new(4, 0, 0, 256);
 /// Key1 or user data
-pub(crate) const BLOCK_KEY1: EfuseField = EfuseField::new(5, 0, 0, 256);
+pub const BLOCK_KEY1: EfuseField = EfuseField::new(5, 0, 0, 256);
 /// Key2 or user data
-pub(crate) const BLOCK_KEY2: EfuseField = EfuseField::new(6, 0, 0, 256);
+pub const BLOCK_KEY2: EfuseField = EfuseField::new(6, 0, 0, 256);
 /// Key3 or user data
-pub(crate) const BLOCK_KEY3: EfuseField = EfuseField::new(7, 0, 0, 256);
+pub const BLOCK_KEY3: EfuseField = EfuseField::new(7, 0, 0, 256);
 /// Key4 or user data
-pub(crate) const BLOCK_KEY4: EfuseField = EfuseField::new(8, 0, 0, 256);
+pub const BLOCK_KEY4: EfuseField = EfuseField::new(8, 0, 0, 256);
 /// Key5 or user data
-pub(crate) const BLOCK_KEY5: EfuseField = EfuseField::new(9, 0, 0, 256);
+pub const BLOCK_KEY5: EfuseField = EfuseField::new(9, 0, 0, 256);
 /// System data part 2 (reserved)
-pub(crate) const BLOCK_SYS_DATA2: EfuseField = EfuseField::new(10, 0, 0, 256);
+pub const BLOCK_SYS_DATA2: EfuseField = EfuseField::new(10, 0, 0, 256);

--- a/espflash/src/target/efuse/esp32p4.rs
+++ b/espflash/src/target/efuse/esp32p4.rs
@@ -1,6 +1,8 @@
+//! eFuse field definitions for the esp32p4
+//!
 //! This file was automatically generated, please do not edit it manually!
 //!
-//! Generated: 2025-06-25 09:59
+//! Generated: 2025-06-25 11:06
 //! Version:   f7765f0ac3faf4b54f8c1f064307522c
 
 #![allow(unused)]

--- a/espflash/src/target/efuse/esp32p4.rs
+++ b/espflash/src/target/efuse/esp32p4.rs
@@ -1,7 +1,7 @@
 //! This file was automatically generated, please do not edit it manually!
 //!
-//! Generated: 2025-05-30 12:24
-//! Version:   73787d3f5ae45b80abca925a7562120b
+//! Generated: 2025-06-25 09:59
+//! Version:   f7765f0ac3faf4b54f8c1f064307522c
 
 #![allow(unused)]
 
@@ -11,341 +11,341 @@ use super::EfuseField;
 pub(crate) const BLOCK_SIZES: &[u32] = &[24, 24, 32, 32, 32, 32, 32, 32, 32, 32, 32];
 
 /// Disable programming of individual eFuses
-pub(crate) const WR_DIS: EfuseField = EfuseField::new(0, 0, 0, 32);
+pub const WR_DIS: EfuseField = EfuseField::new(0, 0, 0, 32);
 /// Disable reading from BlOCK4-10
-pub(crate) const RD_DIS: EfuseField = EfuseField::new(0, 1, 32, 7);
+pub const RD_DIS: EfuseField = EfuseField::new(0, 1, 32, 7);
 /// Enable usb device exchange pins of D+ and D-
-pub(crate) const USB_DEVICE_EXCHG_PINS: EfuseField = EfuseField::new(0, 1, 39, 1);
+pub const USB_DEVICE_EXCHG_PINS: EfuseField = EfuseField::new(0, 1, 39, 1);
 /// Enable usb otg11 exchange pins of D+ and D-
-pub(crate) const USB_OTG11_EXCHG_PINS: EfuseField = EfuseField::new(0, 1, 40, 1);
+pub const USB_OTG11_EXCHG_PINS: EfuseField = EfuseField::new(0, 1, 40, 1);
 /// Represents whether the function of usb switch to jtag is disabled or
 /// enabled. 1: disabled. 0: enabled
-pub(crate) const DIS_USB_JTAG: EfuseField = EfuseField::new(0, 1, 41, 1);
+pub const DIS_USB_JTAG: EfuseField = EfuseField::new(0, 1, 41, 1);
 /// Represents whether power glitch function is enabled. 1: enabled. 0: disabled
-pub(crate) const POWERGLITCH_EN: EfuseField = EfuseField::new(0, 1, 42, 1);
+pub const POWERGLITCH_EN: EfuseField = EfuseField::new(0, 1, 42, 1);
 /// Represents whether USB-Serial-JTAG is disabled or enabled. 1: disabled. 0:
 /// enabled
-pub(crate) const DIS_USB_SERIAL_JTAG: EfuseField = EfuseField::new(0, 1, 43, 1);
+pub const DIS_USB_SERIAL_JTAG: EfuseField = EfuseField::new(0, 1, 43, 1);
 /// Represents whether the function that forces chip into download mode is
 /// disabled or enabled. 1: disabled. 0: enabled
-pub(crate) const DIS_FORCE_DOWNLOAD: EfuseField = EfuseField::new(0, 1, 44, 1);
+pub const DIS_FORCE_DOWNLOAD: EfuseField = EfuseField::new(0, 1, 44, 1);
 /// Set this bit to disable accessing MSPI flash/MSPI ram by SYS AXI matrix
 /// during boot_mode_download
-pub(crate) const SPI_DOWNLOAD_MSPI_DIS: EfuseField = EfuseField::new(0, 1, 45, 1);
+pub const SPI_DOWNLOAD_MSPI_DIS: EfuseField = EfuseField::new(0, 1, 45, 1);
 /// Represents whether TWAI function is disabled or enabled. 1: disabled. 0:
 /// enabled
-pub(crate) const DIS_TWAI: EfuseField = EfuseField::new(0, 1, 46, 1);
+pub const DIS_TWAI: EfuseField = EfuseField::new(0, 1, 46, 1);
 /// Represents whether the selection between usb_to_jtag and pad_to_jtag through
 /// strapping gpio34 when both EFUSE_DIS_PAD_JTAG and EFUSE_DIS_USB_JTAG are
 /// equal to 0 is enabled or disabled. 1: enabled. 0: disabled
-pub(crate) const JTAG_SEL_ENABLE: EfuseField = EfuseField::new(0, 1, 47, 1);
+pub const JTAG_SEL_ENABLE: EfuseField = EfuseField::new(0, 1, 47, 1);
 /// Represents whether JTAG is disabled in soft way. Odd number: disabled. Even
 /// number: enabled
-pub(crate) const SOFT_DIS_JTAG: EfuseField = EfuseField::new(0, 1, 48, 3);
+pub const SOFT_DIS_JTAG: EfuseField = EfuseField::new(0, 1, 48, 3);
 /// Represents whether JTAG is disabled in the hard way(permanently). 1:
 /// disabled. 0: enabled
-pub(crate) const DIS_PAD_JTAG: EfuseField = EfuseField::new(0, 1, 51, 1);
+pub const DIS_PAD_JTAG: EfuseField = EfuseField::new(0, 1, 51, 1);
 /// Represents whether flash encrypt function is disabled or enabled(except in
 /// SPI boot mode). 1: disabled. 0: enabled
-pub(crate) const DIS_DOWNLOAD_MANUAL_ENCRYPT: EfuseField = EfuseField::new(0, 1, 52, 1);
+pub const DIS_DOWNLOAD_MANUAL_ENCRYPT: EfuseField = EfuseField::new(0, 1, 52, 1);
 /// USB intphy of usb device signle-end input high threshold; 1.76V to 2V. Step
 /// by 80mV
-pub(crate) const USB_DEVICE_DREFH: EfuseField = EfuseField::new(0, 1, 53, 2);
+pub const USB_DEVICE_DREFH: EfuseField = EfuseField::new(0, 1, 53, 2);
 /// USB intphy of usb otg11 signle-end input high threshold; 1.76V to 2V. Step
 /// by 80mV
-pub(crate) const USB_OTG11_DREFH: EfuseField = EfuseField::new(0, 1, 55, 2);
+pub const USB_OTG11_DREFH: EfuseField = EfuseField::new(0, 1, 55, 2);
 /// TBD
-pub(crate) const USB_PHY_SEL: EfuseField = EfuseField::new(0, 1, 57, 1);
+pub const USB_PHY_SEL: EfuseField = EfuseField::new(0, 1, 57, 1);
 /// Set this bit to control validation of HUK generate mode. Odd of 1 is
 /// invalid; even of 1 is valid
-pub(crate) const KM_HUK_GEN_STATE: EfuseField = EfuseField::new(0, 1, 58, 9);
+pub const KM_HUK_GEN_STATE: EfuseField = EfuseField::new(0, 1, 58, 9);
 /// Set bits to control key manager random number switch cycle. 0: control by
 /// register. 1: 8 km clk cycles. 2: 16 km cycles. 3: 32 km cycles
-pub(crate) const KM_RND_SWITCH_CYCLE: EfuseField = EfuseField::new(0, 2, 67, 2);
+pub const KM_RND_SWITCH_CYCLE: EfuseField = EfuseField::new(0, 2, 67, 2);
 /// Set each bit to control whether corresponding key can only be deployed once.
 /// 1 is true; 0 is false. Bit0: ecdsa. Bit1: xts. Bit2: hmac. Bit3: ds
-pub(crate) const KM_DEPLOY_ONLY_ONCE: EfuseField = EfuseField::new(0, 2, 69, 4);
+pub const KM_DEPLOY_ONLY_ONCE: EfuseField = EfuseField::new(0, 2, 69, 4);
 /// Set each bit to control whether corresponding key must come from key
 /// manager.. 1 is true; 0 is false. Bit0: ecdsa. Bit1: xts. Bit2: hmac. Bit3:
 /// ds
-pub(crate) const FORCE_USE_KEY_MANAGER_KEY: EfuseField = EfuseField::new(0, 2, 73, 4);
+pub const FORCE_USE_KEY_MANAGER_KEY: EfuseField = EfuseField::new(0, 2, 73, 4);
 /// Set this bit to disable software written init key; and force use
 /// efuse_init_key
-pub(crate) const FORCE_DISABLE_SW_INIT_KEY: EfuseField = EfuseField::new(0, 2, 77, 1);
+pub const FORCE_DISABLE_SW_INIT_KEY: EfuseField = EfuseField::new(0, 2, 77, 1);
 /// Set this bit to configure flash encryption use xts-128 key; else use xts-256
 /// key
-pub(crate) const XTS_KEY_LENGTH_256: EfuseField = EfuseField::new(0, 2, 78, 1);
+pub const XTS_KEY_LENGTH_256: EfuseField = EfuseField::new(0, 2, 78, 1);
 /// Reserved; it was created by set_missed_fields_in_regs func
-pub(crate) const RESERVE_0_79: EfuseField = EfuseField::new(0, 2, 79, 1);
+pub const RESERVE_0_79: EfuseField = EfuseField::new(0, 2, 79, 1);
 /// Represents whether RTC watchdog timeout threshold is selected at startup. 1:
 /// selected. 0: not selected
-pub(crate) const WDT_DELAY_SEL: EfuseField = EfuseField::new(0, 2, 80, 2);
+pub const WDT_DELAY_SEL: EfuseField = EfuseField::new(0, 2, 80, 2);
 /// Enables flash encryption when 1 or 3 bits are set and disables otherwise
-pub(crate) const SPI_BOOT_CRYPT_CNT: EfuseField = EfuseField::new(0, 2, 82, 3);
+pub const SPI_BOOT_CRYPT_CNT: EfuseField = EfuseField::new(0, 2, 82, 3);
 /// Revoke 1st secure boot key
-pub(crate) const SECURE_BOOT_KEY_REVOKE0: EfuseField = EfuseField::new(0, 2, 85, 1);
+pub const SECURE_BOOT_KEY_REVOKE0: EfuseField = EfuseField::new(0, 2, 85, 1);
 /// Revoke 2nd secure boot key
-pub(crate) const SECURE_BOOT_KEY_REVOKE1: EfuseField = EfuseField::new(0, 2, 86, 1);
+pub const SECURE_BOOT_KEY_REVOKE1: EfuseField = EfuseField::new(0, 2, 86, 1);
 /// Revoke 3rd secure boot key
-pub(crate) const SECURE_BOOT_KEY_REVOKE2: EfuseField = EfuseField::new(0, 2, 87, 1);
+pub const SECURE_BOOT_KEY_REVOKE2: EfuseField = EfuseField::new(0, 2, 87, 1);
 /// Represents the purpose of Key0
-pub(crate) const KEY_PURPOSE_0: EfuseField = EfuseField::new(0, 2, 88, 4);
+pub const KEY_PURPOSE_0: EfuseField = EfuseField::new(0, 2, 88, 4);
 /// Represents the purpose of Key1
-pub(crate) const KEY_PURPOSE_1: EfuseField = EfuseField::new(0, 2, 92, 4);
+pub const KEY_PURPOSE_1: EfuseField = EfuseField::new(0, 2, 92, 4);
 /// Represents the purpose of Key2
-pub(crate) const KEY_PURPOSE_2: EfuseField = EfuseField::new(0, 3, 96, 4);
+pub const KEY_PURPOSE_2: EfuseField = EfuseField::new(0, 3, 96, 4);
 /// Represents the purpose of Key3
-pub(crate) const KEY_PURPOSE_3: EfuseField = EfuseField::new(0, 3, 100, 4);
+pub const KEY_PURPOSE_3: EfuseField = EfuseField::new(0, 3, 100, 4);
 /// Represents the purpose of Key4
-pub(crate) const KEY_PURPOSE_4: EfuseField = EfuseField::new(0, 3, 104, 4);
+pub const KEY_PURPOSE_4: EfuseField = EfuseField::new(0, 3, 104, 4);
 /// Represents the purpose of Key5
-pub(crate) const KEY_PURPOSE_5: EfuseField = EfuseField::new(0, 3, 108, 4);
+pub const KEY_PURPOSE_5: EfuseField = EfuseField::new(0, 3, 108, 4);
 /// Represents the spa secure level by configuring the clock random divide mode
-pub(crate) const SEC_DPA_LEVEL: EfuseField = EfuseField::new(0, 3, 112, 2);
+pub const SEC_DPA_LEVEL: EfuseField = EfuseField::new(0, 3, 112, 2);
 /// Represents whether hardware random number k is forced used in ESDCA. 1:
 /// force used. 0: not force used
-pub(crate) const ECDSA_ENABLE_SOFT_K: EfuseField = EfuseField::new(0, 3, 114, 1);
+pub const ECDSA_ENABLE_SOFT_K: EfuseField = EfuseField::new(0, 3, 114, 1);
 /// Represents whether anti-dpa attack is enabled. 1:enabled. 0: disabled
-pub(crate) const CRYPT_DPA_ENABLE: EfuseField = EfuseField::new(0, 3, 115, 1);
+pub const CRYPT_DPA_ENABLE: EfuseField = EfuseField::new(0, 3, 115, 1);
 /// Represents whether secure boot is enabled or disabled. 1: enabled. 0:
 /// disabled
-pub(crate) const SECURE_BOOT_EN: EfuseField = EfuseField::new(0, 3, 116, 1);
+pub const SECURE_BOOT_EN: EfuseField = EfuseField::new(0, 3, 116, 1);
 /// Represents whether revoking aggressive secure boot is enabled or disabled.
 /// 1: enabled. 0: disabled
-pub(crate) const SECURE_BOOT_AGGRESSIVE_REVOKE: EfuseField = EfuseField::new(0, 3, 117, 1);
+pub const SECURE_BOOT_AGGRESSIVE_REVOKE: EfuseField = EfuseField::new(0, 3, 117, 1);
 /// Reserved; it was created by set_missed_fields_in_regs func
-pub(crate) const RESERVE_0_118: EfuseField = EfuseField::new(0, 3, 118, 1);
+pub const RESERVE_0_118: EfuseField = EfuseField::new(0, 3, 118, 1);
 /// The type of interfaced flash. 0: four data lines; 1: eight data lines
-pub(crate) const FLASH_TYPE: EfuseField = EfuseField::new(0, 3, 119, 1);
+pub const FLASH_TYPE: EfuseField = EfuseField::new(0, 3, 119, 1);
 /// Set flash page size
-pub(crate) const FLASH_PAGE_SIZE: EfuseField = EfuseField::new(0, 3, 120, 2);
+pub const FLASH_PAGE_SIZE: EfuseField = EfuseField::new(0, 3, 120, 2);
 /// Set this bit to enable ecc for flash boot
-pub(crate) const FLASH_ECC_EN: EfuseField = EfuseField::new(0, 3, 122, 1);
+pub const FLASH_ECC_EN: EfuseField = EfuseField::new(0, 3, 122, 1);
 /// Set this bit to disable download via USB-OTG
-pub(crate) const DIS_USB_OTG_DOWNLOAD_MODE: EfuseField = EfuseField::new(0, 3, 123, 1);
+pub const DIS_USB_OTG_DOWNLOAD_MODE: EfuseField = EfuseField::new(0, 3, 123, 1);
 /// Represents the flash waiting time after power-up; in unit of ms. When the
 /// value less than 15; the waiting time is the programmed value. Otherwise; the
 /// waiting time is 2 times the programmed value
-pub(crate) const FLASH_TPUW: EfuseField = EfuseField::new(0, 3, 124, 4);
+pub const FLASH_TPUW: EfuseField = EfuseField::new(0, 3, 124, 4);
 /// Represents whether Download mode is disabled or enabled. 1: disabled. 0:
 /// enabled
-pub(crate) const DIS_DOWNLOAD_MODE: EfuseField = EfuseField::new(0, 4, 128, 1);
+pub const DIS_DOWNLOAD_MODE: EfuseField = EfuseField::new(0, 4, 128, 1);
 /// Represents whether direct boot mode is disabled or enabled. 1: disabled. 0:
 /// enabled
-pub(crate) const DIS_DIRECT_BOOT: EfuseField = EfuseField::new(0, 4, 129, 1);
+pub const DIS_DIRECT_BOOT: EfuseField = EfuseField::new(0, 4, 129, 1);
 /// Represents whether print from USB-Serial-JTAG is disabled or enabled. 1:
 /// disabled. 0: enabled
-pub(crate) const DIS_USB_SERIAL_JTAG_ROM_PRINT: EfuseField = EfuseField::new(0, 4, 130, 1);
+pub const DIS_USB_SERIAL_JTAG_ROM_PRINT: EfuseField = EfuseField::new(0, 4, 130, 1);
 /// TBD
-pub(crate) const LOCK_KM_KEY: EfuseField = EfuseField::new(0, 4, 131, 1);
+pub const LOCK_KM_KEY: EfuseField = EfuseField::new(0, 4, 131, 1);
 /// Represents whether the USB-Serial-JTAG download function is disabled or
 /// enabled. 1: disabled. 0: enabled
-pub(crate) const DIS_USB_SERIAL_JTAG_DOWNLOAD_MODE: EfuseField = EfuseField::new(0, 4, 132, 1);
+pub const DIS_USB_SERIAL_JTAG_DOWNLOAD_MODE: EfuseField = EfuseField::new(0, 4, 132, 1);
 /// Represents whether security download is enabled or disabled. 1: enabled. 0:
 /// disabled
-pub(crate) const ENABLE_SECURITY_DOWNLOAD: EfuseField = EfuseField::new(0, 4, 133, 1);
+pub const ENABLE_SECURITY_DOWNLOAD: EfuseField = EfuseField::new(0, 4, 133, 1);
 /// Represents the type of UART printing. 00: force enable printing. 01: enable
 /// printing when GPIO8 is reset at low level. 10: enable printing when GPIO8 is
 /// reset at high level. 11: force disable printing
-pub(crate) const UART_PRINT_CONTROL: EfuseField = EfuseField::new(0, 4, 134, 2);
+pub const UART_PRINT_CONTROL: EfuseField = EfuseField::new(0, 4, 134, 2);
 /// Represents whether ROM code is forced to send a resume command during SPI
 /// boot. 1: forced. 0:not forced
-pub(crate) const FORCE_SEND_RESUME: EfuseField = EfuseField::new(0, 4, 136, 1);
+pub const FORCE_SEND_RESUME: EfuseField = EfuseField::new(0, 4, 136, 1);
 /// Represents the version used by ESP-IDF anti-rollback feature
-pub(crate) const SECURE_VERSION: EfuseField = EfuseField::new(0, 4, 137, 16);
+pub const SECURE_VERSION: EfuseField = EfuseField::new(0, 4, 137, 16);
 /// Represents whether FAST VERIFY ON WAKE is disabled or enabled when Secure
 /// Boot is enabled. 1: disabled. 0: enabled
-pub(crate) const SECURE_BOOT_DISABLE_FAST_WAKE: EfuseField = EfuseField::new(0, 4, 153, 1);
+pub const SECURE_BOOT_DISABLE_FAST_WAKE: EfuseField = EfuseField::new(0, 4, 153, 1);
 /// Represents whether the hysteresis function of corresponding PAD is enabled.
 /// 1: enabled. 0:disabled
-pub(crate) const HYS_EN_PAD: EfuseField = EfuseField::new(0, 4, 154, 1);
+pub const HYS_EN_PAD: EfuseField = EfuseField::new(0, 4, 154, 1);
 /// Set the dcdc voltage default
-pub(crate) const DCDC_VSET: EfuseField = EfuseField::new(0, 4, 155, 5);
+pub const DCDC_VSET: EfuseField = EfuseField::new(0, 4, 155, 5);
 /// TBD
-pub(crate) const PXA0_TIEH_SEL_0: EfuseField = EfuseField::new(0, 5, 160, 2);
+pub const PXA0_TIEH_SEL_0: EfuseField = EfuseField::new(0, 5, 160, 2);
 /// TBD
-pub(crate) const PXA0_TIEH_SEL_1: EfuseField = EfuseField::new(0, 5, 162, 2);
+pub const PXA0_TIEH_SEL_1: EfuseField = EfuseField::new(0, 5, 162, 2);
 /// TBD
-pub(crate) const PXA0_TIEH_SEL_2: EfuseField = EfuseField::new(0, 5, 164, 2);
+pub const PXA0_TIEH_SEL_2: EfuseField = EfuseField::new(0, 5, 164, 2);
 /// TBD
-pub(crate) const PXA0_TIEH_SEL_3: EfuseField = EfuseField::new(0, 5, 166, 2);
+pub const PXA0_TIEH_SEL_3: EfuseField = EfuseField::new(0, 5, 166, 2);
 /// TBD
-pub(crate) const KM_DISABLE_DEPLOY_MODE: EfuseField = EfuseField::new(0, 5, 168, 4);
+pub const KM_DISABLE_DEPLOY_MODE: EfuseField = EfuseField::new(0, 5, 168, 4);
 /// Represents the usb device single-end input low threshold; 0.8 V to 1.04 V
 /// with step of 80 mV
-pub(crate) const USB_DEVICE_DREFL: EfuseField = EfuseField::new(0, 5, 172, 2);
+pub const USB_DEVICE_DREFL: EfuseField = EfuseField::new(0, 5, 172, 2);
 /// Represents the usb otg11 single-end input low threshold; 0.8 V to 1.04 V
 /// with step of 80 mV
-pub(crate) const USB_OTG11_DREFL: EfuseField = EfuseField::new(0, 5, 174, 2);
+pub const USB_OTG11_DREFL: EfuseField = EfuseField::new(0, 5, 174, 2);
 /// Reserved; it was created by set_missed_fields_in_regs func
-pub(crate) const RESERVE_0_176: EfuseField = EfuseField::new(0, 5, 176, 2);
+pub const RESERVE_0_176: EfuseField = EfuseField::new(0, 5, 176, 2);
 /// HP system power source select. 0:LDO. 1: DCDC
-pub(crate) const HP_PWR_SRC_SEL: EfuseField = EfuseField::new(0, 5, 178, 1);
+pub const HP_PWR_SRC_SEL: EfuseField = EfuseField::new(0, 5, 178, 1);
 /// Select dcdc vset use efuse_dcdc_vset
-pub(crate) const DCDC_VSET_EN: EfuseField = EfuseField::new(0, 5, 179, 1);
+pub const DCDC_VSET_EN: EfuseField = EfuseField::new(0, 5, 179, 1);
 /// Set this bit to disable watch dog
-pub(crate) const DIS_WDT: EfuseField = EfuseField::new(0, 5, 180, 1);
+pub const DIS_WDT: EfuseField = EfuseField::new(0, 5, 180, 1);
 /// Set this bit to disable super-watchdog
-pub(crate) const DIS_SWD: EfuseField = EfuseField::new(0, 5, 181, 1);
+pub const DIS_SWD: EfuseField = EfuseField::new(0, 5, 181, 1);
 /// Reserved; it was created by set_missed_fields_in_regs func
-pub(crate) const RESERVE_0_182: EfuseField = EfuseField::new(0, 5, 182, 10);
+pub const RESERVE_0_182: EfuseField = EfuseField::new(0, 5, 182, 10);
 /// MAC address
-pub(crate) const MAC0: EfuseField = EfuseField::new(1, 0, 0, 32);
+pub const MAC0: EfuseField = EfuseField::new(1, 0, 0, 32);
 /// MAC address
-pub(crate) const MAC1: EfuseField = EfuseField::new(1, 1, 32, 16);
+pub const MAC1: EfuseField = EfuseField::new(1, 1, 32, 16);
 /// Stores the extended bits of MAC address
-pub(crate) const RESERVED_1_16: EfuseField = EfuseField::new(1, 1, 48, 16);
+pub const RESERVED_1_16: EfuseField = EfuseField::new(1, 1, 48, 16);
 /// Minor chip version
-pub(crate) const WAFER_VERSION_MINOR: EfuseField = EfuseField::new(1, 2, 64, 4);
-/// Major chip version
-pub(crate) const WAFER_VERSION_MAJOR: EfuseField = EfuseField::new(1, 2, 68, 2);
+pub const WAFER_VERSION_MINOR: EfuseField = EfuseField::new(1, 2, 64, 4);
+/// Major chip version (lower 2 bits)
+pub const WAFER_VERSION_MAJOR_LO: EfuseField = EfuseField::new(1, 2, 68, 2);
 /// Disables check of wafer version major
-pub(crate) const DISABLE_WAFER_VERSION_MAJOR: EfuseField = EfuseField::new(1, 2, 70, 1);
+pub const DISABLE_WAFER_VERSION_MAJOR: EfuseField = EfuseField::new(1, 2, 70, 1);
 /// Disables check of blk version major
-pub(crate) const DISABLE_BLK_VERSION_MAJOR: EfuseField = EfuseField::new(1, 2, 71, 1);
+pub const DISABLE_BLK_VERSION_MAJOR: EfuseField = EfuseField::new(1, 2, 71, 1);
 /// BLK_VERSION_MINOR of BLOCK2
-pub(crate) const BLK_VERSION_MINOR: EfuseField = EfuseField::new(1, 2, 72, 3);
+pub const BLK_VERSION_MINOR: EfuseField = EfuseField::new(1, 2, 72, 3);
 /// BLK_VERSION_MAJOR of BLOCK2
-pub(crate) const BLK_VERSION_MAJOR: EfuseField = EfuseField::new(1, 2, 75, 2);
+pub const BLK_VERSION_MAJOR: EfuseField = EfuseField::new(1, 2, 75, 2);
 /// PSRAM capacity
-pub(crate) const PSRAM_CAP: EfuseField = EfuseField::new(1, 2, 77, 3);
+pub const PSRAM_CAP: EfuseField = EfuseField::new(1, 2, 77, 3);
 /// Operating temperature of the ESP chip
-pub(crate) const TEMP: EfuseField = EfuseField::new(1, 2, 80, 2);
+pub const TEMP: EfuseField = EfuseField::new(1, 2, 80, 2);
 /// PSRAM vendor
-pub(crate) const PSRAM_VENDOR: EfuseField = EfuseField::new(1, 2, 82, 2);
+pub const PSRAM_VENDOR: EfuseField = EfuseField::new(1, 2, 82, 2);
 /// Package version
-pub(crate) const PKG_VERSION: EfuseField = EfuseField::new(1, 2, 84, 3);
-/// reserved
-pub(crate) const RESERVED_1_87: EfuseField = EfuseField::new(1, 2, 87, 1);
+pub const PKG_VERSION: EfuseField = EfuseField::new(1, 2, 84, 3);
+/// Major chip version (MSB)
+pub const WAFER_VERSION_MAJOR_HI: EfuseField = EfuseField::new(1, 2, 87, 1);
 /// Output VO1 parameter
-pub(crate) const LDO_VO1_DREF: EfuseField = EfuseField::new(1, 2, 88, 4);
+pub const LDO_VO1_DREF: EfuseField = EfuseField::new(1, 2, 88, 4);
 /// Output VO2 parameter
-pub(crate) const LDO_VO2_DREF: EfuseField = EfuseField::new(1, 2, 92, 4);
+pub const LDO_VO2_DREF: EfuseField = EfuseField::new(1, 2, 92, 4);
 /// Output VO1 parameter
-pub(crate) const LDO_VO1_MUL: EfuseField = EfuseField::new(1, 3, 96, 3);
+pub const LDO_VO1_MUL: EfuseField = EfuseField::new(1, 3, 96, 3);
 /// Output VO2 parameter
-pub(crate) const LDO_VO2_MUL: EfuseField = EfuseField::new(1, 3, 99, 3);
+pub const LDO_VO2_MUL: EfuseField = EfuseField::new(1, 3, 99, 3);
 /// Output VO3 calibration parameter
-pub(crate) const LDO_VO3_K: EfuseField = EfuseField::new(1, 3, 102, 8);
+pub const LDO_VO3_K: EfuseField = EfuseField::new(1, 3, 102, 8);
 /// Output VO3 calibration parameter
-pub(crate) const LDO_VO3_VOS: EfuseField = EfuseField::new(1, 3, 110, 6);
+pub const LDO_VO3_VOS: EfuseField = EfuseField::new(1, 3, 110, 6);
 /// Output VO3 calibration parameter
-pub(crate) const LDO_VO3_C: EfuseField = EfuseField::new(1, 3, 116, 6);
+pub const LDO_VO3_C: EfuseField = EfuseField::new(1, 3, 116, 6);
 /// Output VO4 calibration parameter
-pub(crate) const LDO_VO4_K: EfuseField = EfuseField::new(1, 3, 122, 8);
+pub const LDO_VO4_K: EfuseField = EfuseField::new(1, 3, 122, 8);
 /// Output VO4 calibration parameter
-pub(crate) const LDO_VO4_VOS: EfuseField = EfuseField::new(1, 4, 130, 6);
+pub const LDO_VO4_VOS: EfuseField = EfuseField::new(1, 4, 130, 6);
 /// Output VO4 calibration parameter
-pub(crate) const LDO_VO4_C: EfuseField = EfuseField::new(1, 4, 136, 6);
+pub const LDO_VO4_C: EfuseField = EfuseField::new(1, 4, 136, 6);
 /// reserved
-pub(crate) const RESERVED_1_142: EfuseField = EfuseField::new(1, 4, 142, 2);
+pub const RESERVED_1_142: EfuseField = EfuseField::new(1, 4, 142, 2);
 /// Active HP DBIAS of fixed voltage
-pub(crate) const ACTIVE_HP_DBIAS: EfuseField = EfuseField::new(1, 4, 144, 4);
+pub const ACTIVE_HP_DBIAS: EfuseField = EfuseField::new(1, 4, 144, 4);
 /// Active LP DBIAS of fixed voltage
-pub(crate) const ACTIVE_LP_DBIAS: EfuseField = EfuseField::new(1, 4, 148, 4);
+pub const ACTIVE_LP_DBIAS: EfuseField = EfuseField::new(1, 4, 148, 4);
 /// LSLP HP DBIAS of fixed voltage
-pub(crate) const LSLP_HP_DBIAS: EfuseField = EfuseField::new(1, 4, 152, 4);
+pub const LSLP_HP_DBIAS: EfuseField = EfuseField::new(1, 4, 152, 4);
 /// DSLP BDG of fixed voltage
-pub(crate) const DSLP_DBG: EfuseField = EfuseField::new(1, 4, 156, 4);
+pub const DSLP_DBG: EfuseField = EfuseField::new(1, 4, 156, 4);
 /// DSLP LP DBIAS of fixed voltage
-pub(crate) const DSLP_LP_DBIAS: EfuseField = EfuseField::new(1, 5, 160, 5);
+pub const DSLP_LP_DBIAS: EfuseField = EfuseField::new(1, 5, 160, 5);
 /// DBIAS gap between LP and DCDC
-pub(crate) const LP_DCDC_DBIAS_VOL_GAP: EfuseField = EfuseField::new(1, 5, 165, 5);
+pub const LP_DCDC_DBIAS_VOL_GAP: EfuseField = EfuseField::new(1, 5, 165, 5);
 /// reserved
-pub(crate) const RESERVED_1_170: EfuseField = EfuseField::new(1, 5, 170, 22);
+pub const RESERVED_1_170: EfuseField = EfuseField::new(1, 5, 170, 22);
 /// Optional unique 128-bit ID
-pub(crate) const OPTIONAL_UNIQUE_ID: EfuseField = EfuseField::new(2, 0, 0, 128);
+pub const OPTIONAL_UNIQUE_ID: EfuseField = EfuseField::new(2, 0, 0, 128);
 /// Average initcode of ADC1 atten0
-pub(crate) const ADC1_AVE_INITCODE_ATTEN0: EfuseField = EfuseField::new(2, 4, 128, 10);
+pub const ADC1_AVE_INITCODE_ATTEN0: EfuseField = EfuseField::new(2, 4, 128, 10);
 /// Average initcode of ADC1 atten1
-pub(crate) const ADC1_AVE_INITCODE_ATTEN1: EfuseField = EfuseField::new(2, 4, 138, 10);
+pub const ADC1_AVE_INITCODE_ATTEN1: EfuseField = EfuseField::new(2, 4, 138, 10);
 /// Average initcode of ADC1 atten2
-pub(crate) const ADC1_AVE_INITCODE_ATTEN2: EfuseField = EfuseField::new(2, 4, 148, 10);
+pub const ADC1_AVE_INITCODE_ATTEN2: EfuseField = EfuseField::new(2, 4, 148, 10);
 /// Average initcode of ADC1 atten3
-pub(crate) const ADC1_AVE_INITCODE_ATTEN3: EfuseField = EfuseField::new(2, 4, 158, 10);
+pub const ADC1_AVE_INITCODE_ATTEN3: EfuseField = EfuseField::new(2, 4, 158, 10);
 /// Average initcode of ADC2 atten0
-pub(crate) const ADC2_AVE_INITCODE_ATTEN0: EfuseField = EfuseField::new(2, 5, 168, 10);
+pub const ADC2_AVE_INITCODE_ATTEN0: EfuseField = EfuseField::new(2, 5, 168, 10);
 /// Average initcode of ADC2 atten1
-pub(crate) const ADC2_AVE_INITCODE_ATTEN1: EfuseField = EfuseField::new(2, 5, 178, 10);
+pub const ADC2_AVE_INITCODE_ATTEN1: EfuseField = EfuseField::new(2, 5, 178, 10);
 /// Average initcode of ADC2 atten2
-pub(crate) const ADC2_AVE_INITCODE_ATTEN2: EfuseField = EfuseField::new(2, 5, 188, 10);
+pub const ADC2_AVE_INITCODE_ATTEN2: EfuseField = EfuseField::new(2, 5, 188, 10);
 /// Average initcode of ADC2 atten3
-pub(crate) const ADC2_AVE_INITCODE_ATTEN3: EfuseField = EfuseField::new(2, 6, 198, 10);
+pub const ADC2_AVE_INITCODE_ATTEN3: EfuseField = EfuseField::new(2, 6, 198, 10);
 /// HI_DOUT of ADC1 atten0
-pub(crate) const ADC1_HI_DOUT_ATTEN0: EfuseField = EfuseField::new(2, 6, 208, 10);
+pub const ADC1_HI_DOUT_ATTEN0: EfuseField = EfuseField::new(2, 6, 208, 10);
 /// HI_DOUT of ADC1 atten1
-pub(crate) const ADC1_HI_DOUT_ATTEN1: EfuseField = EfuseField::new(2, 6, 218, 10);
+pub const ADC1_HI_DOUT_ATTEN1: EfuseField = EfuseField::new(2, 6, 218, 10);
 /// HI_DOUT of ADC1 atten2
-pub(crate) const ADC1_HI_DOUT_ATTEN2: EfuseField = EfuseField::new(2, 7, 228, 10);
+pub const ADC1_HI_DOUT_ATTEN2: EfuseField = EfuseField::new(2, 7, 228, 10);
 /// HI_DOUT of ADC1 atten3
-pub(crate) const ADC1_HI_DOUT_ATTEN3: EfuseField = EfuseField::new(2, 7, 238, 10);
+pub const ADC1_HI_DOUT_ATTEN3: EfuseField = EfuseField::new(2, 7, 238, 10);
 /// reserved
-pub(crate) const RESERVED_2_248: EfuseField = EfuseField::new(2, 7, 248, 8);
+pub const RESERVED_2_248: EfuseField = EfuseField::new(2, 7, 248, 8);
 /// User data
-pub(crate) const BLOCK_USR_DATA: EfuseField = EfuseField::new(3, 0, 0, 192);
+pub const BLOCK_USR_DATA: EfuseField = EfuseField::new(3, 0, 0, 192);
 /// reserved
-pub(crate) const RESERVED_3_192: EfuseField = EfuseField::new(3, 6, 192, 8);
+pub const RESERVED_3_192: EfuseField = EfuseField::new(3, 6, 192, 8);
 /// Custom MAC
-pub(crate) const CUSTOM_MAC: EfuseField = EfuseField::new(3, 6, 200, 48);
+pub const CUSTOM_MAC: EfuseField = EfuseField::new(3, 6, 200, 48);
 /// reserved
-pub(crate) const RESERVED_3_248: EfuseField = EfuseField::new(3, 7, 248, 8);
+pub const RESERVED_3_248: EfuseField = EfuseField::new(3, 7, 248, 8);
 /// Key0 or user data
-pub(crate) const BLOCK_KEY0: EfuseField = EfuseField::new(4, 0, 0, 256);
+pub const BLOCK_KEY0: EfuseField = EfuseField::new(4, 0, 0, 256);
 /// Key1 or user data
-pub(crate) const BLOCK_KEY1: EfuseField = EfuseField::new(5, 0, 0, 256);
+pub const BLOCK_KEY1: EfuseField = EfuseField::new(5, 0, 0, 256);
 /// Key2 or user data
-pub(crate) const BLOCK_KEY2: EfuseField = EfuseField::new(6, 0, 0, 256);
+pub const BLOCK_KEY2: EfuseField = EfuseField::new(6, 0, 0, 256);
 /// Key3 or user data
-pub(crate) const BLOCK_KEY3: EfuseField = EfuseField::new(7, 0, 0, 256);
+pub const BLOCK_KEY3: EfuseField = EfuseField::new(7, 0, 0, 256);
 /// Key4 or user data
-pub(crate) const BLOCK_KEY4: EfuseField = EfuseField::new(8, 0, 0, 256);
+pub const BLOCK_KEY4: EfuseField = EfuseField::new(8, 0, 0, 256);
 /// Key5 or user data
-pub(crate) const BLOCK_KEY5: EfuseField = EfuseField::new(9, 0, 0, 256);
+pub const BLOCK_KEY5: EfuseField = EfuseField::new(9, 0, 0, 256);
 /// HI_DOUT of ADC2 atten0
-pub(crate) const ADC2_HI_DOUT_ATTEN0: EfuseField = EfuseField::new(10, 0, 0, 10);
+pub const ADC2_HI_DOUT_ATTEN0: EfuseField = EfuseField::new(10, 0, 0, 10);
 /// HI_DOUT of ADC2 atten1
-pub(crate) const ADC2_HI_DOUT_ATTEN1: EfuseField = EfuseField::new(10, 0, 10, 10);
+pub const ADC2_HI_DOUT_ATTEN1: EfuseField = EfuseField::new(10, 0, 10, 10);
 /// HI_DOUT of ADC2 atten2
-pub(crate) const ADC2_HI_DOUT_ATTEN2: EfuseField = EfuseField::new(10, 0, 20, 10);
+pub const ADC2_HI_DOUT_ATTEN2: EfuseField = EfuseField::new(10, 0, 20, 10);
 /// HI_DOUT of ADC2 atten3
-pub(crate) const ADC2_HI_DOUT_ATTEN3: EfuseField = EfuseField::new(10, 0, 30, 10);
+pub const ADC2_HI_DOUT_ATTEN3: EfuseField = EfuseField::new(10, 0, 30, 10);
 /// Gap between ADC1_ch0 and average initcode
-pub(crate) const ADC1_CH0_ATTEN0_INITCODE_DIFF: EfuseField = EfuseField::new(10, 1, 40, 4);
+pub const ADC1_CH0_ATTEN0_INITCODE_DIFF: EfuseField = EfuseField::new(10, 1, 40, 4);
 /// Gap between ADC1_ch1 and average initcode
-pub(crate) const ADC1_CH1_ATTEN0_INITCODE_DIFF: EfuseField = EfuseField::new(10, 1, 44, 4);
+pub const ADC1_CH1_ATTEN0_INITCODE_DIFF: EfuseField = EfuseField::new(10, 1, 44, 4);
 /// Gap between ADC1_ch2 and average initcode
-pub(crate) const ADC1_CH2_ATTEN0_INITCODE_DIFF: EfuseField = EfuseField::new(10, 1, 48, 4);
+pub const ADC1_CH2_ATTEN0_INITCODE_DIFF: EfuseField = EfuseField::new(10, 1, 48, 4);
 /// Gap between ADC1_ch3 and average initcode
-pub(crate) const ADC1_CH3_ATTEN0_INITCODE_DIFF: EfuseField = EfuseField::new(10, 1, 52, 4);
+pub const ADC1_CH3_ATTEN0_INITCODE_DIFF: EfuseField = EfuseField::new(10, 1, 52, 4);
 /// Gap between ADC1_ch4 and average initcode
-pub(crate) const ADC1_CH4_ATTEN0_INITCODE_DIFF: EfuseField = EfuseField::new(10, 1, 56, 4);
+pub const ADC1_CH4_ATTEN0_INITCODE_DIFF: EfuseField = EfuseField::new(10, 1, 56, 4);
 /// Gap between ADC1_ch5 and average initcode
-pub(crate) const ADC1_CH5_ATTEN0_INITCODE_DIFF: EfuseField = EfuseField::new(10, 1, 60, 4);
+pub const ADC1_CH5_ATTEN0_INITCODE_DIFF: EfuseField = EfuseField::new(10, 1, 60, 4);
 /// Gap between ADC1_ch6 and average initcode
-pub(crate) const ADC1_CH6_ATTEN0_INITCODE_DIFF: EfuseField = EfuseField::new(10, 2, 64, 4);
+pub const ADC1_CH6_ATTEN0_INITCODE_DIFF: EfuseField = EfuseField::new(10, 2, 64, 4);
 /// Gap between ADC1_ch7 and average initcode
-pub(crate) const ADC1_CH7_ATTEN0_INITCODE_DIFF: EfuseField = EfuseField::new(10, 2, 68, 4);
+pub const ADC1_CH7_ATTEN0_INITCODE_DIFF: EfuseField = EfuseField::new(10, 2, 68, 4);
 /// Gap between ADC2_ch0 and average initcode
-pub(crate) const ADC2_CH0_ATTEN0_INITCODE_DIFF: EfuseField = EfuseField::new(10, 2, 72, 4);
+pub const ADC2_CH0_ATTEN0_INITCODE_DIFF: EfuseField = EfuseField::new(10, 2, 72, 4);
 /// Gap between ADC2_ch1 and average initcode
-pub(crate) const ADC2_CH1_ATTEN0_INITCODE_DIFF: EfuseField = EfuseField::new(10, 2, 76, 4);
+pub const ADC2_CH1_ATTEN0_INITCODE_DIFF: EfuseField = EfuseField::new(10, 2, 76, 4);
 /// Gap between ADC2_ch2 and average initcode
-pub(crate) const ADC2_CH2_ATTEN0_INITCODE_DIFF: EfuseField = EfuseField::new(10, 2, 80, 4);
+pub const ADC2_CH2_ATTEN0_INITCODE_DIFF: EfuseField = EfuseField::new(10, 2, 80, 4);
 /// Gap between ADC2_ch3 and average initcode
-pub(crate) const ADC2_CH3_ATTEN0_INITCODE_DIFF: EfuseField = EfuseField::new(10, 2, 84, 4);
+pub const ADC2_CH3_ATTEN0_INITCODE_DIFF: EfuseField = EfuseField::new(10, 2, 84, 4);
 /// Gap between ADC2_ch4 and average initcode
-pub(crate) const ADC2_CH4_ATTEN0_INITCODE_DIFF: EfuseField = EfuseField::new(10, 2, 88, 4);
+pub const ADC2_CH4_ATTEN0_INITCODE_DIFF: EfuseField = EfuseField::new(10, 2, 88, 4);
 /// Gap between ADC2_ch5 and average initcode
-pub(crate) const ADC2_CH5_ATTEN0_INITCODE_DIFF: EfuseField = EfuseField::new(10, 2, 92, 4);
+pub const ADC2_CH5_ATTEN0_INITCODE_DIFF: EfuseField = EfuseField::new(10, 2, 92, 4);
 /// Temperature calibration data
-pub(crate) const TEMPERATURE_SENSOR: EfuseField = EfuseField::new(10, 3, 96, 9);
+pub const TEMPERATURE_SENSOR: EfuseField = EfuseField::new(10, 3, 96, 9);
 /// reserved
-pub(crate) const RESERVED_10_105: EfuseField = EfuseField::new(10, 3, 105, 23);
+pub const RESERVED_10_105: EfuseField = EfuseField::new(10, 3, 105, 23);
 /// Stores the $nth 32 bits of the 2nd part of system data
-pub(crate) const SYS_DATA_PART2_4: EfuseField = EfuseField::new(10, 4, 128, 32);
+pub const SYS_DATA_PART2_4: EfuseField = EfuseField::new(10, 4, 128, 32);
 /// Stores the $nth 32 bits of the 2nd part of system data
-pub(crate) const SYS_DATA_PART2_5: EfuseField = EfuseField::new(10, 5, 160, 32);
+pub const SYS_DATA_PART2_5: EfuseField = EfuseField::new(10, 5, 160, 32);
 /// Stores the $nth 32 bits of the 2nd part of system data
-pub(crate) const SYS_DATA_PART2_6: EfuseField = EfuseField::new(10, 6, 192, 32);
+pub const SYS_DATA_PART2_6: EfuseField = EfuseField::new(10, 6, 192, 32);
 /// Stores the $nth 32 bits of the 2nd part of system data
-pub(crate) const SYS_DATA_PART2_7: EfuseField = EfuseField::new(10, 7, 224, 32);
+pub const SYS_DATA_PART2_7: EfuseField = EfuseField::new(10, 7, 224, 32);

--- a/espflash/src/target/efuse/esp32s2.rs
+++ b/espflash/src/target/efuse/esp32s2.rs
@@ -1,6 +1,8 @@
+//! eFuse field definitions for the esp32s2
+//!
 //! This file was automatically generated, please do not edit it manually!
 //!
-//! Generated: 2025-06-25 09:59
+//! Generated: 2025-06-25 11:06
 //! Version:   888a61f6f500d9c7ee0aa32016b0bee7
 
 #![allow(unused)]

--- a/espflash/src/target/efuse/esp32s2.rs
+++ b/espflash/src/target/efuse/esp32s2.rs
@@ -1,6 +1,6 @@
 //! This file was automatically generated, please do not edit it manually!
 //!
-//! Generated: 2025-05-30 12:24
+//! Generated: 2025-06-25 09:59
 //! Version:   888a61f6f500d9c7ee0aa32016b0bee7
 
 #![allow(unused)]
@@ -11,246 +11,246 @@ use super::EfuseField;
 pub(crate) const BLOCK_SIZES: &[u32] = &[24, 24, 32, 32, 32, 32, 32, 32, 32, 32, 32];
 
 /// Disable programming of individual eFuses
-pub(crate) const WR_DIS: EfuseField = EfuseField::new(0, 0, 0, 32);
+pub const WR_DIS: EfuseField = EfuseField::new(0, 0, 0, 32);
 /// Disable reading from BlOCK4-10
-pub(crate) const RD_DIS: EfuseField = EfuseField::new(0, 1, 32, 7);
+pub const RD_DIS: EfuseField = EfuseField::new(0, 1, 32, 7);
 /// Reserved
-pub(crate) const DIS_RTC_RAM_BOOT: EfuseField = EfuseField::new(0, 1, 39, 1);
+pub const DIS_RTC_RAM_BOOT: EfuseField = EfuseField::new(0, 1, 39, 1);
 /// Set this bit to disable Icache
-pub(crate) const DIS_ICACHE: EfuseField = EfuseField::new(0, 1, 40, 1);
+pub const DIS_ICACHE: EfuseField = EfuseField::new(0, 1, 40, 1);
 /// Set this bit to disable Dcache
-pub(crate) const DIS_DCACHE: EfuseField = EfuseField::new(0, 1, 41, 1);
+pub const DIS_DCACHE: EfuseField = EfuseField::new(0, 1, 41, 1);
 /// Disables Icache when SoC is in Download mode
-pub(crate) const DIS_DOWNLOAD_ICACHE: EfuseField = EfuseField::new(0, 1, 42, 1);
+pub const DIS_DOWNLOAD_ICACHE: EfuseField = EfuseField::new(0, 1, 42, 1);
 /// Disables Dcache when SoC is in Download mode
-pub(crate) const DIS_DOWNLOAD_DCACHE: EfuseField = EfuseField::new(0, 1, 43, 1);
+pub const DIS_DOWNLOAD_DCACHE: EfuseField = EfuseField::new(0, 1, 43, 1);
 /// Set this bit to disable the function that forces chip into download mode
-pub(crate) const DIS_FORCE_DOWNLOAD: EfuseField = EfuseField::new(0, 1, 44, 1);
+pub const DIS_FORCE_DOWNLOAD: EfuseField = EfuseField::new(0, 1, 44, 1);
 /// Set this bit to disable USB OTG function
-pub(crate) const DIS_USB: EfuseField = EfuseField::new(0, 1, 45, 1);
+pub const DIS_USB: EfuseField = EfuseField::new(0, 1, 45, 1);
 /// Set this bit to disable the TWAI Controller function
-pub(crate) const DIS_TWAI: EfuseField = EfuseField::new(0, 1, 46, 1);
+pub const DIS_TWAI: EfuseField = EfuseField::new(0, 1, 46, 1);
 /// Disables capability to Remap RAM to ROM address space
-pub(crate) const DIS_BOOT_REMAP: EfuseField = EfuseField::new(0, 1, 47, 1);
+pub const DIS_BOOT_REMAP: EfuseField = EfuseField::new(0, 1, 47, 1);
 /// Reserved (used for four backups method)
-pub(crate) const RPT4_RESERVED5: EfuseField = EfuseField::new(0, 1, 48, 1);
+pub const RPT4_RESERVED5: EfuseField = EfuseField::new(0, 1, 48, 1);
 /// Software disables JTAG. When software disabled; JTAG can be activated
 /// temporarily by HMAC peripheral
-pub(crate) const SOFT_DIS_JTAG: EfuseField = EfuseField::new(0, 1, 49, 1);
+pub const SOFT_DIS_JTAG: EfuseField = EfuseField::new(0, 1, 49, 1);
 /// Hardware disables JTAG permanently
-pub(crate) const HARD_DIS_JTAG: EfuseField = EfuseField::new(0, 1, 50, 1);
+pub const HARD_DIS_JTAG: EfuseField = EfuseField::new(0, 1, 50, 1);
 /// Disables flash encryption when in download boot modes
-pub(crate) const DIS_DOWNLOAD_MANUAL_ENCRYPT: EfuseField = EfuseField::new(0, 1, 51, 1);
+pub const DIS_DOWNLOAD_MANUAL_ENCRYPT: EfuseField = EfuseField::new(0, 1, 51, 1);
 /// Controls single-end input threshold vrefh; 1.76 V to 2 V with step of 80 mV;
 /// stored in eFuse
-pub(crate) const USB_DREFH: EfuseField = EfuseField::new(0, 1, 52, 2);
+pub const USB_DREFH: EfuseField = EfuseField::new(0, 1, 52, 2);
 /// Controls single-end input threshold vrefl; 0.8 V to 1.04 V with step of 80
 /// mV; stored in eFuse
-pub(crate) const USB_DREFL: EfuseField = EfuseField::new(0, 1, 54, 2);
+pub const USB_DREFL: EfuseField = EfuseField::new(0, 1, 54, 2);
 /// Set this bit to exchange USB D+ and D- pins
-pub(crate) const USB_EXCHG_PINS: EfuseField = EfuseField::new(0, 1, 56, 1);
+pub const USB_EXCHG_PINS: EfuseField = EfuseField::new(0, 1, 56, 1);
 /// Set this bit to enable external USB PHY
-pub(crate) const USB_EXT_PHY_ENABLE: EfuseField = EfuseField::new(0, 1, 57, 1);
+pub const USB_EXT_PHY_ENABLE: EfuseField = EfuseField::new(0, 1, 57, 1);
 /// If set; forces USB BVALID to 1
-pub(crate) const USB_FORCE_NOPERSIST: EfuseField = EfuseField::new(0, 1, 58, 1);
+pub const USB_FORCE_NOPERSIST: EfuseField = EfuseField::new(0, 1, 58, 1);
 /// BLOCK0 efuse version
-pub(crate) const BLOCK0_VERSION: EfuseField = EfuseField::new(0, 1, 59, 2);
+pub const BLOCK0_VERSION: EfuseField = EfuseField::new(0, 1, 59, 2);
 /// SPI regulator switches current limit mode
-pub(crate) const VDD_SPI_MODECURLIM: EfuseField = EfuseField::new(0, 1, 61, 1);
+pub const VDD_SPI_MODECURLIM: EfuseField = EfuseField::new(0, 1, 61, 1);
 /// SPI regulator high voltage reference
-pub(crate) const VDD_SPI_DREFH: EfuseField = EfuseField::new(0, 1, 62, 2);
+pub const VDD_SPI_DREFH: EfuseField = EfuseField::new(0, 1, 62, 2);
 /// SPI regulator medium voltage reference
-pub(crate) const VDD_SPI_DREFM: EfuseField = EfuseField::new(0, 2, 64, 2);
+pub const VDD_SPI_DREFM: EfuseField = EfuseField::new(0, 2, 64, 2);
 /// SPI regulator low voltage reference
-pub(crate) const VDD_SPI_DREFL: EfuseField = EfuseField::new(0, 2, 66, 2);
+pub const VDD_SPI_DREFL: EfuseField = EfuseField::new(0, 2, 66, 2);
 /// If VDD_SPI_FORCE is 1; this value determines if the VDD_SPI regulator is
 /// powered on
-pub(crate) const VDD_SPI_XPD: EfuseField = EfuseField::new(0, 2, 68, 1);
+pub const VDD_SPI_XPD: EfuseField = EfuseField::new(0, 2, 68, 1);
 /// If VDD_SPI_FORCE is 1; determines VDD_SPI voltage
-pub(crate) const VDD_SPI_TIEH: EfuseField = EfuseField::new(0, 2, 69, 1);
+pub const VDD_SPI_TIEH: EfuseField = EfuseField::new(0, 2, 69, 1);
 /// Set this bit to use XPD_VDD_PSI_REG and VDD_SPI_TIEH to configure VDD_SPI
 /// LDO
-pub(crate) const VDD_SPI_FORCE: EfuseField = EfuseField::new(0, 2, 70, 1);
+pub const VDD_SPI_FORCE: EfuseField = EfuseField::new(0, 2, 70, 1);
 /// Set SPI regulator to 0 to configure init[1:0]=0
-pub(crate) const VDD_SPI_EN_INIT: EfuseField = EfuseField::new(0, 2, 71, 1);
+pub const VDD_SPI_EN_INIT: EfuseField = EfuseField::new(0, 2, 71, 1);
 /// Set SPI regulator to 1 to enable output current limit
-pub(crate) const VDD_SPI_ENCURLIM: EfuseField = EfuseField::new(0, 2, 72, 1);
+pub const VDD_SPI_ENCURLIM: EfuseField = EfuseField::new(0, 2, 72, 1);
 /// Tunes the current limit threshold of SPI regulator when tieh=0; about 800
 /// mA/(8+d)
-pub(crate) const VDD_SPI_DCURLIM: EfuseField = EfuseField::new(0, 2, 73, 3);
+pub const VDD_SPI_DCURLIM: EfuseField = EfuseField::new(0, 2, 73, 3);
 /// Adds resistor from LDO output to ground
-pub(crate) const VDD_SPI_INIT: EfuseField = EfuseField::new(0, 2, 76, 2);
+pub const VDD_SPI_INIT: EfuseField = EfuseField::new(0, 2, 76, 2);
 /// Prevents SPI regulator from overshoot
-pub(crate) const VDD_SPI_DCAP: EfuseField = EfuseField::new(0, 2, 78, 2);
+pub const VDD_SPI_DCAP: EfuseField = EfuseField::new(0, 2, 78, 2);
 /// RTC watchdog timeout threshold; in unit of slow clock cycle
-pub(crate) const WDT_DELAY_SEL: EfuseField = EfuseField::new(0, 2, 80, 2);
+pub const WDT_DELAY_SEL: EfuseField = EfuseField::new(0, 2, 80, 2);
 /// Enables flash encryption when 1 or 3 bits are set and disabled otherwise
-pub(crate) const SPI_BOOT_CRYPT_CNT: EfuseField = EfuseField::new(0, 2, 82, 3);
+pub const SPI_BOOT_CRYPT_CNT: EfuseField = EfuseField::new(0, 2, 82, 3);
 /// Revoke 1st secure boot key
-pub(crate) const SECURE_BOOT_KEY_REVOKE0: EfuseField = EfuseField::new(0, 2, 85, 1);
+pub const SECURE_BOOT_KEY_REVOKE0: EfuseField = EfuseField::new(0, 2, 85, 1);
 /// Revoke 2nd secure boot key
-pub(crate) const SECURE_BOOT_KEY_REVOKE1: EfuseField = EfuseField::new(0, 2, 86, 1);
+pub const SECURE_BOOT_KEY_REVOKE1: EfuseField = EfuseField::new(0, 2, 86, 1);
 /// Revoke 3rd secure boot key
-pub(crate) const SECURE_BOOT_KEY_REVOKE2: EfuseField = EfuseField::new(0, 2, 87, 1);
+pub const SECURE_BOOT_KEY_REVOKE2: EfuseField = EfuseField::new(0, 2, 87, 1);
 /// Purpose of KEY0
-pub(crate) const KEY_PURPOSE_0: EfuseField = EfuseField::new(0, 2, 88, 4);
+pub const KEY_PURPOSE_0: EfuseField = EfuseField::new(0, 2, 88, 4);
 /// Purpose of KEY1
-pub(crate) const KEY_PURPOSE_1: EfuseField = EfuseField::new(0, 2, 92, 4);
+pub const KEY_PURPOSE_1: EfuseField = EfuseField::new(0, 2, 92, 4);
 /// Purpose of KEY2
-pub(crate) const KEY_PURPOSE_2: EfuseField = EfuseField::new(0, 3, 96, 4);
+pub const KEY_PURPOSE_2: EfuseField = EfuseField::new(0, 3, 96, 4);
 /// Purpose of KEY3
-pub(crate) const KEY_PURPOSE_3: EfuseField = EfuseField::new(0, 3, 100, 4);
+pub const KEY_PURPOSE_3: EfuseField = EfuseField::new(0, 3, 100, 4);
 /// Purpose of KEY4
-pub(crate) const KEY_PURPOSE_4: EfuseField = EfuseField::new(0, 3, 104, 4);
+pub const KEY_PURPOSE_4: EfuseField = EfuseField::new(0, 3, 104, 4);
 /// Purpose of KEY5
-pub(crate) const KEY_PURPOSE_5: EfuseField = EfuseField::new(0, 3, 108, 4);
+pub const KEY_PURPOSE_5: EfuseField = EfuseField::new(0, 3, 108, 4);
 /// Purpose of KEY6
-pub(crate) const KEY_PURPOSE_6: EfuseField = EfuseField::new(0, 3, 112, 4);
+pub const KEY_PURPOSE_6: EfuseField = EfuseField::new(0, 3, 112, 4);
 /// Set this bit to enable secure boot
-pub(crate) const SECURE_BOOT_EN: EfuseField = EfuseField::new(0, 3, 116, 1);
+pub const SECURE_BOOT_EN: EfuseField = EfuseField::new(0, 3, 116, 1);
 /// Set this bit to enable aggressive secure boot key revocation mode
-pub(crate) const SECURE_BOOT_AGGRESSIVE_REVOKE: EfuseField = EfuseField::new(0, 3, 117, 1);
+pub const SECURE_BOOT_AGGRESSIVE_REVOKE: EfuseField = EfuseField::new(0, 3, 117, 1);
 /// Reserved (used for four backups method)
-pub(crate) const RPT4_RESERVED1: EfuseField = EfuseField::new(0, 3, 118, 6);
+pub const RPT4_RESERVED1: EfuseField = EfuseField::new(0, 3, 118, 6);
 /// Configures flash startup delay after SoC power-up; in unit of (ms/2). When
 /// the value is 15; delay is 7.5 ms
-pub(crate) const FLASH_TPUW: EfuseField = EfuseField::new(0, 3, 124, 4);
+pub const FLASH_TPUW: EfuseField = EfuseField::new(0, 3, 124, 4);
 /// Set this bit to disable all download boot modes
-pub(crate) const DIS_DOWNLOAD_MODE: EfuseField = EfuseField::new(0, 4, 128, 1);
+pub const DIS_DOWNLOAD_MODE: EfuseField = EfuseField::new(0, 4, 128, 1);
 /// Set this bit to disable Legacy SPI boot mode
-pub(crate) const DIS_LEGACY_SPI_BOOT: EfuseField = EfuseField::new(0, 4, 129, 1);
+pub const DIS_LEGACY_SPI_BOOT: EfuseField = EfuseField::new(0, 4, 129, 1);
 /// Selects the default UART for printing boot messages
-pub(crate) const UART_PRINT_CHANNEL: EfuseField = EfuseField::new(0, 4, 130, 1);
+pub const UART_PRINT_CHANNEL: EfuseField = EfuseField::new(0, 4, 130, 1);
 /// Reserved (used for four backups method)
-pub(crate) const RPT4_RESERVED3: EfuseField = EfuseField::new(0, 4, 131, 1);
+pub const RPT4_RESERVED3: EfuseField = EfuseField::new(0, 4, 131, 1);
 /// Set this bit to disable use of USB OTG in UART download boot mode
-pub(crate) const DIS_USB_DOWNLOAD_MODE: EfuseField = EfuseField::new(0, 4, 132, 1);
+pub const DIS_USB_DOWNLOAD_MODE: EfuseField = EfuseField::new(0, 4, 132, 1);
 /// Set this bit to enable secure UART download mode (read/write flash only)
-pub(crate) const ENABLE_SECURITY_DOWNLOAD: EfuseField = EfuseField::new(0, 4, 133, 1);
+pub const ENABLE_SECURITY_DOWNLOAD: EfuseField = EfuseField::new(0, 4, 133, 1);
 /// Set the default UART boot message output mode
-pub(crate) const UART_PRINT_CONTROL: EfuseField = EfuseField::new(0, 4, 134, 2);
+pub const UART_PRINT_CONTROL: EfuseField = EfuseField::new(0, 4, 134, 2);
 /// Set default power supply for GPIO33-GPIO37; set when SPI flash is
 /// initialized
-pub(crate) const PIN_POWER_SELECTION: EfuseField = EfuseField::new(0, 4, 136, 1);
+pub const PIN_POWER_SELECTION: EfuseField = EfuseField::new(0, 4, 136, 1);
 /// SPI flash type
-pub(crate) const FLASH_TYPE: EfuseField = EfuseField::new(0, 4, 137, 1);
+pub const FLASH_TYPE: EfuseField = EfuseField::new(0, 4, 137, 1);
 /// If set; forces ROM code to send an SPI flash resume command during SPI boot
-pub(crate) const FORCE_SEND_RESUME: EfuseField = EfuseField::new(0, 4, 138, 1);
+pub const FORCE_SEND_RESUME: EfuseField = EfuseField::new(0, 4, 138, 1);
 /// Secure version (used by ESP-IDF anti-rollback feature)
-pub(crate) const SECURE_VERSION: EfuseField = EfuseField::new(0, 4, 139, 16);
+pub const SECURE_VERSION: EfuseField = EfuseField::new(0, 4, 139, 16);
 /// Reserved (used for four backups method)
-pub(crate) const RPT4_RESERVED2: EfuseField = EfuseField::new(0, 4, 155, 5);
+pub const RPT4_RESERVED2: EfuseField = EfuseField::new(0, 4, 155, 5);
 /// Disables check of wafer version major
-pub(crate) const DISABLE_WAFER_VERSION_MAJOR: EfuseField = EfuseField::new(0, 5, 160, 1);
+pub const DISABLE_WAFER_VERSION_MAJOR: EfuseField = EfuseField::new(0, 5, 160, 1);
 /// Disables check of blk version major
-pub(crate) const DISABLE_BLK_VERSION_MAJOR: EfuseField = EfuseField::new(0, 5, 161, 1);
+pub const DISABLE_BLK_VERSION_MAJOR: EfuseField = EfuseField::new(0, 5, 161, 1);
 /// reserved
-pub(crate) const RESERVED_0_162: EfuseField = EfuseField::new(0, 5, 162, 30);
+pub const RESERVED_0_162: EfuseField = EfuseField::new(0, 5, 162, 30);
 /// MAC address
-pub(crate) const MAC0: EfuseField = EfuseField::new(1, 0, 0, 32);
+pub const MAC0: EfuseField = EfuseField::new(1, 0, 0, 32);
 /// MAC address
-pub(crate) const MAC1: EfuseField = EfuseField::new(1, 1, 32, 16);
+pub const MAC1: EfuseField = EfuseField::new(1, 1, 32, 16);
 /// SPI_PAD_configure CLK
-pub(crate) const SPI_PAD_CONFIG_CLK: EfuseField = EfuseField::new(1, 1, 48, 6);
+pub const SPI_PAD_CONFIG_CLK: EfuseField = EfuseField::new(1, 1, 48, 6);
 /// SPI_PAD_configure Q(D1)
-pub(crate) const SPI_PAD_CONFIG_Q: EfuseField = EfuseField::new(1, 1, 54, 6);
+pub const SPI_PAD_CONFIG_Q: EfuseField = EfuseField::new(1, 1, 54, 6);
 /// SPI_PAD_configure D(D0)
-pub(crate) const SPI_PAD_CONFIG_D: EfuseField = EfuseField::new(1, 1, 60, 6);
+pub const SPI_PAD_CONFIG_D: EfuseField = EfuseField::new(1, 1, 60, 6);
 /// SPI_PAD_configure CS
-pub(crate) const SPI_PAD_CONFIG_CS: EfuseField = EfuseField::new(1, 2, 66, 6);
+pub const SPI_PAD_CONFIG_CS: EfuseField = EfuseField::new(1, 2, 66, 6);
 /// SPI_PAD_configure HD(D3)
-pub(crate) const SPI_PAD_CONFIG_HD: EfuseField = EfuseField::new(1, 2, 72, 6);
+pub const SPI_PAD_CONFIG_HD: EfuseField = EfuseField::new(1, 2, 72, 6);
 /// SPI_PAD_configure WP(D2)
-pub(crate) const SPI_PAD_CONFIG_WP: EfuseField = EfuseField::new(1, 2, 78, 6);
+pub const SPI_PAD_CONFIG_WP: EfuseField = EfuseField::new(1, 2, 78, 6);
 /// SPI_PAD_configure DQS
-pub(crate) const SPI_PAD_CONFIG_DQS: EfuseField = EfuseField::new(1, 2, 84, 6);
+pub const SPI_PAD_CONFIG_DQS: EfuseField = EfuseField::new(1, 2, 84, 6);
 /// SPI_PAD_configure D4
-pub(crate) const SPI_PAD_CONFIG_D4: EfuseField = EfuseField::new(1, 2, 90, 6);
+pub const SPI_PAD_CONFIG_D4: EfuseField = EfuseField::new(1, 2, 90, 6);
 /// SPI_PAD_configure D5
-pub(crate) const SPI_PAD_CONFIG_D5: EfuseField = EfuseField::new(1, 3, 96, 6);
+pub const SPI_PAD_CONFIG_D5: EfuseField = EfuseField::new(1, 3, 96, 6);
 /// SPI_PAD_configure D6
-pub(crate) const SPI_PAD_CONFIG_D6: EfuseField = EfuseField::new(1, 3, 102, 6);
+pub const SPI_PAD_CONFIG_D6: EfuseField = EfuseField::new(1, 3, 102, 6);
 /// SPI_PAD_configure D7
-pub(crate) const SPI_PAD_CONFIG_D7: EfuseField = EfuseField::new(1, 3, 108, 6);
+pub const SPI_PAD_CONFIG_D7: EfuseField = EfuseField::new(1, 3, 108, 6);
 /// WAFER_VERSION_MAJOR
-pub(crate) const WAFER_VERSION_MAJOR: EfuseField = EfuseField::new(1, 3, 114, 2);
+pub const WAFER_VERSION_MAJOR: EfuseField = EfuseField::new(1, 3, 114, 2);
 /// WAFER_VERSION_MINOR most significant bit
-pub(crate) const WAFER_VERSION_MINOR_HI: EfuseField = EfuseField::new(1, 3, 116, 1);
+pub const WAFER_VERSION_MINOR_HI: EfuseField = EfuseField::new(1, 3, 116, 1);
 /// Flash version
-pub(crate) const FLASH_VERSION: EfuseField = EfuseField::new(1, 3, 117, 4);
+pub const FLASH_VERSION: EfuseField = EfuseField::new(1, 3, 117, 4);
 /// BLK_VERSION_MAJOR
-pub(crate) const BLK_VERSION_MAJOR: EfuseField = EfuseField::new(1, 3, 121, 2);
+pub const BLK_VERSION_MAJOR: EfuseField = EfuseField::new(1, 3, 121, 2);
 /// reserved
-pub(crate) const RESERVED_1_123: EfuseField = EfuseField::new(1, 3, 123, 1);
+pub const RESERVED_1_123: EfuseField = EfuseField::new(1, 3, 123, 1);
 /// PSRAM version
-pub(crate) const PSRAM_VERSION: EfuseField = EfuseField::new(1, 3, 124, 4);
+pub const PSRAM_VERSION: EfuseField = EfuseField::new(1, 3, 124, 4);
 /// Package version
-pub(crate) const PKG_VERSION: EfuseField = EfuseField::new(1, 4, 128, 4);
+pub const PKG_VERSION: EfuseField = EfuseField::new(1, 4, 128, 4);
 /// WAFER_VERSION_MINOR least significant bits
-pub(crate) const WAFER_VERSION_MINOR_LO: EfuseField = EfuseField::new(1, 4, 132, 3);
+pub const WAFER_VERSION_MINOR_LO: EfuseField = EfuseField::new(1, 4, 132, 3);
 /// reserved
-pub(crate) const RESERVED_1_135: EfuseField = EfuseField::new(1, 4, 135, 25);
+pub const RESERVED_1_135: EfuseField = EfuseField::new(1, 4, 135, 25);
 /// Stores the second part of the zeroth part of system data
-pub(crate) const SYS_DATA_PART0_2: EfuseField = EfuseField::new(1, 5, 160, 32);
+pub const SYS_DATA_PART0_2: EfuseField = EfuseField::new(1, 5, 160, 32);
 /// Optional unique 128-bit ID
-pub(crate) const OPTIONAL_UNIQUE_ID: EfuseField = EfuseField::new(2, 0, 0, 128);
+pub const OPTIONAL_UNIQUE_ID: EfuseField = EfuseField::new(2, 0, 0, 128);
 /// 4 bit of ADC calibration
-pub(crate) const ADC_CALIB: EfuseField = EfuseField::new(2, 4, 128, 4);
+pub const ADC_CALIB: EfuseField = EfuseField::new(2, 4, 128, 4);
 /// BLK_VERSION_MINOR of BLOCK2
-pub(crate) const BLK_VERSION_MINOR: EfuseField = EfuseField::new(2, 4, 132, 3);
+pub const BLK_VERSION_MINOR: EfuseField = EfuseField::new(2, 4, 132, 3);
 /// Temperature calibration data
-pub(crate) const TEMP_CALIB: EfuseField = EfuseField::new(2, 4, 135, 9);
+pub const TEMP_CALIB: EfuseField = EfuseField::new(2, 4, 135, 9);
 ///
-pub(crate) const RTCCALIB_V1IDX_A10H: EfuseField = EfuseField::new(2, 4, 144, 8);
+pub const RTCCALIB_V1IDX_A10H: EfuseField = EfuseField::new(2, 4, 144, 8);
 ///
-pub(crate) const RTCCALIB_V1IDX_A11H: EfuseField = EfuseField::new(2, 4, 152, 8);
+pub const RTCCALIB_V1IDX_A11H: EfuseField = EfuseField::new(2, 4, 152, 8);
 ///
-pub(crate) const RTCCALIB_V1IDX_A12H: EfuseField = EfuseField::new(2, 5, 160, 8);
+pub const RTCCALIB_V1IDX_A12H: EfuseField = EfuseField::new(2, 5, 160, 8);
 ///
-pub(crate) const RTCCALIB_V1IDX_A13H: EfuseField = EfuseField::new(2, 5, 168, 8);
+pub const RTCCALIB_V1IDX_A13H: EfuseField = EfuseField::new(2, 5, 168, 8);
 ///
-pub(crate) const RTCCALIB_V1IDX_A20H: EfuseField = EfuseField::new(2, 5, 176, 8);
+pub const RTCCALIB_V1IDX_A20H: EfuseField = EfuseField::new(2, 5, 176, 8);
 ///
-pub(crate) const RTCCALIB_V1IDX_A21H: EfuseField = EfuseField::new(2, 5, 184, 8);
+pub const RTCCALIB_V1IDX_A21H: EfuseField = EfuseField::new(2, 5, 184, 8);
 ///
-pub(crate) const RTCCALIB_V1IDX_A22H: EfuseField = EfuseField::new(2, 6, 192, 8);
+pub const RTCCALIB_V1IDX_A22H: EfuseField = EfuseField::new(2, 6, 192, 8);
 ///
-pub(crate) const RTCCALIB_V1IDX_A23H: EfuseField = EfuseField::new(2, 6, 200, 8);
+pub const RTCCALIB_V1IDX_A23H: EfuseField = EfuseField::new(2, 6, 200, 8);
 ///
-pub(crate) const RTCCALIB_V1IDX_A10L: EfuseField = EfuseField::new(2, 6, 208, 6);
+pub const RTCCALIB_V1IDX_A10L: EfuseField = EfuseField::new(2, 6, 208, 6);
 ///
-pub(crate) const RTCCALIB_V1IDX_A11L: EfuseField = EfuseField::new(2, 6, 214, 6);
+pub const RTCCALIB_V1IDX_A11L: EfuseField = EfuseField::new(2, 6, 214, 6);
 ///
-pub(crate) const RTCCALIB_V1IDX_A12L: EfuseField = EfuseField::new(2, 6, 220, 6);
+pub const RTCCALIB_V1IDX_A12L: EfuseField = EfuseField::new(2, 6, 220, 6);
 ///
-pub(crate) const RTCCALIB_V1IDX_A13L: EfuseField = EfuseField::new(2, 7, 226, 6);
+pub const RTCCALIB_V1IDX_A13L: EfuseField = EfuseField::new(2, 7, 226, 6);
 ///
-pub(crate) const RTCCALIB_V1IDX_A20L: EfuseField = EfuseField::new(2, 7, 232, 6);
+pub const RTCCALIB_V1IDX_A20L: EfuseField = EfuseField::new(2, 7, 232, 6);
 ///
-pub(crate) const RTCCALIB_V1IDX_A21L: EfuseField = EfuseField::new(2, 7, 238, 6);
+pub const RTCCALIB_V1IDX_A21L: EfuseField = EfuseField::new(2, 7, 238, 6);
 ///
-pub(crate) const RTCCALIB_V1IDX_A22L: EfuseField = EfuseField::new(2, 7, 244, 6);
+pub const RTCCALIB_V1IDX_A22L: EfuseField = EfuseField::new(2, 7, 244, 6);
 ///
-pub(crate) const RTCCALIB_V1IDX_A23L: EfuseField = EfuseField::new(2, 7, 250, 6);
+pub const RTCCALIB_V1IDX_A23L: EfuseField = EfuseField::new(2, 7, 250, 6);
 /// User data
-pub(crate) const BLOCK_USR_DATA: EfuseField = EfuseField::new(3, 0, 0, 192);
+pub const BLOCK_USR_DATA: EfuseField = EfuseField::new(3, 0, 0, 192);
 /// reserved
-pub(crate) const RESERVED_3_192: EfuseField = EfuseField::new(3, 6, 192, 8);
+pub const RESERVED_3_192: EfuseField = EfuseField::new(3, 6, 192, 8);
 /// Custom MAC
-pub(crate) const CUSTOM_MAC: EfuseField = EfuseField::new(3, 6, 200, 48);
+pub const CUSTOM_MAC: EfuseField = EfuseField::new(3, 6, 200, 48);
 /// reserved
-pub(crate) const RESERVED_3_248: EfuseField = EfuseField::new(3, 7, 248, 8);
+pub const RESERVED_3_248: EfuseField = EfuseField::new(3, 7, 248, 8);
 /// Key0 or user data
-pub(crate) const BLOCK_KEY0: EfuseField = EfuseField::new(4, 0, 0, 256);
+pub const BLOCK_KEY0: EfuseField = EfuseField::new(4, 0, 0, 256);
 /// Key1 or user data
-pub(crate) const BLOCK_KEY1: EfuseField = EfuseField::new(5, 0, 0, 256);
+pub const BLOCK_KEY1: EfuseField = EfuseField::new(5, 0, 0, 256);
 /// Key2 or user data
-pub(crate) const BLOCK_KEY2: EfuseField = EfuseField::new(6, 0, 0, 256);
+pub const BLOCK_KEY2: EfuseField = EfuseField::new(6, 0, 0, 256);
 /// Key3 or user data
-pub(crate) const BLOCK_KEY3: EfuseField = EfuseField::new(7, 0, 0, 256);
+pub const BLOCK_KEY3: EfuseField = EfuseField::new(7, 0, 0, 256);
 /// Key4 or user data
-pub(crate) const BLOCK_KEY4: EfuseField = EfuseField::new(8, 0, 0, 256);
+pub const BLOCK_KEY4: EfuseField = EfuseField::new(8, 0, 0, 256);
 /// Key5 or user data
-pub(crate) const BLOCK_KEY5: EfuseField = EfuseField::new(9, 0, 0, 256);
+pub const BLOCK_KEY5: EfuseField = EfuseField::new(9, 0, 0, 256);
 /// System data part 2 (reserved)
-pub(crate) const BLOCK_SYS_DATA2: EfuseField = EfuseField::new(10, 0, 0, 256);
+pub const BLOCK_SYS_DATA2: EfuseField = EfuseField::new(10, 0, 0, 256);

--- a/espflash/src/target/efuse/esp32s3.rs
+++ b/espflash/src/target/efuse/esp32s3.rs
@@ -1,6 +1,8 @@
+//! eFuse field definitions for the esp32s3
+//!
 //! This file was automatically generated, please do not edit it manually!
 //!
-//! Generated: 2025-06-25 09:59
+//! Generated: 2025-06-25 11:06
 //! Version:   7127dd097e72bb90d0b790d460993126
 
 #![allow(unused)]

--- a/espflash/src/target/efuse/esp32s3.rs
+++ b/espflash/src/target/efuse/esp32s3.rs
@@ -1,6 +1,6 @@
 //! This file was automatically generated, please do not edit it manually!
 //!
-//! Generated: 2025-05-30 12:24
+//! Generated: 2025-06-25 09:59
 //! Version:   7127dd097e72bb90d0b790d460993126
 
 #![allow(unused)]
@@ -11,286 +11,286 @@ use super::EfuseField;
 pub(crate) const BLOCK_SIZES: &[u32] = &[23, 24, 32, 32, 32, 32, 32, 32, 32, 32, 32];
 
 /// Disable programming of individual eFuses
-pub(crate) const WR_DIS: EfuseField = EfuseField::new(0, 0, 0, 32);
+pub const WR_DIS: EfuseField = EfuseField::new(0, 0, 0, 32);
 /// Disable reading from BlOCK4-10
-pub(crate) const RD_DIS: EfuseField = EfuseField::new(0, 1, 32, 7);
+pub const RD_DIS: EfuseField = EfuseField::new(0, 1, 32, 7);
 /// Set this bit to disable boot from RTC RAM
-pub(crate) const DIS_RTC_RAM_BOOT: EfuseField = EfuseField::new(0, 1, 39, 1);
+pub const DIS_RTC_RAM_BOOT: EfuseField = EfuseField::new(0, 1, 39, 1);
 /// Set this bit to disable Icache
-pub(crate) const DIS_ICACHE: EfuseField = EfuseField::new(0, 1, 40, 1);
+pub const DIS_ICACHE: EfuseField = EfuseField::new(0, 1, 40, 1);
 /// Set this bit to disable Dcache
-pub(crate) const DIS_DCACHE: EfuseField = EfuseField::new(0, 1, 41, 1);
+pub const DIS_DCACHE: EfuseField = EfuseField::new(0, 1, 41, 1);
 /// Set this bit to disable Icache in download mode (boot_mode[3:0] is 0; 1; 2;
 /// 3; 6; 7)
-pub(crate) const DIS_DOWNLOAD_ICACHE: EfuseField = EfuseField::new(0, 1, 42, 1);
+pub const DIS_DOWNLOAD_ICACHE: EfuseField = EfuseField::new(0, 1, 42, 1);
 /// Set this bit to disable Dcache in download mode ( boot_mode[3:0] is 0; 1; 2;
 /// 3; 6; 7)
-pub(crate) const DIS_DOWNLOAD_DCACHE: EfuseField = EfuseField::new(0, 1, 43, 1);
+pub const DIS_DOWNLOAD_DCACHE: EfuseField = EfuseField::new(0, 1, 43, 1);
 /// Set this bit to disable the function that forces chip into download mode
-pub(crate) const DIS_FORCE_DOWNLOAD: EfuseField = EfuseField::new(0, 1, 44, 1);
+pub const DIS_FORCE_DOWNLOAD: EfuseField = EfuseField::new(0, 1, 44, 1);
 /// Set this bit to disable USB function
-pub(crate) const DIS_USB_OTG: EfuseField = EfuseField::new(0, 1, 45, 1);
+pub const DIS_USB_OTG: EfuseField = EfuseField::new(0, 1, 45, 1);
 /// Set this bit to disable CAN function
-pub(crate) const DIS_TWAI: EfuseField = EfuseField::new(0, 1, 46, 1);
+pub const DIS_TWAI: EfuseField = EfuseField::new(0, 1, 46, 1);
 /// Disable app cpu
-pub(crate) const DIS_APP_CPU: EfuseField = EfuseField::new(0, 1, 47, 1);
+pub const DIS_APP_CPU: EfuseField = EfuseField::new(0, 1, 47, 1);
 /// Set these bits to disable JTAG in the soft way (odd number 1 means disable
 /// ). JTAG can be enabled in HMAC module
-pub(crate) const SOFT_DIS_JTAG: EfuseField = EfuseField::new(0, 1, 48, 3);
+pub const SOFT_DIS_JTAG: EfuseField = EfuseField::new(0, 1, 48, 3);
 /// Set this bit to disable JTAG in the hard way. JTAG is disabled permanently
-pub(crate) const DIS_PAD_JTAG: EfuseField = EfuseField::new(0, 1, 51, 1);
+pub const DIS_PAD_JTAG: EfuseField = EfuseField::new(0, 1, 51, 1);
 /// Set this bit to disable flash encryption when in download boot modes
-pub(crate) const DIS_DOWNLOAD_MANUAL_ENCRYPT: EfuseField = EfuseField::new(0, 1, 52, 1);
+pub const DIS_DOWNLOAD_MANUAL_ENCRYPT: EfuseField = EfuseField::new(0, 1, 52, 1);
 /// Controls single-end input threshold vrefh; 1.76 V to 2 V with step of 80 mV;
 /// stored in eFuse
-pub(crate) const USB_DREFH: EfuseField = EfuseField::new(0, 1, 53, 2);
+pub const USB_DREFH: EfuseField = EfuseField::new(0, 1, 53, 2);
 /// Controls single-end input threshold vrefl; 0.8 V to 1.04 V with step of 80
 /// mV; stored in eFuse
-pub(crate) const USB_DREFL: EfuseField = EfuseField::new(0, 1, 55, 2);
+pub const USB_DREFL: EfuseField = EfuseField::new(0, 1, 55, 2);
 /// Set this bit to exchange USB D+ and D- pins
-pub(crate) const USB_EXCHG_PINS: EfuseField = EfuseField::new(0, 1, 57, 1);
+pub const USB_EXCHG_PINS: EfuseField = EfuseField::new(0, 1, 57, 1);
 /// Set this bit to enable external PHY
-pub(crate) const USB_EXT_PHY_ENABLE: EfuseField = EfuseField::new(0, 1, 58, 1);
+pub const USB_EXT_PHY_ENABLE: EfuseField = EfuseField::new(0, 1, 58, 1);
 /// Bluetooth GPIO signal output security level control
-pub(crate) const BTLC_GPIO_ENABLE: EfuseField = EfuseField::new(0, 1, 59, 2);
+pub const BTLC_GPIO_ENABLE: EfuseField = EfuseField::new(0, 1, 59, 2);
 /// SPI regulator switches current limit mode
-pub(crate) const VDD_SPI_MODECURLIM: EfuseField = EfuseField::new(0, 1, 61, 1);
+pub const VDD_SPI_MODECURLIM: EfuseField = EfuseField::new(0, 1, 61, 1);
 /// SPI regulator high voltage reference
-pub(crate) const VDD_SPI_DREFH: EfuseField = EfuseField::new(0, 1, 62, 2);
+pub const VDD_SPI_DREFH: EfuseField = EfuseField::new(0, 1, 62, 2);
 /// SPI regulator medium voltage reference
-pub(crate) const VDD_SPI_DREFM: EfuseField = EfuseField::new(0, 2, 64, 2);
+pub const VDD_SPI_DREFM: EfuseField = EfuseField::new(0, 2, 64, 2);
 /// SPI regulator low voltage reference
-pub(crate) const VDD_SPI_DREFL: EfuseField = EfuseField::new(0, 2, 66, 2);
+pub const VDD_SPI_DREFL: EfuseField = EfuseField::new(0, 2, 66, 2);
 /// SPI regulator power up signal
-pub(crate) const VDD_SPI_XPD: EfuseField = EfuseField::new(0, 2, 68, 1);
+pub const VDD_SPI_XPD: EfuseField = EfuseField::new(0, 2, 68, 1);
 /// If VDD_SPI_FORCE is 1; determines VDD_SPI voltage
-pub(crate) const VDD_SPI_TIEH: EfuseField = EfuseField::new(0, 2, 69, 1);
+pub const VDD_SPI_TIEH: EfuseField = EfuseField::new(0, 2, 69, 1);
 /// Set this bit and force to use the configuration of eFuse to configure
 /// VDD_SPI
-pub(crate) const VDD_SPI_FORCE: EfuseField = EfuseField::new(0, 2, 70, 1);
+pub const VDD_SPI_FORCE: EfuseField = EfuseField::new(0, 2, 70, 1);
 /// Set SPI regulator to 0 to configure init[1:0]=0
-pub(crate) const VDD_SPI_EN_INIT: EfuseField = EfuseField::new(0, 2, 71, 1);
+pub const VDD_SPI_EN_INIT: EfuseField = EfuseField::new(0, 2, 71, 1);
 /// Set SPI regulator to 1 to enable output current limit
-pub(crate) const VDD_SPI_ENCURLIM: EfuseField = EfuseField::new(0, 2, 72, 1);
+pub const VDD_SPI_ENCURLIM: EfuseField = EfuseField::new(0, 2, 72, 1);
 /// Tunes the current limit threshold of SPI regulator when tieh=0; about 800
 /// mA/(8+d)
-pub(crate) const VDD_SPI_DCURLIM: EfuseField = EfuseField::new(0, 2, 73, 3);
+pub const VDD_SPI_DCURLIM: EfuseField = EfuseField::new(0, 2, 73, 3);
 /// Adds resistor from LDO output to ground
-pub(crate) const VDD_SPI_INIT: EfuseField = EfuseField::new(0, 2, 76, 2);
+pub const VDD_SPI_INIT: EfuseField = EfuseField::new(0, 2, 76, 2);
 /// Prevents SPI regulator from overshoot
-pub(crate) const VDD_SPI_DCAP: EfuseField = EfuseField::new(0, 2, 78, 2);
+pub const VDD_SPI_DCAP: EfuseField = EfuseField::new(0, 2, 78, 2);
 /// RTC watchdog timeout threshold; in unit of slow clock cycle
-pub(crate) const WDT_DELAY_SEL: EfuseField = EfuseField::new(0, 2, 80, 2);
+pub const WDT_DELAY_SEL: EfuseField = EfuseField::new(0, 2, 80, 2);
 /// Enables flash encryption when 1 or 3 bits are set and disabled otherwise
-pub(crate) const SPI_BOOT_CRYPT_CNT: EfuseField = EfuseField::new(0, 2, 82, 3);
+pub const SPI_BOOT_CRYPT_CNT: EfuseField = EfuseField::new(0, 2, 82, 3);
 /// Revoke 1st secure boot key
-pub(crate) const SECURE_BOOT_KEY_REVOKE0: EfuseField = EfuseField::new(0, 2, 85, 1);
+pub const SECURE_BOOT_KEY_REVOKE0: EfuseField = EfuseField::new(0, 2, 85, 1);
 /// Revoke 2nd secure boot key
-pub(crate) const SECURE_BOOT_KEY_REVOKE1: EfuseField = EfuseField::new(0, 2, 86, 1);
+pub const SECURE_BOOT_KEY_REVOKE1: EfuseField = EfuseField::new(0, 2, 86, 1);
 /// Revoke 3rd secure boot key
-pub(crate) const SECURE_BOOT_KEY_REVOKE2: EfuseField = EfuseField::new(0, 2, 87, 1);
+pub const SECURE_BOOT_KEY_REVOKE2: EfuseField = EfuseField::new(0, 2, 87, 1);
 /// Purpose of Key0
-pub(crate) const KEY_PURPOSE_0: EfuseField = EfuseField::new(0, 2, 88, 4);
+pub const KEY_PURPOSE_0: EfuseField = EfuseField::new(0, 2, 88, 4);
 /// Purpose of Key1
-pub(crate) const KEY_PURPOSE_1: EfuseField = EfuseField::new(0, 2, 92, 4);
+pub const KEY_PURPOSE_1: EfuseField = EfuseField::new(0, 2, 92, 4);
 /// Purpose of Key2
-pub(crate) const KEY_PURPOSE_2: EfuseField = EfuseField::new(0, 3, 96, 4);
+pub const KEY_PURPOSE_2: EfuseField = EfuseField::new(0, 3, 96, 4);
 /// Purpose of Key3
-pub(crate) const KEY_PURPOSE_3: EfuseField = EfuseField::new(0, 3, 100, 4);
+pub const KEY_PURPOSE_3: EfuseField = EfuseField::new(0, 3, 100, 4);
 /// Purpose of Key4
-pub(crate) const KEY_PURPOSE_4: EfuseField = EfuseField::new(0, 3, 104, 4);
+pub const KEY_PURPOSE_4: EfuseField = EfuseField::new(0, 3, 104, 4);
 /// Purpose of Key5
-pub(crate) const KEY_PURPOSE_5: EfuseField = EfuseField::new(0, 3, 108, 4);
+pub const KEY_PURPOSE_5: EfuseField = EfuseField::new(0, 3, 108, 4);
 /// Reserved (used for four backups method)
-pub(crate) const RPT4_RESERVED0: EfuseField = EfuseField::new(0, 3, 112, 4);
+pub const RPT4_RESERVED0: EfuseField = EfuseField::new(0, 3, 112, 4);
 /// Set this bit to enable secure boot
-pub(crate) const SECURE_BOOT_EN: EfuseField = EfuseField::new(0, 3, 116, 1);
+pub const SECURE_BOOT_EN: EfuseField = EfuseField::new(0, 3, 116, 1);
 /// Set this bit to enable revoking aggressive secure boot
-pub(crate) const SECURE_BOOT_AGGRESSIVE_REVOKE: EfuseField = EfuseField::new(0, 3, 117, 1);
+pub const SECURE_BOOT_AGGRESSIVE_REVOKE: EfuseField = EfuseField::new(0, 3, 117, 1);
 /// Set this bit to disable function of usb switch to jtag in module of usb
 /// device
-pub(crate) const DIS_USB_JTAG: EfuseField = EfuseField::new(0, 3, 118, 1);
+pub const DIS_USB_JTAG: EfuseField = EfuseField::new(0, 3, 118, 1);
 /// Set this bit to disable usb device
-pub(crate) const DIS_USB_SERIAL_JTAG: EfuseField = EfuseField::new(0, 3, 119, 1);
+pub const DIS_USB_SERIAL_JTAG: EfuseField = EfuseField::new(0, 3, 119, 1);
 /// Set this bit to enable selection between usb_to_jtag and pad_to_jtag through
 /// strapping gpio3 when both reg_dis_usb_jtag and reg_dis_pad_jtag are equal to
 /// 0
-pub(crate) const STRAP_JTAG_SEL: EfuseField = EfuseField::new(0, 3, 120, 1);
+pub const STRAP_JTAG_SEL: EfuseField = EfuseField::new(0, 3, 120, 1);
 /// This bit is used to switch internal PHY and external PHY for USB OTG and USB
 /// Device
-pub(crate) const USB_PHY_SEL: EfuseField = EfuseField::new(0, 3, 121, 1);
+pub const USB_PHY_SEL: EfuseField = EfuseField::new(0, 3, 121, 1);
 /// Sample delay configuration of power glitch
-pub(crate) const POWER_GLITCH_DSENSE: EfuseField = EfuseField::new(0, 3, 122, 2);
+pub const POWER_GLITCH_DSENSE: EfuseField = EfuseField::new(0, 3, 122, 2);
 /// Configures flash waiting time after power-up; in unit of ms. If the value is
 /// less than 15; the waiting time is the configurable value.  Otherwise; the
 /// waiting time is twice the configurable value
-pub(crate) const FLASH_TPUW: EfuseField = EfuseField::new(0, 3, 124, 4);
+pub const FLASH_TPUW: EfuseField = EfuseField::new(0, 3, 124, 4);
 /// Set this bit to disable download mode (boot_mode[3:0] = 0; 1; 2; 3; 6; 7)
-pub(crate) const DIS_DOWNLOAD_MODE: EfuseField = EfuseField::new(0, 4, 128, 1);
+pub const DIS_DOWNLOAD_MODE: EfuseField = EfuseField::new(0, 4, 128, 1);
 /// Disable direct boot mode
-pub(crate) const DIS_DIRECT_BOOT: EfuseField = EfuseField::new(0, 4, 129, 1);
+pub const DIS_DIRECT_BOOT: EfuseField = EfuseField::new(0, 4, 129, 1);
 /// USB printing
-pub(crate) const DIS_USB_SERIAL_JTAG_ROM_PRINT: EfuseField = EfuseField::new(0, 4, 130, 1);
+pub const DIS_USB_SERIAL_JTAG_ROM_PRINT: EfuseField = EfuseField::new(0, 4, 130, 1);
 /// Flash ECC mode in ROM
-pub(crate) const FLASH_ECC_MODE: EfuseField = EfuseField::new(0, 4, 131, 1);
+pub const FLASH_ECC_MODE: EfuseField = EfuseField::new(0, 4, 131, 1);
 /// Set this bit to disable UART download mode through USB
-pub(crate) const DIS_USB_SERIAL_JTAG_DOWNLOAD_MODE: EfuseField = EfuseField::new(0, 4, 132, 1);
+pub const DIS_USB_SERIAL_JTAG_DOWNLOAD_MODE: EfuseField = EfuseField::new(0, 4, 132, 1);
 /// Set this bit to enable secure UART download mode
-pub(crate) const ENABLE_SECURITY_DOWNLOAD: EfuseField = EfuseField::new(0, 4, 133, 1);
+pub const ENABLE_SECURITY_DOWNLOAD: EfuseField = EfuseField::new(0, 4, 133, 1);
 /// Set the default UART boot message output mode
-pub(crate) const UART_PRINT_CONTROL: EfuseField = EfuseField::new(0, 4, 134, 2);
+pub const UART_PRINT_CONTROL: EfuseField = EfuseField::new(0, 4, 134, 2);
 /// Set default power supply for GPIO33-GPIO37; set when SPI flash is
 /// initialized
-pub(crate) const PIN_POWER_SELECTION: EfuseField = EfuseField::new(0, 4, 136, 1);
+pub const PIN_POWER_SELECTION: EfuseField = EfuseField::new(0, 4, 136, 1);
 /// SPI flash type
-pub(crate) const FLASH_TYPE: EfuseField = EfuseField::new(0, 4, 137, 1);
+pub const FLASH_TYPE: EfuseField = EfuseField::new(0, 4, 137, 1);
 /// Set Flash page size
-pub(crate) const FLASH_PAGE_SIZE: EfuseField = EfuseField::new(0, 4, 138, 2);
+pub const FLASH_PAGE_SIZE: EfuseField = EfuseField::new(0, 4, 138, 2);
 /// Set 1 to enable ECC for flash boot
-pub(crate) const FLASH_ECC_EN: EfuseField = EfuseField::new(0, 4, 140, 1);
+pub const FLASH_ECC_EN: EfuseField = EfuseField::new(0, 4, 140, 1);
 /// Set this bit to force ROM code to send a resume command during SPI boot
-pub(crate) const FORCE_SEND_RESUME: EfuseField = EfuseField::new(0, 4, 141, 1);
+pub const FORCE_SEND_RESUME: EfuseField = EfuseField::new(0, 4, 141, 1);
 /// Secure version (used by ESP-IDF anti-rollback feature)
-pub(crate) const SECURE_VERSION: EfuseField = EfuseField::new(0, 4, 142, 16);
+pub const SECURE_VERSION: EfuseField = EfuseField::new(0, 4, 142, 16);
 /// Set this bit to enable power glitch function
-pub(crate) const POWERGLITCH_EN: EfuseField = EfuseField::new(0, 4, 158, 1);
+pub const POWERGLITCH_EN: EfuseField = EfuseField::new(0, 4, 158, 1);
 /// Set this bit to disable download through USB-OTG
-pub(crate) const DIS_USB_OTG_DOWNLOAD_MODE: EfuseField = EfuseField::new(0, 4, 159, 1);
+pub const DIS_USB_OTG_DOWNLOAD_MODE: EfuseField = EfuseField::new(0, 4, 159, 1);
 /// Disables check of wafer version major
-pub(crate) const DISABLE_WAFER_VERSION_MAJOR: EfuseField = EfuseField::new(0, 5, 160, 1);
+pub const DISABLE_WAFER_VERSION_MAJOR: EfuseField = EfuseField::new(0, 5, 160, 1);
 /// Disables check of blk version major
-pub(crate) const DISABLE_BLK_VERSION_MAJOR: EfuseField = EfuseField::new(0, 5, 161, 1);
+pub const DISABLE_BLK_VERSION_MAJOR: EfuseField = EfuseField::new(0, 5, 161, 1);
 /// reserved
-pub(crate) const RESERVED_0_162: EfuseField = EfuseField::new(0, 5, 162, 22);
+pub const RESERVED_0_162: EfuseField = EfuseField::new(0, 5, 162, 22);
 /// MAC address
-pub(crate) const MAC0: EfuseField = EfuseField::new(1, 0, 0, 32);
+pub const MAC0: EfuseField = EfuseField::new(1, 0, 0, 32);
 /// MAC address
-pub(crate) const MAC1: EfuseField = EfuseField::new(1, 1, 32, 16);
+pub const MAC1: EfuseField = EfuseField::new(1, 1, 32, 16);
 /// SPI_PAD_configure CLK
-pub(crate) const SPI_PAD_CONFIG_CLK: EfuseField = EfuseField::new(1, 1, 48, 6);
+pub const SPI_PAD_CONFIG_CLK: EfuseField = EfuseField::new(1, 1, 48, 6);
 /// SPI_PAD_configure Q(D1)
-pub(crate) const SPI_PAD_CONFIG_Q: EfuseField = EfuseField::new(1, 1, 54, 6);
+pub const SPI_PAD_CONFIG_Q: EfuseField = EfuseField::new(1, 1, 54, 6);
 /// SPI_PAD_configure D(D0)
-pub(crate) const SPI_PAD_CONFIG_D: EfuseField = EfuseField::new(1, 1, 60, 6);
+pub const SPI_PAD_CONFIG_D: EfuseField = EfuseField::new(1, 1, 60, 6);
 /// SPI_PAD_configure CS
-pub(crate) const SPI_PAD_CONFIG_CS: EfuseField = EfuseField::new(1, 2, 66, 6);
+pub const SPI_PAD_CONFIG_CS: EfuseField = EfuseField::new(1, 2, 66, 6);
 /// SPI_PAD_configure HD(D3)
-pub(crate) const SPI_PAD_CONFIG_HD: EfuseField = EfuseField::new(1, 2, 72, 6);
+pub const SPI_PAD_CONFIG_HD: EfuseField = EfuseField::new(1, 2, 72, 6);
 /// SPI_PAD_configure WP(D2)
-pub(crate) const SPI_PAD_CONFIG_WP: EfuseField = EfuseField::new(1, 2, 78, 6);
+pub const SPI_PAD_CONFIG_WP: EfuseField = EfuseField::new(1, 2, 78, 6);
 /// SPI_PAD_configure DQS
-pub(crate) const SPI_PAD_CONFIG_DQS: EfuseField = EfuseField::new(1, 2, 84, 6);
+pub const SPI_PAD_CONFIG_DQS: EfuseField = EfuseField::new(1, 2, 84, 6);
 /// SPI_PAD_configure D4
-pub(crate) const SPI_PAD_CONFIG_D4: EfuseField = EfuseField::new(1, 2, 90, 6);
+pub const SPI_PAD_CONFIG_D4: EfuseField = EfuseField::new(1, 2, 90, 6);
 /// SPI_PAD_configure D5
-pub(crate) const SPI_PAD_CONFIG_D5: EfuseField = EfuseField::new(1, 3, 96, 6);
+pub const SPI_PAD_CONFIG_D5: EfuseField = EfuseField::new(1, 3, 96, 6);
 /// SPI_PAD_configure D6
-pub(crate) const SPI_PAD_CONFIG_D6: EfuseField = EfuseField::new(1, 3, 102, 6);
+pub const SPI_PAD_CONFIG_D6: EfuseField = EfuseField::new(1, 3, 102, 6);
 /// SPI_PAD_configure D7
-pub(crate) const SPI_PAD_CONFIG_D7: EfuseField = EfuseField::new(1, 3, 108, 6);
+pub const SPI_PAD_CONFIG_D7: EfuseField = EfuseField::new(1, 3, 108, 6);
 /// WAFER_VERSION_MINOR least significant bits
-pub(crate) const WAFER_VERSION_MINOR_LO: EfuseField = EfuseField::new(1, 3, 114, 3);
+pub const WAFER_VERSION_MINOR_LO: EfuseField = EfuseField::new(1, 3, 114, 3);
 /// Package version
-pub(crate) const PKG_VERSION: EfuseField = EfuseField::new(1, 3, 117, 3);
+pub const PKG_VERSION: EfuseField = EfuseField::new(1, 3, 117, 3);
 /// BLK_VERSION_MINOR
-pub(crate) const BLK_VERSION_MINOR: EfuseField = EfuseField::new(1, 3, 120, 3);
+pub const BLK_VERSION_MINOR: EfuseField = EfuseField::new(1, 3, 120, 3);
 /// Flash capacity
-pub(crate) const FLASH_CAP: EfuseField = EfuseField::new(1, 3, 123, 3);
+pub const FLASH_CAP: EfuseField = EfuseField::new(1, 3, 123, 3);
 /// Flash temperature
-pub(crate) const FLASH_TEMP: EfuseField = EfuseField::new(1, 3, 126, 2);
+pub const FLASH_TEMP: EfuseField = EfuseField::new(1, 3, 126, 2);
 /// Flash vendor
-pub(crate) const FLASH_VENDOR: EfuseField = EfuseField::new(1, 4, 128, 3);
+pub const FLASH_VENDOR: EfuseField = EfuseField::new(1, 4, 128, 3);
 /// PSRAM capacity
-pub(crate) const PSRAM_CAP: EfuseField = EfuseField::new(1, 4, 131, 2);
+pub const PSRAM_CAP: EfuseField = EfuseField::new(1, 4, 131, 2);
 /// PSRAM temperature
-pub(crate) const PSRAM_TEMP: EfuseField = EfuseField::new(1, 4, 133, 2);
+pub const PSRAM_TEMP: EfuseField = EfuseField::new(1, 4, 133, 2);
 /// PSRAM vendor
-pub(crate) const PSRAM_VENDOR: EfuseField = EfuseField::new(1, 4, 135, 2);
+pub const PSRAM_VENDOR: EfuseField = EfuseField::new(1, 4, 135, 2);
 /// reserved
-pub(crate) const RESERVED_1_137: EfuseField = EfuseField::new(1, 4, 137, 4);
+pub const RESERVED_1_137: EfuseField = EfuseField::new(1, 4, 137, 4);
 /// BLOCK1 K_RTC_LDO
-pub(crate) const K_RTC_LDO: EfuseField = EfuseField::new(1, 4, 141, 7);
+pub const K_RTC_LDO: EfuseField = EfuseField::new(1, 4, 141, 7);
 /// BLOCK1 K_DIG_LDO
-pub(crate) const K_DIG_LDO: EfuseField = EfuseField::new(1, 4, 148, 7);
+pub const K_DIG_LDO: EfuseField = EfuseField::new(1, 4, 148, 7);
 /// BLOCK1 voltage of rtc dbias20
-pub(crate) const V_RTC_DBIAS20: EfuseField = EfuseField::new(1, 4, 155, 8);
+pub const V_RTC_DBIAS20: EfuseField = EfuseField::new(1, 4, 155, 8);
 /// BLOCK1 voltage of digital dbias20
-pub(crate) const V_DIG_DBIAS20: EfuseField = EfuseField::new(1, 5, 163, 8);
+pub const V_DIG_DBIAS20: EfuseField = EfuseField::new(1, 5, 163, 8);
 /// BLOCK1 digital dbias when hvt
-pub(crate) const DIG_DBIAS_HVT: EfuseField = EfuseField::new(1, 5, 171, 5);
+pub const DIG_DBIAS_HVT: EfuseField = EfuseField::new(1, 5, 171, 5);
 /// reserved
-pub(crate) const RESERVED_1_176: EfuseField = EfuseField::new(1, 5, 176, 3);
+pub const RESERVED_1_176: EfuseField = EfuseField::new(1, 5, 176, 3);
 /// PSRAM capacity bit 3
-pub(crate) const PSRAM_CAP_3: EfuseField = EfuseField::new(1, 5, 179, 1);
+pub const PSRAM_CAP_3: EfuseField = EfuseField::new(1, 5, 179, 1);
 /// reserved
-pub(crate) const RESERVED_1_180: EfuseField = EfuseField::new(1, 5, 180, 3);
+pub const RESERVED_1_180: EfuseField = EfuseField::new(1, 5, 180, 3);
 /// WAFER_VERSION_MINOR most significant bit
-pub(crate) const WAFER_VERSION_MINOR_HI: EfuseField = EfuseField::new(1, 5, 183, 1);
+pub const WAFER_VERSION_MINOR_HI: EfuseField = EfuseField::new(1, 5, 183, 1);
 /// WAFER_VERSION_MAJOR
-pub(crate) const WAFER_VERSION_MAJOR: EfuseField = EfuseField::new(1, 5, 184, 2);
+pub const WAFER_VERSION_MAJOR: EfuseField = EfuseField::new(1, 5, 184, 2);
 /// ADC2 calibration voltage at atten3
-pub(crate) const ADC2_CAL_VOL_ATTEN3: EfuseField = EfuseField::new(1, 5, 186, 6);
+pub const ADC2_CAL_VOL_ATTEN3: EfuseField = EfuseField::new(1, 5, 186, 6);
 /// Optional unique 128-bit ID
-pub(crate) const OPTIONAL_UNIQUE_ID: EfuseField = EfuseField::new(2, 0, 0, 128);
+pub const OPTIONAL_UNIQUE_ID: EfuseField = EfuseField::new(2, 0, 0, 128);
 /// BLK_VERSION_MAJOR of BLOCK2
-pub(crate) const BLK_VERSION_MAJOR: EfuseField = EfuseField::new(2, 4, 128, 2);
+pub const BLK_VERSION_MAJOR: EfuseField = EfuseField::new(2, 4, 128, 2);
 /// reserved
-pub(crate) const RESERVED_2_130: EfuseField = EfuseField::new(2, 4, 130, 2);
+pub const RESERVED_2_130: EfuseField = EfuseField::new(2, 4, 130, 2);
 /// Temperature calibration data
-pub(crate) const TEMP_CALIB: EfuseField = EfuseField::new(2, 4, 132, 9);
+pub const TEMP_CALIB: EfuseField = EfuseField::new(2, 4, 132, 9);
 /// ADC OCode
-pub(crate) const OCODE: EfuseField = EfuseField::new(2, 4, 141, 8);
+pub const OCODE: EfuseField = EfuseField::new(2, 4, 141, 8);
 /// ADC1 init code at atten0
-pub(crate) const ADC1_INIT_CODE_ATTEN0: EfuseField = EfuseField::new(2, 4, 149, 8);
+pub const ADC1_INIT_CODE_ATTEN0: EfuseField = EfuseField::new(2, 4, 149, 8);
 /// ADC1 init code at atten1
-pub(crate) const ADC1_INIT_CODE_ATTEN1: EfuseField = EfuseField::new(2, 4, 157, 6);
+pub const ADC1_INIT_CODE_ATTEN1: EfuseField = EfuseField::new(2, 4, 157, 6);
 /// ADC1 init code at atten2
-pub(crate) const ADC1_INIT_CODE_ATTEN2: EfuseField = EfuseField::new(2, 5, 163, 6);
+pub const ADC1_INIT_CODE_ATTEN2: EfuseField = EfuseField::new(2, 5, 163, 6);
 /// ADC1 init code at atten3
-pub(crate) const ADC1_INIT_CODE_ATTEN3: EfuseField = EfuseField::new(2, 5, 169, 6);
+pub const ADC1_INIT_CODE_ATTEN3: EfuseField = EfuseField::new(2, 5, 169, 6);
 /// ADC2 init code at atten0
-pub(crate) const ADC2_INIT_CODE_ATTEN0: EfuseField = EfuseField::new(2, 5, 175, 8);
+pub const ADC2_INIT_CODE_ATTEN0: EfuseField = EfuseField::new(2, 5, 175, 8);
 /// ADC2 init code at atten1
-pub(crate) const ADC2_INIT_CODE_ATTEN1: EfuseField = EfuseField::new(2, 5, 183, 6);
+pub const ADC2_INIT_CODE_ATTEN1: EfuseField = EfuseField::new(2, 5, 183, 6);
 /// ADC2 init code at atten2
-pub(crate) const ADC2_INIT_CODE_ATTEN2: EfuseField = EfuseField::new(2, 5, 189, 6);
+pub const ADC2_INIT_CODE_ATTEN2: EfuseField = EfuseField::new(2, 5, 189, 6);
 /// ADC2 init code at atten3
-pub(crate) const ADC2_INIT_CODE_ATTEN3: EfuseField = EfuseField::new(2, 6, 195, 6);
+pub const ADC2_INIT_CODE_ATTEN3: EfuseField = EfuseField::new(2, 6, 195, 6);
 /// ADC1 calibration voltage at atten0
-pub(crate) const ADC1_CAL_VOL_ATTEN0: EfuseField = EfuseField::new(2, 6, 201, 8);
+pub const ADC1_CAL_VOL_ATTEN0: EfuseField = EfuseField::new(2, 6, 201, 8);
 /// ADC1 calibration voltage at atten1
-pub(crate) const ADC1_CAL_VOL_ATTEN1: EfuseField = EfuseField::new(2, 6, 209, 8);
+pub const ADC1_CAL_VOL_ATTEN1: EfuseField = EfuseField::new(2, 6, 209, 8);
 /// ADC1 calibration voltage at atten2
-pub(crate) const ADC1_CAL_VOL_ATTEN2: EfuseField = EfuseField::new(2, 6, 217, 8);
+pub const ADC1_CAL_VOL_ATTEN2: EfuseField = EfuseField::new(2, 6, 217, 8);
 /// ADC1 calibration voltage at atten3
-pub(crate) const ADC1_CAL_VOL_ATTEN3: EfuseField = EfuseField::new(2, 7, 225, 8);
+pub const ADC1_CAL_VOL_ATTEN3: EfuseField = EfuseField::new(2, 7, 225, 8);
 /// ADC2 calibration voltage at atten0
-pub(crate) const ADC2_CAL_VOL_ATTEN0: EfuseField = EfuseField::new(2, 7, 233, 8);
+pub const ADC2_CAL_VOL_ATTEN0: EfuseField = EfuseField::new(2, 7, 233, 8);
 /// ADC2 calibration voltage at atten1
-pub(crate) const ADC2_CAL_VOL_ATTEN1: EfuseField = EfuseField::new(2, 7, 241, 7);
+pub const ADC2_CAL_VOL_ATTEN1: EfuseField = EfuseField::new(2, 7, 241, 7);
 /// ADC2 calibration voltage at atten2
-pub(crate) const ADC2_CAL_VOL_ATTEN2: EfuseField = EfuseField::new(2, 7, 248, 7);
+pub const ADC2_CAL_VOL_ATTEN2: EfuseField = EfuseField::new(2, 7, 248, 7);
 /// reserved
-pub(crate) const RESERVED_2_255: EfuseField = EfuseField::new(2, 7, 255, 1);
+pub const RESERVED_2_255: EfuseField = EfuseField::new(2, 7, 255, 1);
 /// User data
-pub(crate) const BLOCK_USR_DATA: EfuseField = EfuseField::new(3, 0, 0, 192);
+pub const BLOCK_USR_DATA: EfuseField = EfuseField::new(3, 0, 0, 192);
 /// reserved
-pub(crate) const RESERVED_3_192: EfuseField = EfuseField::new(3, 6, 192, 8);
+pub const RESERVED_3_192: EfuseField = EfuseField::new(3, 6, 192, 8);
 /// Custom MAC
-pub(crate) const CUSTOM_MAC: EfuseField = EfuseField::new(3, 6, 200, 48);
+pub const CUSTOM_MAC: EfuseField = EfuseField::new(3, 6, 200, 48);
 /// reserved
-pub(crate) const RESERVED_3_248: EfuseField = EfuseField::new(3, 7, 248, 8);
+pub const RESERVED_3_248: EfuseField = EfuseField::new(3, 7, 248, 8);
 /// Key0 or user data
-pub(crate) const BLOCK_KEY0: EfuseField = EfuseField::new(4, 0, 0, 256);
+pub const BLOCK_KEY0: EfuseField = EfuseField::new(4, 0, 0, 256);
 /// Key1 or user data
-pub(crate) const BLOCK_KEY1: EfuseField = EfuseField::new(5, 0, 0, 256);
+pub const BLOCK_KEY1: EfuseField = EfuseField::new(5, 0, 0, 256);
 /// Key2 or user data
-pub(crate) const BLOCK_KEY2: EfuseField = EfuseField::new(6, 0, 0, 256);
+pub const BLOCK_KEY2: EfuseField = EfuseField::new(6, 0, 0, 256);
 /// Key3 or user data
-pub(crate) const BLOCK_KEY3: EfuseField = EfuseField::new(7, 0, 0, 256);
+pub const BLOCK_KEY3: EfuseField = EfuseField::new(7, 0, 0, 256);
 /// Key4 or user data
-pub(crate) const BLOCK_KEY4: EfuseField = EfuseField::new(8, 0, 0, 256);
+pub const BLOCK_KEY4: EfuseField = EfuseField::new(8, 0, 0, 256);
 /// Key5 or user data
-pub(crate) const BLOCK_KEY5: EfuseField = EfuseField::new(9, 0, 0, 256);
+pub const BLOCK_KEY5: EfuseField = EfuseField::new(9, 0, 0, 256);
 /// System data part 2 (reserved)
-pub(crate) const BLOCK_SYS_DATA2: EfuseField = EfuseField::new(10, 0, 0, 256);
+pub const BLOCK_SYS_DATA2: EfuseField = EfuseField::new(10, 0, 0, 256);

--- a/espflash/src/target/efuse/mod.rs
+++ b/espflash/src/target/efuse/mod.rs
@@ -1,14 +1,14 @@
 #![allow(clippy::empty_docs)]
 
-pub(crate) mod esp32;
-pub(crate) mod esp32c2;
-pub(crate) mod esp32c3;
-pub(crate) mod esp32c5;
-pub(crate) mod esp32c6;
-pub(crate) mod esp32h2;
-pub(crate) mod esp32p4;
-pub(crate) mod esp32s2;
-pub(crate) mod esp32s3;
+pub mod esp32;
+pub mod esp32c2;
+pub mod esp32c3;
+pub mod esp32c5;
+pub mod esp32c6;
+pub mod esp32h2;
+pub mod esp32p4;
+pub mod esp32s2;
+pub mod esp32s3;
 
 #[allow(unused)]
 #[derive(Debug, Clone, serde::Deserialize)]

--- a/espflash/src/target/efuse/mod.rs
+++ b/espflash/src/target/efuse/mod.rs
@@ -13,10 +13,10 @@ pub(crate) mod esp32s3;
 #[allow(unused)]
 #[derive(Debug, Clone, serde::Deserialize)]
 pub struct EfuseField {
-    pub(crate) block: u32,
-    pub(crate) word: u32,
-    pub(crate) bit_start: u32,
-    pub(crate) bit_count: u32,
+    pub block: u32,
+    pub word: u32,
+    pub bit_start: u32,
+    pub bit_count: u32,
 }
 
 impl EfuseField {

--- a/espflash/src/target/flash_target/esp32.rs
+++ b/espflash/src/target/flash_target/esp32.rs
@@ -137,7 +137,7 @@ impl FlashTarget for Esp32Target {
         encoder.write_all(&segment.data)?;
         let compressed = encoder.finish()?;
 
-        let flash_write_size = self.chip.flash_write_size(connection)?;
+        let flash_write_size = self.chip.flash_write_size();
         let block_count = compressed.len().div_ceil(flash_write_size);
         let erase_count = segment.data.len().div_ceil(FLASH_SECTOR_SIZE);
 

--- a/espflash/src/target/flash_target/mod.rs
+++ b/espflash/src/target/flash_target/mod.rs
@@ -1,4 +1,3 @@
-pub(crate) use self::ram::MAX_RAM_BLOCK_SIZE;
 pub use self::{esp32::Esp32Target, ram::RamTarget};
 use crate::{Error, connection::Connection, flasher::ProgressCallbacks, image_format::Segment};
 

--- a/espflash/src/target/flash_target/ram.rs
+++ b/espflash/src/target/flash_target/ram.rs
@@ -1,4 +1,4 @@
-use crate::{Error, image_format::Segment};
+use crate::{Error, image_format::Segment, target::MAX_RAM_BLOCK_SIZE};
 #[cfg(feature = "serialport")]
 use crate::{
     connection::{
@@ -8,9 +8,6 @@ use crate::{
     flasher::ProgressCallbacks,
     target::FlashTarget,
 };
-
-/// Maximum block size for RAM flashing.
-pub const MAX_RAM_BLOCK_SIZE: usize = 0x1800;
 
 /// Applications running in the target device's RAM.
 #[derive(Debug)]

--- a/espflash/src/target/mod.rs
+++ b/espflash/src/target/mod.rs
@@ -10,18 +10,15 @@ use serde::{Deserialize, Serialize};
 use strum::{Display, EnumIter, EnumString, IntoEnumIterator, VariantNames};
 
 #[cfg(feature = "serialport")]
-pub use self::{
-    efuse::EfuseField,
-    flash_target::{Esp32Target, FlashTarget, RamTarget},
-};
+pub use self::flash_target::{Esp32Target, FlashTarget, RamTarget};
 use crate::{
     Error,
     flasher::{FLASH_WRITE_SIZE, FlashFrequency},
 };
 #[cfg(feature = "serialport")]
-use crate::{connection::Connection, flasher::SpiAttachParams};
+use crate::{connection::Connection, flasher::SpiAttachParams, target::efuse::EfuseField};
 
-mod efuse;
+pub mod efuse;
 
 #[cfg(feature = "serialport")]
 pub(crate) mod flash_target;

--- a/espflash/src/target/mod.rs
+++ b/espflash/src/target/mod.rs
@@ -14,13 +14,12 @@ pub use self::{
     efuse::EfuseField,
     flash_target::{Esp32Target, FlashTarget, RamTarget},
 };
-use crate::{Error, flasher::FlashFrequency};
-#[cfg(feature = "serialport")]
 use crate::{
-    connection::Connection,
-    flasher::{FLASH_WRITE_SIZE, SpiAttachParams},
-    target::flash_target::MAX_RAM_BLOCK_SIZE,
+    Error,
+    flasher::{FLASH_WRITE_SIZE, FlashFrequency},
 };
+#[cfg(feature = "serialport")]
+use crate::{connection::Connection, flasher::SpiAttachParams};
 
 mod efuse;
 
@@ -29,6 +28,9 @@ pub(crate) mod flash_target;
 
 #[cfg(feature = "serialport")]
 pub(crate) const WDT_WKEY: u32 = 0x50D8_3AA1;
+
+/// Maximum block size for RAM flashing.
+pub(crate) const MAX_RAM_BLOCK_SIZE: usize = 0x1800;
 
 /// Supported crystal frequencies
 ///
@@ -770,10 +772,9 @@ impl Chip {
         })
     }
 
-    #[cfg(feature = "serialport")]
     /// Write size for flashing operations
-    pub fn flash_write_size(&self, _connection: &mut Connection) -> Result<usize, Error> {
-        Ok(FLASH_WRITE_SIZE)
+    pub fn flash_write_size(&self) -> usize {
+        FLASH_WRITE_SIZE
     }
 
     #[cfg(feature = "serialport")]
@@ -807,10 +808,9 @@ impl Chip {
         Ok(mac_addr)
     }
 
-    #[cfg(feature = "serialport")]
     /// Maximum RAM block size for writing
-    pub fn max_ram_block_size(&self, _connection: &mut Connection) -> Result<usize, Error> {
-        Ok(MAX_RAM_BLOCK_SIZE)
+    pub fn max_ram_block_size(&self) -> usize {
+        MAX_RAM_BLOCK_SIZE
     }
 
     /// SPI register addresses for a chip

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -49,6 +49,8 @@ fn main() -> Result<()> {
 // Generate eFuse Fields
 
 const HEADER: &str = r#"
+//! eFuse field definitions for the $CHIP
+//!
 //! This file was automatically generated, please do not edit it manually!
 //! 
 //! Generated: $DATE
@@ -205,6 +207,7 @@ fn generate_efuse_definitions(espflash_path: &Path, efuse_fields: EfuseFields) -
             writer,
             "{}",
             HEADER
+                .replace("$CHIP", &chip)
                 .replace(
                     "$DATE",
                     &chrono::Utc::now().format("%Y-%m-%d %H:%M").to_string()

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -188,7 +188,7 @@ fn process_efuse_definitions(efuse_fields: &mut EfuseFields) -> Result<()> {
 fn generate_efuse_definitions(espflash_path: &Path, efuse_fields: EfuseFields) -> Result<()> {
     let targets_efuse_path = espflash_path
         .join("src")
-        .join("targets")
+        .join("target")
         .join("efuse")
         .canonicalize()?;
 
@@ -272,7 +272,7 @@ fn generate_efuse_constants(
         writeln!(writer, "/// {description}")?;
         writeln!(
             writer,
-            "pub(crate) const {}: EfuseField = EfuseField::new({}, {}, {}, {});",
+            "pub const {}: EfuseField = EfuseField::new({}, {}, {}, {});",
             name, block, word, start, len
         )?;
     }


### PR DESCRIPTION
Major change here is making the eFuse field definitions public. There was a minor change for the P4 which required some updates to read the version correctly again.

Also removed unnecessary parameters/Result types from a couple functions which do not require them.