### PR TITLE
Add app descriptor check to save image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- `save-image` now checks if the ELF contains the app descriptor (#920)
 
 ### Changed
 

--- a/cargo-espflash/src/main.rs
+++ b/cargo-espflash/src/main.rs
@@ -337,7 +337,7 @@ fn flash(args: FlashArgs, config: &Config) -> Result<()> {
     let elf_data = fs::read(build_ctx.artifact_path.clone()).into_diagnostic()?;
 
     // Check if the ELF contains the app descriptor, if required.
-    if args.flash_args.image.check_app_descriptor.unwrap_or(true) {
+    if args.flash_args.image.check_app_descriptor {
         check_idf_bootloader(&elf_data)?;
     }
 
@@ -616,6 +616,11 @@ fn save_image(args: SaveImageArgs, config: &Config) -> Result<()> {
 
     let build_ctx = build(&args.build_args, &cargo_config, args.save_image_args.chip)?;
     let elf_data = fs::read(&build_ctx.artifact_path).into_diagnostic()?;
+
+    // Check if the ELF contains the app descriptor, if required.
+    if args.save_image_args.image.check_app_descriptor {
+        check_idf_bootloader(&elf_data)?;
+    }
 
     // Since we have no `Flasher` instance and as such cannot print the board
     // information, we will print whatever information we _do_ have.

--- a/cargo-espflash/src/main.rs
+++ b/cargo-espflash/src/main.rs
@@ -15,7 +15,7 @@ use espflash::{
         *,
     },
     flasher::FlashSize,
-    image_format::{ImageFormat, ImageFormatKind, idf::check_idf_bootloader},
+    image_format::{ImageFormat, ImageFormatKind, idf::check_app_descriptor},
     logging::initialize_logger,
     target::{Chip, XtalFrequency},
     update::check_for_update,
@@ -336,9 +336,8 @@ fn flash(args: FlashArgs, config: &Config) -> Result<()> {
     // Read the ELF data from the build path and load it to the target.
     let elf_data = fs::read(build_ctx.artifact_path.clone()).into_diagnostic()?;
 
-    // Check if the ELF contains the app descriptor, if required.
-    if args.flash_args.image.check_app_descriptor {
-        check_idf_bootloader(&elf_data)?;
+    if args.flash_args.image.check_app_descriptor && args.format == ImageFormatKind::EspIdf {
+        check_app_descriptor(&elf_data)?;
     }
 
     let mut monitor_args = args.flash_args.monitor_args;
@@ -617,9 +616,8 @@ fn save_image(args: SaveImageArgs, config: &Config) -> Result<()> {
     let build_ctx = build(&args.build_args, &cargo_config, args.save_image_args.chip)?;
     let elf_data = fs::read(&build_ctx.artifact_path).into_diagnostic()?;
 
-    // Check if the ELF contains the app descriptor, if required.
-    if args.save_image_args.image.check_app_descriptor {
-        check_idf_bootloader(&elf_data)?;
+    if args.save_image_args.image.check_app_descriptor && args.format == ImageFormatKind::EspIdf {
+        check_app_descriptor(&elf_data)?;
     }
 
     // Since we have no `Flasher` instance and as such cannot print the board

--- a/cargo-espflash/src/main.rs
+++ b/cargo-espflash/src/main.rs
@@ -15,7 +15,7 @@ use espflash::{
         *,
     },
     flasher::FlashSize,
-    image_format::{ImageFormat, ImageFormatKind, idf::check_app_descriptor},
+    image_format::{ImageFormat, ImageFormatKind, idf::check_idf_bootloader},
     logging::initialize_logger,
     target::{Chip, XtalFrequency},
     update::check_for_update,
@@ -337,7 +337,7 @@ fn flash(args: FlashArgs, config: &Config) -> Result<()> {
     let elf_data = fs::read(build_ctx.artifact_path.clone()).into_diagnostic()?;
 
     if args.flash_args.image.check_app_descriptor && args.format == ImageFormatKind::EspIdf {
-        check_app_descriptor(&elf_data)?;
+        check_idf_bootloader(&elf_data)?;
     }
 
     let mut monitor_args = args.flash_args.monitor_args;
@@ -617,7 +617,7 @@ fn save_image(args: SaveImageArgs, config: &Config) -> Result<()> {
     let elf_data = fs::read(&build_ctx.artifact_path).into_diagnostic()?;
 
     if args.save_image_args.image.check_app_descriptor && args.format == ImageFormatKind::EspIdf {
-        check_app_descriptor(&elf_data)?;
+        check_idf_bootloader(&elf_data)?;
     }
 
     // Since we have no `Flasher` instance and as such cannot print the board

--- a/espflash/src/bin/espflash.rs
+++ b/espflash/src/bin/espflash.rs
@@ -10,7 +10,7 @@ use espflash::{
         *,
     },
     flasher::FlashSize,
-    image_format::{ImageFormat, ImageFormatKind, idf::check_app_descriptor},
+    image_format::{ImageFormat, ImageFormatKind, idf::check_idf_bootloader},
     logging::initialize_logger,
     target::{Chip, XtalFrequency},
     update::check_for_update,
@@ -264,7 +264,7 @@ fn flash(args: FlashArgs, config: &Config) -> Result<()> {
     let elf_data = fs::read(&args.image).into_diagnostic()?;
 
     if args.flash_args.image.check_app_descriptor && args.format == ImageFormatKind::EspIdf {
-        check_app_descriptor(&elf_data)?;
+        check_idf_bootloader(&elf_data)?;
     }
 
     print_board_info(&mut flasher)?;
@@ -344,7 +344,7 @@ fn save_image(args: SaveImageArgs, config: &Config) -> Result<()> {
         .wrap_err_with(|| format!("Failed to open image {}", args.image.display()))?;
 
     if args.save_image_args.image.check_app_descriptor && args.format == ImageFormatKind::EspIdf {
-        check_app_descriptor(&elf_data)?;
+        check_idf_bootloader(&elf_data)?;
     }
 
     // Since we have no `Flasher` instance and as such cannot print the board

--- a/espflash/src/bin/espflash.rs
+++ b/espflash/src/bin/espflash.rs
@@ -264,7 +264,7 @@ fn flash(args: FlashArgs, config: &Config) -> Result<()> {
     let elf_data = fs::read(&args.image).into_diagnostic()?;
 
     // Check if the ELF contains the app descriptor, if required.
-    if args.flash_args.image.check_app_descriptor.unwrap_or(true) {
+    if args.flash_args.image.check_app_descriptor {
         check_idf_bootloader(&elf_data)?;
     }
 
@@ -343,6 +343,11 @@ fn save_image(args: SaveImageArgs, config: &Config) -> Result<()> {
     let elf_data = fs::read(&args.image)
         .into_diagnostic()
         .wrap_err_with(|| format!("Failed to open image {}", args.image.display()))?;
+
+    // Check if the ELF contains the app descriptor, if required.
+    if args.save_image_args.image.check_app_descriptor {
+        check_idf_bootloader(&elf_data)?;
+    }
 
     // Since we have no `Flasher` instance and as such cannot print the board
     // information, we will print whatever information we _do_ have.

--- a/espflash/src/bin/espflash.rs
+++ b/espflash/src/bin/espflash.rs
@@ -10,7 +10,7 @@ use espflash::{
         *,
     },
     flasher::FlashSize,
-    image_format::{ImageFormat, ImageFormatKind, idf::check_idf_bootloader},
+    image_format::{ImageFormat, ImageFormatKind, idf::check_app_descriptor},
     logging::initialize_logger,
     target::{Chip, XtalFrequency},
     update::check_for_update,
@@ -263,9 +263,8 @@ fn flash(args: FlashArgs, config: &Config) -> Result<()> {
     // Read the ELF data from the build path and load it to the target.
     let elf_data = fs::read(&args.image).into_diagnostic()?;
 
-    // Check if the ELF contains the app descriptor, if required.
-    if args.flash_args.image.check_app_descriptor {
-        check_idf_bootloader(&elf_data)?;
+    if args.flash_args.image.check_app_descriptor && args.format == ImageFormatKind::EspIdf {
+        check_app_descriptor(&elf_data)?;
     }
 
     print_board_info(&mut flasher)?;
@@ -344,9 +343,8 @@ fn save_image(args: SaveImageArgs, config: &Config) -> Result<()> {
         .into_diagnostic()
         .wrap_err_with(|| format!("Failed to open image {}", args.image.display()))?;
 
-    // Check if the ELF contains the app descriptor, if required.
-    if args.save_image_args.image.check_app_descriptor {
-        check_idf_bootloader(&elf_data)?;
+    if args.save_image_args.image.check_app_descriptor && args.format == ImageFormatKind::EspIdf {
+        check_app_descriptor(&elf_data)?;
     }
 
     // Since we have no `Flasher` instance and as such cannot print the board

--- a/espflash/src/cli/mod.rs
+++ b/espflash/src/cli/mod.rs
@@ -259,7 +259,7 @@ pub struct ImageArgs {
     pub mmu_page_size: Option<u32>,
     /// Flag to check the app descriptor in bootloader
     #[arg(long, default_value = "true", value_parser = clap::value_parser!(bool))]
-    pub check_app_descriptor: Option<bool>,
+    pub check_app_descriptor: bool,
 }
 
 /// ESP-IDF image format arguments

--- a/espflash/src/image_format/idf.rs
+++ b/espflash/src/image_format/idf.rs
@@ -806,7 +806,7 @@ where
 }
 
 /// Check if the provided ELF contains the app descriptor required by [the IDF bootloader](https://docs.espressif.com/projects/esp-idf/en/stable/esp32/api-guides/bootloader.html).
-pub fn check_app_descriptor(elf_data: &Vec<u8>) -> Result<()> {
+pub fn check_idf_bootloader(elf_data: &Vec<u8>) -> Result<()> {
     let object = File::parse(elf_data.as_slice()).into_diagnostic()?;
 
     let has_app_desc = object.symbols().any(|sym| sym.name() == Ok("esp_app_desc"));

--- a/espflash/src/image_format/idf.rs
+++ b/espflash/src/image_format/idf.rs
@@ -806,7 +806,7 @@ where
 }
 
 /// Check if the provided ELF contains the app descriptor required by [the IDF bootloader](https://docs.espressif.com/projects/esp-idf/en/stable/esp32/api-guides/bootloader.html).
-pub fn check_idf_bootloader(elf_data: &Vec<u8>) -> Result<()> {
+pub fn check_app_descriptor(elf_data: &Vec<u8>) -> Result<()> {
     let object = File::parse(elf_data.as_slice()).into_diagnostic()?;
 
     let has_app_desc = object.symbols().any(|sym| sym.name() == Ok("esp_app_desc"));


### PR DESCRIPTION
- Add app descriptor check to save image
- ~~Rename `check_idf_bootloader` to `check_app_descriptor`~~
- Only check_app_descriptor for `EspIdf` format (useless for now as its the only supported, but...)
- `ImageArgs::check_app_descriptor` is now a `bool`, as it already has a default value