### PR TITLE
Move non-interactive flag to connect args

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Update checks can now be skipped by setting the the `ESPFLASH_SKIP_UPDATE_CHECK` environment variable (#900)
 - `flash_write_size` and `max_ram_block_size` functions no longer take a connection parameter and return a Result type (#903)
 - `DefaultProgressCallback` which implements `ProgressCallbacks` but all methods are no-ops (#904)
+- Update checks can now be skipped by setting the `ESPFLASH_SKIP_UPDATE_CHECK` environment variable (#900)
 
 ### Changed
 
@@ -82,6 +83,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `ResetBeforeOperation` & `ResetAfterOperation` are now public, to allow the creation of a `Connection` (#895)
 - `Flasher` now respects its internal `verify` and `skip` flags for all methods. (#901)
 - Progress is now reported on skipped segments and verification (#904)
+- Moved the `non-interactive` flag to `ConnectArgs` so we also avoid asking the user to select a port (#906)
 
 ### Removed
 

--- a/cargo-espflash/src/main.rs
+++ b/cargo-espflash/src/main.rs
@@ -348,7 +348,11 @@ fn flash(args: FlashArgs, config: &Config) -> Result<()> {
     let mut monitor_args = args.flash_args.monitor_args;
     monitor_args.elf = Some(build_ctx.artifact_path.clone());
 
-    check_monitor_args(&args.flash_args.monitor, &monitor_args)?;
+    check_monitor_args(
+        &args.flash_args.monitor,
+        &monitor_args,
+        args.connect_args.non_interactive,
+    )?;
     check_idf_args(
         args.format,
         &args.flash_args.erase_parts,
@@ -419,6 +423,7 @@ fn flash(args: FlashArgs, config: &Config) -> Result<()> {
             Some(&elf_data),
             pid,
             monitor_args,
+            args.connect_args.non_interactive,
         )
     } else {
         Ok(())

--- a/espflash/src/bin/espflash.rs
+++ b/espflash/src/bin/espflash.rs
@@ -234,7 +234,11 @@ fn erase_parts(args: ErasePartsArgs, config: &Config) -> Result<()> {
 fn flash(args: FlashArgs, config: &Config) -> Result<()> {
     let mut monitor_args = args.flash_args.monitor_args;
     monitor_args.elf = Some(args.image.clone());
-    check_monitor_args(&args.flash_args.monitor, &monitor_args)?;
+    check_monitor_args(
+        &args.flash_args.monitor,
+        &monitor_args,
+        args.connect_args.non_interactive,
+    )?;
     check_idf_args(
         args.format,
         &args.flash_args.erase_parts,
@@ -332,6 +336,7 @@ fn flash(args: FlashArgs, config: &Config) -> Result<()> {
             Some(&elf_data),
             pid,
             monitor_args,
+            args.connect_args.non_interactive,
         )
     } else {
         Ok(())

--- a/espflash/src/cli/serial.rs
+++ b/espflash/src/cli/serial.rs
@@ -41,6 +41,9 @@ pub fn serial_port_info(matches: &ConnectArgs, config: &Config) -> Result<Serial
         find_serial_port(&ports, serial)
     } else {
         let ports = detect_usb_serial_ports(matches.list_all_ports).unwrap_or_default();
+        if ports.len() > 1 && matches.non_interactive {
+            return Err(Error::SerialNotSelected);
+        }
         let (port, matches) = select_serial_port(ports, &config.port_config, matches.confirm_port)?;
         match &port.port_type {
             SerialPortType::UsbPort(usb_info) if !matches => {

--- a/espflash/src/error.rs
+++ b/espflash/src/error.rs
@@ -154,6 +154,15 @@ pub enum Error {
     )]
     SerialNotFound(String),
 
+    #[error("No serial port was provided")]
+    #[diagnostic(
+        code(espflash::serial_not_selected),
+        help(
+            "Make sure to provide a serial port via argument, environment variable or configuration file when using the `--non-interactive` flag"
+        )
+    )]
+    SerialNotSelected,
+
     #[error("The {chip} does not support {feature}")]
     #[diagnostic(code(espflash::unsupported_feature))]
     UnsupportedFeature { chip: Chip, feature: String },


### PR DESCRIPTION
Moved the `non-interactive` flag to `ConnectArgs` so we also avoid asking the user to select a port. The logic added is the following: When using `non-interactive`, it will use any of the selected ports (via flag, environment variable or config file) and if no port was selected it will: Detect the number of ports, if there is only one, it will use this one, if there are multiple ports it will throw an error (MacOs usually duplicates ports so its not ideal, maybe we should error if >2 on macos?)