### PR TITLE
Indicate in CLI when a partition was skipped or being verified, fix incorrect chunk size being shown.

### DIFF
--- a/espflash/src/target/flash_target/esp32.rs
+++ b/espflash/src/target/flash_target/esp32.rs
@@ -125,7 +125,7 @@ impl FlashTarget for Esp32Target {
         let chunks = compressed.chunks(flash_write_size);
         let num_chunks = chunks.len();
 
-        progress.init(addr, num_chunks + self.verify as usize);
+        progress.init(addr, num_chunks);
 
         if self.skip {
             let flash_checksum_md5: u128 = connection.with_timeout(
@@ -190,6 +190,7 @@ impl FlashTarget for Esp32Target {
         }
 
         if self.verify {
+            progress.verifying();
             let flash_checksum_md5: u128 = connection.with_timeout(
                 CommandType::FlashMd5.timeout_for_size(segment.data.len() as u32),
                 |connection| {
@@ -206,7 +207,6 @@ impl FlashTarget for Esp32Target {
                 return Err(Error::VerifyFailed);
             }
             debug!("Segment at address '0x{addr:x}' verified successfully");
-            progress.update(num_chunks + 1)
         }
 
         progress.finish(false);

--- a/espflash/src/target/flash_target/mod.rs
+++ b/espflash/src/target/flash_target/mod.rs
@@ -27,6 +27,8 @@ pub trait ProgressCallbacks {
     fn init(&mut self, addr: u32, total: usize);
     /// Update some progress report.
     fn update(&mut self, current: usize);
+    /// Indicate post-flash checksum verification has begun.
+    fn verifying(&mut self);
     /// Finish some progress report.
     fn finish(&mut self, skipped: bool);
 }
@@ -38,5 +40,6 @@ pub struct DefaultProgressCallback;
 impl ProgressCallbacks for DefaultProgressCallback {
     fn init(&mut self, _addr: u32, _total: usize) {}
     fn update(&mut self, _current: usize) {}
+    fn verifying(&mut self) {}
     fn finish(&mut self, _skipped: bool) {}
 }


### PR DESCRIPTION
This is meant to extend #904 to utilize the "skipped" flag in CLI, show an example usage of the `verifying` [signal I suggested](https://github.com/esp-rs/espflash/issues/794#issuecomment-3006635559) in the conversation in #794, and fix what I consider to be a (overall minor) mistake in #904.

Showcase for Verifying:

[Screencast_20250627_183019.webm](https://github.com/user-attachments/assets/4c6db327-b8f1-4736-8fb5-14b7784dfc7d)

Showcase for Skipping: 

[Screencast_20250627_182941.webm](https://github.com/user-attachments/assets/19d996f0-e97f-41b6-8a48-bbc4edc9fc53)

In the past, `espflash` seemed to pause for a moment during post-flash verification, and with #904, that was changed to add a ghost chunk to the reported total length of the segment that would be paused on during verification.

I personally disagree with this specific change, since it also changes the reported output to users on how large their uploads are, and could potentially lead some to the wrong idea on why things are taking extra time. So I chose to make it much more clear as to what actions are being taken.

Before #904:
![image](https://github.com/user-attachments/assets/479ff4b7-eade-4329-8985-0180460ae0db)

After #904:
![image](https://github.com/user-attachments/assets/f5663558-8e04-4afd-bd04-1cf18b28eb78)

(Note the +1 to each segment's reported length).
