### PR TITLE
Show progress when skipping and verifying

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - All methods on the now removed `Target` & `ReadEFuse`, `UsbOtg` and `RtcWdtReset` traits have been implemented directly on (#891)
 - Update checks can now be skipped by setting the the `ESPFLASH_SKIP_UPDATE_CHECK` environment variable (#900)
 - `flash_write_size` and `max_ram_block_size` functions no longer take a connection parameter and return a Result type (#903)
-- `EmptyProgressCallbacks` which implements `ProgressCallbacks` but all methods are no-ops (#904)
+- `DefaultProgressCallback` which implements `ProgressCallbacks` but all methods are no-ops (#904)
 
 ### Changed
 
@@ -66,6 +66,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Test data is now excluded from the crates.io release (#897)
 - The command module, and `Command` related structs now exist in a top level module, instead of the `connection` module (#901)
 - API's that take `Option<&mut dyn ProgressCallbacks>` now take `&mut dyn ProgressCallbacks` instead (#904)
+- `ProgressCallbacks::finish()` now has a `skipped: bool` parameter to indicate if a segment was skipped (#904)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - All methods on the now removed `Target` & `ReadEFuse`, `UsbOtg` and `RtcWdtReset` traits have been implemented directly on (#891)
 - Update checks can now be skipped by setting the the `ESPFLASH_SKIP_UPDATE_CHECK` environment variable (#900)
 - `flash_write_size` and `max_ram_block_size` functions no longer take a connection parameter and return a Result type (#903)
+- `EmptyProgressCallbacks` which implements `ProgressCallbacks` but all methods are no-ops (#904)
 
 ### Changed
 
@@ -58,13 +59,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `Flasher::into_serial` has been replaced by `Flasher::into_connection` (#882)
 - Automatically migrate `espflash@3` configuration files to the new format (#883)
 - Update dependencies to their latest versions (#893)
-- `ProgressCallbacks` has moved to `flasher` (#891)
 - `Chip::crystal_freq` has been renamed to `Chip::xtal_frequency` (#891)
 - `Chip::chip_revision` has been renamed to `Chip::revision` (also applies to `minor` and `major`) (#891)
 - Any reference to `esp_idf` or `EspIdf` has been cut to just `idf` (#891)
 - Renamed `targets` module to `target` (#891)
 - Test data is now excluded from the crates.io release (#897)
-- The command module, and `Command` related structs now exist in a top level module, instead of the `connection` module (#901) 
+- The command module, and `Command` related structs now exist in a top level module, instead of the `connection` module (#901)
+- API's that take `Option<&mut dyn ProgressCallbacks>` now take `&mut dyn ProgressCallbacks` instead (#904)
 
 ### Fixed
 
@@ -79,6 +80,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - espflash now extracts the MMU page size from the app descriptor (#835)
 - `ResetBeforeOperation` & `ResetAfterOperation` are now public, to allow the creation of a `Connection` (#895)
 - `Flasher` now respects its internal `verify` and `skip` flags for all methods. (#901)
+- Progress is now reported on skipped segments and verification (#904)
 
 ### Removed
 

--- a/cargo-espflash/src/main.rs
+++ b/cargo-espflash/src/main.rs
@@ -242,7 +242,7 @@ fn main() -> Result<()> {
         subcommand: args,
         skip_update_check,
     } = cli.subcommand;
-    debug!("{:#?}, {:#?}", args, skip_update_check);
+    debug!("{args:#?}, {skip_update_check:#?}");
 
     // Only check for updates once the command-line arguments have been processed,
     // to avoid printing any update notifications when the help message is
@@ -581,7 +581,7 @@ fn build(
             }
             Message::CompilerMessage(message) => {
                 if let Some(rendered) = message.message.rendered {
-                    print!("{}", rendered);
+                    print!("{rendered}");
                 }
             }
             // Ignore all other messages.

--- a/cargo-espflash/src/main.rs
+++ b/cargo-espflash/src/main.rs
@@ -366,7 +366,7 @@ fn flash(args: FlashArgs, config: &Config) -> Result<()> {
         .or_else(|| Some(FlashSize::default())); // Otherwise, use a reasonable default value
 
     if args.flash_args.ram {
-        flasher.load_elf_to_ram(&elf_data, Some(&mut EspflashProgress::default()))?;
+        flasher.load_elf_to_ram(&elf_data, &mut EspflashProgress::default())?;
     } else {
         let flash_data = make_flash_data(
             args.flash_args.image,

--- a/espflash/src/bin/espflash.rs
+++ b/espflash/src/bin/espflash.rs
@@ -279,7 +279,7 @@ fn flash(args: FlashArgs, config: &Config) -> Result<()> {
         .or_else(|| Some(FlashSize::default())); // Otherwise, use a reasonable default value
 
     if args.flash_args.ram {
-        flasher.load_elf_to_ram(&elf_data, Some(&mut EspflashProgress::default()))?;
+        flasher.load_elf_to_ram(&elf_data, &mut EspflashProgress::default())?;
     } else {
         let flash_data = make_flash_data(
             args.flash_args.image,

--- a/espflash/src/cli/config.rs
+++ b/espflash/src/cli/config.rs
@@ -61,7 +61,7 @@ fn serialize_u16_to_hex<S>(decimal: &u16, serializer: S) -> Result<S::Ok, S::Err
 where
     S: serde::Serializer,
 {
-    let hex_string = format!("{:04x}", decimal);
+    let hex_string = format!("{decimal:04x}");
     serializer.serialize_str(&hex_string)
 }
 

--- a/espflash/src/cli/mod.rs
+++ b/espflash/src/cli/mod.rs
@@ -480,7 +480,7 @@ pub fn checksum_md5(args: &ChecksumMd5Args, config: &Config) -> Result<()> {
     let mut flasher = connect(&args.connect_args, config, true, true)?;
 
     let checksum = flasher.checksum_md5(args.address, args.size)?;
-    println!("0x{:x}", checksum);
+    println!("0x{checksum:x}");
 
     let chip = flasher.chip();
     flasher
@@ -619,7 +619,7 @@ pub fn print_board_info(flasher: &mut Flasher) -> Result<()> {
     println!("Features:          {}", info.features.join(", "));
 
     if let Some(mac) = info.mac_address {
-        println!("MAC address:       {}", mac);
+        println!("MAC address:       {mac}");
     }
 
     Ok(())

--- a/espflash/src/cli/mod.rs
+++ b/espflash/src/cli/mod.rs
@@ -766,7 +766,7 @@ impl ProgressCallbacks for EspflashProgress {
     }
 
     /// End the progress bar
-    fn finish(&mut self) {
+    fn finish(&mut self, _skipped: bool) {
         if let Some(ref pb) = self.pb {
             pb.finish();
         }

--- a/espflash/src/cli/mod.rs
+++ b/espflash/src/cli/mod.rs
@@ -47,7 +47,6 @@ use crate::{
         FlashSettings,
         FlashSize,
         Flasher,
-        ProgressCallbacks,
     },
     image_format::{
         ImageFormat,
@@ -55,7 +54,7 @@ use crate::{
         Metadata,
         idf::{IdfBootloaderFormat, parse_partition_table},
     },
-    target::{Chip, XtalFrequency},
+    target::{Chip, ProgressCallbacks, XtalFrequency},
 };
 
 pub mod config;
@@ -827,7 +826,7 @@ pub fn erase_region(args: EraseRegionArgs, config: &Config) -> Result<()> {
 
 /// Write an ELF image to a target device's flash
 pub fn flash_image<'a>(flasher: &mut Flasher, image_format: ImageFormat<'a>) -> Result<()> {
-    flasher.load_image_to_flash(Some(&mut EspflashProgress::default()), image_format)?;
+    flasher.load_image_to_flash(&mut EspflashProgress::default(), image_format)?;
     info!("Flashing has completed!");
 
     Ok(())
@@ -1117,11 +1116,7 @@ pub fn write_bin(args: WriteBinArgs, config: &Config) -> Result<()> {
     let chip = flasher.chip();
     let target_xtal_freq = chip.xtal_frequency(flasher.connection())?;
 
-    flasher.write_bin_to_flash(
-        args.address,
-        &buffer,
-        Some(&mut EspflashProgress::default()),
-    )?;
+    flasher.write_bin_to_flash(args.address, &buffer, &mut EspflashProgress::default())?;
 
     if args.monitor {
         let pid = flasher.connection().usb_pid();

--- a/espflash/src/cli/monitor/mod.rs
+++ b/espflash/src/cli/monitor/mod.rs
@@ -67,7 +67,7 @@ impl RawModeGuard {
 impl Drop for RawModeGuard {
     fn drop(&mut self) {
         if let Err(e) = disable_raw_mode() {
-            error!("Failed to disable raw_mode: {:#}", e)
+            error!("Failed to disable raw_mode: {e:#}")
         }
     }
 }
@@ -90,7 +90,7 @@ pub fn monitor(
     }
 
     let baud = monitor_args.monitor_baud;
-    debug!("Opening serial monitor with baudrate: {}", baud);
+    debug!("Opening serial monitor with baudrate: {baud}");
 
     // Explicitly set the baud rate when starting the serial monitor, to allow using
     // different rates for flashing.

--- a/espflash/src/cli/monitor/parser/mod.rs
+++ b/espflash/src/cli/monitor/parser/mod.rs
@@ -38,7 +38,7 @@ fn resolve_addresses(
         let location = symbols.location(addr);
 
         if let Some(name) = name {
-            let output = if line.trim() == format!("0x{:x}", addr) {
+            let output = if line.trim() == format!("0x{addr:x}") {
                 if let Some((file, line_num)) = location {
                     format!("{name}\r\n    at {file}:{line_num}\r\n")
                 } else {

--- a/espflash/src/cli/serial.rs
+++ b/espflash/src/cli/serial.rs
@@ -58,7 +58,7 @@ pub fn serial_port_info(matches: &ConnectArgs, config: &Config) -> Result<Serial
                             pid: usb_info.pid,
                         })
                     }) {
-                        error!("Failed to save config {:#}", e);
+                        error!("Failed to save config {e:#}");
                     }
                 }
             }
@@ -190,7 +190,7 @@ fn select_serial_port(
                 match &port_info.port_type {
                     SerialPortType::UsbPort(info) => {
                         if let Some(product) = &info.product {
-                            format!("{} - {}", formatted, product)
+                            format!("{formatted} - {product}")
                         } else {
                             formatted.to_string()
                         }
@@ -242,9 +242,9 @@ fn confirm_port(port_name: &str, product: Option<&String>) -> Result<bool, Error
     Confirm::with_theme(&ColorfulTheme::default())
         .with_prompt({
             if let Some(product) = product {
-                format!("Use serial port '{}' - {}?", port_name, product)
+                format!("Use serial port '{port_name}' - {product}?")
             } else {
-                format!("Use serial port '{}'?", port_name)
+                format!("Use serial port '{port_name}'?")
             }
         })
         .interact_opt()?

--- a/espflash/src/command.rs
+++ b/espflash/src/command.rs
@@ -152,8 +152,7 @@ impl CommandType {
             CommandType::FlashDeflEnd => FLASH_DEFLATE_END_TIMEOUT,
             CommandType::FlashMd5 => {
                 log::warn!(
-                    "Using default timeout for {}, this may not be sufficient for large flash regions. Consider using `timeout_for_size` instead.",
-                    self
+                    "Using default timeout for {self}, this may not be sufficient for large flash regions. Consider using `timeout_for_size` instead."
                 );
 
                 DEFAULT_TIMEOUT

--- a/espflash/src/connection/mod.rs
+++ b/espflash/src/connection/mod.rs
@@ -99,7 +99,7 @@ impl Connection {
                     return Ok(());
                 }
                 Err(e) => {
-                    debug!("Failed to reset, error {:#?}, retrying", e);
+                    debug!("Failed to reset, error {e:#?}, retrying");
                 }
             }
         }
@@ -157,8 +157,8 @@ impl Connection {
                 download_mode = data.get(2).is_some();
 
                 // Further processing or printing the results
-                debug!("Boot Mode: {}", boot_mode);
-                debug!("Download Mode: {}", download_mode);
+                debug!("Boot Mode: {boot_mode}");
+                debug!("Download Mode: {download_mode}");
             };
         }
 
@@ -443,7 +443,7 @@ impl Connection {
 
     /// Write a command to the serial port.
     pub fn write_command(&mut self, command: Command<'_>) -> Result<(), Error> {
-        debug!("Writing command: {:02x?}", command);
+        debug!("Writing command: {command:02x?}");
         let mut binding = Box::new(&mut self.serial);
         let serial = binding.as_mut();
 
@@ -569,7 +569,7 @@ impl Connection {
         } else {
             self.read_reg(CHIP_DETECT_MAGIC_REG_ADDR)?
         };
-        debug!("Read chip magic value: 0x{:08x}", magic);
+        debug!("Read chip magic value: 0x{magic:08x}");
         Chip::from_magic(magic)
     }
 }

--- a/espflash/src/error.rs
+++ b/espflash/src/error.rs
@@ -441,7 +441,7 @@ pub struct TimedOutCommand {
 impl Display for TimedOutCommand {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match &self.command {
-            Some(command) => write!(f, "{} ", command),
+            Some(command) => write!(f, "{command} "),
             None => Ok(()),
         }
     }

--- a/espflash/src/flasher/mod.rs
+++ b/espflash/src/flasher/mod.rs
@@ -20,9 +20,10 @@ use serde::{Deserialize, Serialize};
 use strum::{Display, EnumIter, IntoEnumIterator, VariantNames};
 
 #[cfg(feature = "serialport")]
+use crate::target::{EmptyProgressCallbacks, ProgressCallbacks};
 use crate::{
     Error,
-    target::{Chip, EmptyProgressCallbacks, ProgressCallbacks, XtalFrequency},
+    target::{Chip, XtalFrequency},
 };
 #[cfg(feature = "serialport")]
 use crate::{

--- a/espflash/src/flasher/mod.rs
+++ b/espflash/src/flasher/mod.rs
@@ -19,9 +19,10 @@ use object::{Endianness, read::elf::ElfFile32 as ElfFile};
 use serde::{Deserialize, Serialize};
 use strum::{Display, EnumIter, IntoEnumIterator, VariantNames};
 
+#[cfg(feature = "serialport")]
 use crate::{
     Error,
-    target::{Chip, XtalFrequency},
+    target::{Chip, EmptyProgressCallbacks, ProgressCallbacks, XtalFrequency},
 };
 #[cfg(feature = "serialport")]
 use crate::{
@@ -48,16 +49,6 @@ pub(crate) const TRY_SPI_PARAMS: [SpiAttachParams; 2] =
 #[cfg(feature = "serialport")]
 pub(crate) const FLASH_SECTOR_SIZE: usize = 0x1000;
 pub(crate) const FLASH_WRITE_SIZE: usize = 0x400;
-
-/// Progress update callbacks
-pub trait ProgressCallbacks {
-    /// Initialize some progress report
-    fn init(&mut self, addr: u32, total: usize);
-    /// Update some progress report
-    fn update(&mut self, current: usize);
-    /// Finish some progress report
-    fn finish(&mut self);
-}
 
 /// Security Info Response containing
 #[derive(Debug)]
@@ -762,7 +753,7 @@ impl Flasher {
                     addr: text_addr,
                     data: Cow::Borrowed(&text),
                 },
-                &mut None,
+                &mut EmptyProgressCallbacks,
             )
             .flashing()?;
 
@@ -776,7 +767,7 @@ impl Flasher {
                     addr: data_addr,
                     data: Cow::Borrowed(&data),
                 },
-                &mut None,
+                &mut EmptyProgressCallbacks,
             )
             .flashing()?;
 
@@ -1013,7 +1004,7 @@ impl Flasher {
     pub fn load_elf_to_ram(
         &mut self,
         elf_data: &[u8],
-        mut progress: Option<&mut dyn ProgressCallbacks>,
+        progress: &mut dyn ProgressCallbacks,
     ) -> Result<(), Error> {
         let elf = ElfFile::parse(elf_data)?;
         if rom_segments(self.chip, &elf).next().is_some() {
@@ -1028,7 +1019,7 @@ impl Flasher {
 
         for segment in ram_segments(self.chip, &elf) {
             target
-                .write_segment(&mut self.connection, segment, &mut progress)
+                .write_segment(&mut self.connection, segment, progress)
                 .flashing()?;
         }
 
@@ -1038,7 +1029,7 @@ impl Flasher {
     /// Load an ELF image to flash and execute it
     pub fn load_image_to_flash<'a>(
         &mut self,
-        mut progress: Option<&mut dyn ProgressCallbacks>,
+        progress: &mut dyn ProgressCallbacks,
         image_format: ImageFormat<'a>,
     ) -> Result<(), Error> {
         let mut target =
@@ -1060,7 +1051,7 @@ impl Flasher {
 
         for segment in image_format.flash_segments() {
             target
-                .write_segment(&mut self.connection, segment, &mut progress)
+                .write_segment(&mut self.connection, segment, progress)
                 .flashing()?;
         }
 
@@ -1074,7 +1065,7 @@ impl Flasher {
         &mut self,
         addr: u32,
         data: &[u8],
-        progress: Option<&mut dyn ProgressCallbacks>,
+        progress: &mut dyn ProgressCallbacks,
     ) -> Result<(), Error> {
         let segment = Segment {
             addr,
@@ -1091,7 +1082,7 @@ impl Flasher {
     pub fn write_bins_to_flash(
         &mut self,
         segments: &[Segment<'_>],
-        mut progress: Option<&mut dyn ProgressCallbacks>,
+        progress: &mut dyn ProgressCallbacks,
     ) -> Result<(), Error> {
         if self.connection.secure_download_mode {
             return Err(Error::UnsupportedFeature {
@@ -1107,7 +1098,7 @@ impl Flasher {
         target.begin(&mut self.connection).flashing()?;
 
         for segment in segments {
-            target.write_segment(&mut self.connection, segment.borrow(), &mut progress)?;
+            target.write_segment(&mut self.connection, segment.borrow(), progress)?;
         }
 
         target.finish(&mut self.connection, true).flashing()?;

--- a/espflash/src/flasher/mod.rs
+++ b/espflash/src/flasher/mod.rs
@@ -139,23 +139,23 @@ impl fmt::Display for SecurityInfo {
         let key_purposes_str = self
             .key_purposes
             .iter()
-            .map(|b| format!("{}", b))
+            .map(|b| format!("{b}"))
             .collect::<Vec<_>>()
             .join(", ");
 
         writeln!(f, "\nSecurity Information:")?;
         writeln!(f, "=====================")?;
         writeln!(f, "Flags: {:#010x} ({:b})", self.flags, self.flags)?;
-        writeln!(f, "Key Purposes: [{}]", key_purposes_str)?;
+        writeln!(f, "Key Purposes: [{key_purposes_str}]")?;
 
         // Only print Chip ID if it's Some(value)
         if let Some(chip_id) = self.chip_id {
-            writeln!(f, "Chip ID: {}", chip_id)?;
+            writeln!(f, "Chip ID: {chip_id}")?;
         }
 
         // Only print API Version if it's Some(value)
         if let Some(api_version) = self.eco_version {
-            writeln!(f, "API Version: {}", api_version)?;
+            writeln!(f, "API Version: {api_version}")?;
         }
 
         // Secure Boot
@@ -173,7 +173,7 @@ impl fmt::Display for SecurityInfo {
             .iter()
             .enumerate()
             .filter(|(_, key)| self.security_flag_status(key))
-            .map(|(i, _)| format!("Secure Boot Key{} is Revoked", i))
+            .map(|(i, _)| format!("Secure Boot Key{i} is Revoked"))
             .collect();
 
             if !revoked_keys.is_empty() {
@@ -784,7 +784,7 @@ impl Flasher {
 
         // Re-detect chip to check stub is up
         let chip = self.connection.detect_chip(self.use_stub)?;
-        debug!("Re-detected chip: {:?}", chip);
+        debug!("Re-detected chip: {chip:?}");
 
         Ok(())
     }
@@ -793,7 +793,7 @@ impl Flasher {
         // Loop over all available SPI parameters until we find one that successfully
         // reads the flash size.
         for spi_params in TRY_SPI_PARAMS.iter().copied() {
-            debug!("Attempting flash enable with: {:?}", spi_params);
+            debug!("Attempting flash enable with: {spi_params:?}");
 
             // Send `SpiAttach` to enable flash, in some instances this command
             // may fail while the flash connection succeeds
@@ -847,8 +847,7 @@ impl Flasher {
             Ok(size) => size,
             Err(_) => {
                 warn!(
-                    "Could not detect flash size (FlashID=0x{:02X}, SizeID=0x{:02X}), defaulting to 4MB",
-                    flash_id, size_id
+                    "Could not detect flash size (FlashID=0x{flash_id:02X}, SizeID=0x{size_id:02X}), defaulting to 4MB"
                 );
                 FlashSize::default()
             }
@@ -1129,7 +1128,7 @@ impl Flasher {
 
     /// Change the baud rate of the connection.
     pub fn change_baud(&mut self, baud: u32) -> Result<(), Error> {
-        debug!("Change baud to: {}", baud);
+        debug!("Change baud to: {baud}");
 
         let prior_baud = match self.use_stub {
             true => self.connection.baud()?,
@@ -1163,7 +1162,7 @@ impl Flasher {
 
     /// Erase a region of flash.
     pub fn erase_region(&mut self, offset: u32, size: u32) -> Result<(), Error> {
-        debug!("Erasing region of 0x{:x}B at 0x{:08x}", size, offset);
+        debug!("Erasing region of 0x{size:x}B at 0x{offset:08x}");
 
         self.connection.with_timeout(
             CommandType::EraseRegion.timeout_for_size(size),
@@ -1255,7 +1254,7 @@ impl Flasher {
         max_in_flight: u32,
         file_path: PathBuf,
     ) -> Result<(), Error> {
-        debug!("Reading 0x{:x}B from 0x{:08x}", size, offset);
+        debug!("Reading 0x{size:x}B from 0x{offset:08x}");
 
         let mut data = Vec::new();
 

--- a/espflash/src/flasher/mod.rs
+++ b/espflash/src/flasher/mod.rs
@@ -20,7 +20,7 @@ use serde::{Deserialize, Serialize};
 use strum::{Display, EnumIter, IntoEnumIterator, VariantNames};
 
 #[cfg(feature = "serialport")]
-use crate::target::{EmptyProgressCallbacks, ProgressCallbacks};
+use crate::target::{DefaultProgressCallback, ProgressCallbacks};
 use crate::{
     Error,
     target::{Chip, XtalFrequency},
@@ -754,7 +754,7 @@ impl Flasher {
                     addr: text_addr,
                     data: Cow::Borrowed(&text),
                 },
-                &mut EmptyProgressCallbacks,
+                &mut DefaultProgressCallback,
             )
             .flashing()?;
 
@@ -768,7 +768,7 @@ impl Flasher {
                     addr: data_addr,
                     data: Cow::Borrowed(&data),
                 },
-                &mut EmptyProgressCallbacks,
+                &mut DefaultProgressCallback,
             )
             .flashing()?;
 

--- a/espflash/src/image_format/idf.rs
+++ b/espflash/src/image_format/idf.rs
@@ -400,7 +400,7 @@ impl<'a> IdfBootloaderFormat<'a> {
             .unwrap_or(&[IROM_ALIGN]);
         let valid_page_sizes_string = valid_page_sizes
             .iter()
-            .map(|size| format!("{:#x}", size))
+            .map(|size| format!("{size:#x}"))
             .collect::<Vec<_>>()
             .join(", ");
         let app_desc_mmu_page_size = if let Some(address) = app_desc_addr {
@@ -439,9 +439,8 @@ impl<'a> IdfBootloaderFormat<'a> {
 
                 if page_size.is_none() {
                     warn!(
-                        "The app descriptor is placed at {:#x} which is not aligned to any of the \
-                        supported page sizes: {}",
-                        address, valid_page_sizes_string
+                        "The app descriptor is placed at {address:#x} which is not aligned to any of the \
+                        supported page sizes: {valid_page_sizes_string}"
                     );
                     return Err(AppDescriptorError::IncorrectDescriptorAlignment.into());
                 }
@@ -464,8 +463,7 @@ impl<'a> IdfBootloaderFormat<'a> {
 
         if !valid_page_sizes.contains(&mmu_page_size) {
             warn!(
-                "MMU page size {:#x} is not supported. Supported page sizes are: {}",
-                mmu_page_size, valid_page_sizes_string
+                "MMU page size {mmu_page_size:#x} is not supported. Supported page sizes are: {valid_page_sizes_string}"
             );
             return Err(AppDescriptorError::IncorrectDescriptorAlignment.into());
         };
@@ -858,11 +856,11 @@ mod tests {
 
     #[test]
     fn test_encode_hex() {
-        assert_eq!(encode_hex(&[0u8]), "00");
-        assert_eq!(encode_hex(&[10u8]), "0a");
-        assert_eq!(encode_hex(&[255u8]), "ff");
+        assert_eq!(encode_hex([0u8]), "00");
+        assert_eq!(encode_hex([10u8]), "0a");
+        assert_eq!(encode_hex([255u8]), "ff");
 
-        assert_eq!(encode_hex(&[222u8, 202, 251, 173]), "decafbad");
+        assert_eq!(encode_hex([222u8, 202, 251, 173]), "decafbad");
     }
 
     #[test]

--- a/espflash/src/target/flash_target/esp32.rs
+++ b/espflash/src/target/flash_target/esp32.rs
@@ -146,7 +146,7 @@ impl FlashTarget for Esp32Target {
                     addr
                 );
 
-                progress.finish();
+                progress.finish(true);
                 return Ok(());
             }
         }
@@ -212,7 +212,7 @@ impl FlashTarget for Esp32Target {
             progress.update(num_chunks + 1)
         }
 
-        progress.finish();
+        progress.finish(false);
 
         Ok(())
     }

--- a/espflash/src/target/flash_target/esp32.rs
+++ b/espflash/src/target/flash_target/esp32.rs
@@ -141,10 +141,7 @@ impl FlashTarget for Esp32Target {
             )?;
 
             if checksum_md5.as_slice() == flash_checksum_md5.to_be_bytes() {
-                debug!(
-                    "Segment at address '0x{:x}' has not changed, skipping write",
-                    addr
-                );
+                debug!("Segment at address '0x{addr:x}' has not changed, skipping write");
 
                 progress.finish(true);
                 return Ok(());
@@ -208,7 +205,7 @@ impl FlashTarget for Esp32Target {
             if checksum_md5.as_slice() != flash_checksum_md5.to_be_bytes() {
                 return Err(Error::VerifyFailed);
             }
-            debug!("Segment at address '0x{:x}' verified successfully", addr);
+            debug!("Segment at address '0x{addr:x}' verified successfully");
             progress.update(num_chunks + 1)
         }
 

--- a/espflash/src/target/flash_target/mod.rs
+++ b/espflash/src/target/flash_target/mod.rs
@@ -1,5 +1,5 @@
 pub use self::{esp32::Esp32Target, ram::RamTarget};
-use crate::{Error, connection::Connection, flasher::ProgressCallbacks, image_format::Segment};
+use crate::{Error, connection::Connection, image_format::Segment};
 
 mod esp32;
 mod ram;
@@ -14,9 +14,29 @@ pub trait FlashTarget {
         &mut self,
         connection: &mut Connection,
         segment: Segment<'_>,
-        progress: &mut Option<&mut dyn ProgressCallbacks>,
+        progress: &mut dyn ProgressCallbacks,
     ) -> Result<(), Error>;
 
     /// Complete the flashing operation
     fn finish(&mut self, connection: &mut Connection, reboot: bool) -> Result<(), Error>;
+}
+
+/// Progress update callbacks
+pub trait ProgressCallbacks {
+    /// Initialize some progress report
+    fn init(&mut self, addr: u32, total: usize);
+    /// Update some progress report
+    fn update(&mut self, current: usize);
+    /// Finish some progress report
+    fn finish(&mut self);
+}
+
+/// An empty implementation of [ProgressCallbacks] that does nothing.
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq)]
+pub struct EmptyProgressCallbacks;
+
+impl ProgressCallbacks for EmptyProgressCallbacks {
+    fn init(&mut self, _addr: u32, _total: usize) {}
+    fn update(&mut self, _current: usize) {}
+    fn finish(&mut self) {}
 }

--- a/espflash/src/target/flash_target/mod.rs
+++ b/espflash/src/target/flash_target/mod.rs
@@ -4,12 +4,12 @@ use crate::{Error, connection::Connection, image_format::Segment};
 mod esp32;
 mod ram;
 
-/// Operations for interacting with a flash target
+/// Operations for interacting with a flash target.
 pub trait FlashTarget {
-    /// Begin the flashing operation
+    /// Begin the flashing operation.
     fn begin(&mut self, connection: &mut Connection) -> Result<(), Error>;
 
-    /// Write a segment to the target device
+    /// Write a segment to the target device.
     fn write_segment(
         &mut self,
         connection: &mut Connection,
@@ -17,26 +17,26 @@ pub trait FlashTarget {
         progress: &mut dyn ProgressCallbacks,
     ) -> Result<(), Error>;
 
-    /// Complete the flashing operation
+    /// Complete the flashing operation.
     fn finish(&mut self, connection: &mut Connection, reboot: bool) -> Result<(), Error>;
 }
 
-/// Progress update callbacks
+/// Progress update callbacks.
 pub trait ProgressCallbacks {
-    /// Initialize some progress report
+    /// Initialize some progress report.
     fn init(&mut self, addr: u32, total: usize);
-    /// Update some progress report
+    /// Update some progress report.
     fn update(&mut self, current: usize);
-    /// Finish some progress report
-    fn finish(&mut self);
+    /// Finish some progress report.
+    fn finish(&mut self, skipped: bool);
 }
 
 /// An empty implementation of [ProgressCallbacks] that does nothing.
 #[derive(Copy, Clone, Debug, Default, PartialEq, Eq)]
-pub struct EmptyProgressCallbacks;
+pub struct DefaultProgressCallback;
 
-impl ProgressCallbacks for EmptyProgressCallbacks {
+impl ProgressCallbacks for DefaultProgressCallback {
     fn init(&mut self, _addr: u32, _total: usize) {}
     fn update(&mut self, _current: usize) {}
-    fn finish(&mut self) {}
+    fn finish(&mut self, _skipped: bool) {}
 }

--- a/espflash/src/target/flash_target/ram.rs
+++ b/espflash/src/target/flash_target/ram.rs
@@ -68,7 +68,7 @@ impl FlashTarget for RamTarget {
             progress.update(i + 1)
         }
 
-        progress.finish();
+        progress.finish(false);
 
         Ok(())
     }

--- a/espflash/src/target/mod.rs
+++ b/espflash/src/target/mod.rs
@@ -10,7 +10,14 @@ use serde::{Deserialize, Serialize};
 use strum::{Display, EnumIter, EnumString, IntoEnumIterator, VariantNames};
 
 #[cfg(feature = "serialport")]
-pub use self::flash_target::{Esp32Target, FlashTarget, RamTarget};
+pub use self::flash_target::{
+    EmptyProgressCallbacks,
+    Esp32Target,
+    FlashTarget,
+    ProgressCallbacks,
+    RamTarget,
+};
+#[cfg(feature = "serialport")]
 use crate::{
     Error,
     flasher::{FLASH_WRITE_SIZE, FlashFrequency},

--- a/espflash/src/target/mod.rs
+++ b/espflash/src/target/mod.rs
@@ -11,7 +11,7 @@ use strum::{Display, EnumIter, EnumString, IntoEnumIterator, VariantNames};
 
 #[cfg(feature = "serialport")]
 pub use self::flash_target::{
-    EmptyProgressCallbacks,
+    DefaultProgressCallback,
     Esp32Target,
     FlashTarget,
     ProgressCallbacks,

--- a/espflash/src/target/mod.rs
+++ b/espflash/src/target/mod.rs
@@ -17,7 +17,6 @@ pub use self::flash_target::{
     ProgressCallbacks,
     RamTarget,
 };
-#[cfg(feature = "serialport")]
 use crate::{
     Error,
     flasher::{FLASH_WRITE_SIZE, FlashFrequency},

--- a/espflash/src/target/mod.rs
+++ b/espflash/src/target/mod.rs
@@ -804,7 +804,7 @@ impl Chip {
 
         let mac_addr = bytes
             .iter()
-            .map(|b| format!("{:02x}", b))
+            .map(|b| format!("{b:02x}"))
             .collect::<Vec<_>>()
             .join(":");
 

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -275,8 +275,7 @@ fn generate_efuse_constants(
         writeln!(writer, "/// {description}")?;
         writeln!(
             writer,
-            "pub const {}: EfuseField = EfuseField::new({}, {}, {}, {});",
-            name, block, word, start, len
+            "pub const {name}: EfuseField = EfuseField::new({block}, {word}, {start}, {len});"
         )?;
     }
 


### PR DESCRIPTION
The progress callbacks get initialized and updated even if we skip a segment. For verification, we add an extra step to the progress which is updated once verification is complete.