### PR TITLE
Fix using `cli::IdfFormatArgs` in `espflash.toml`

### DIFF
--- a/cargo-espflash/README.md
+++ b/cargo-espflash/README.md
@@ -147,13 +147,15 @@ baudrate = 460800
 ```
 - Bootloader:
 ```toml
+[idf]
 bootloader = "path/to/custom/bootloader.bin"
 ```
-- Partition table
+- Partition table:
 ```toml
+[idf]
 partition_table = "path/to/custom/partition-table.bin"
 ```
-- Flash settings
+- Flash settings:
 ```toml
 [flash]
 mode = "qio"

--- a/espflash/README.md
+++ b/espflash/README.md
@@ -167,13 +167,15 @@ baudrate = 460800
 ```
 - Bootloader:
 ```toml
+[idf]
 bootloader = "path/to/custom/bootloader.bin"
 ```
-- Partition table
+- Partition table:
 ```toml
+[idf]
 partition_table = "path/to/custom/partition-table.bin"
 ```
-- Flash settings
+- Flash settings:
 ```toml
 [flash]
 mode = "qio"

--- a/espflash/src/error.rs
+++ b/espflash/src/error.rs
@@ -345,6 +345,10 @@ pub enum Error {
     #[error("{0}")]
     #[diagnostic(code(espflash::app_desc::app_descriptor_not_present))]
     AppDescriptorNotPresent(String),
+
+    /// Key is not in the expected section
+    #[error("Misplaced key, check your configuration file. Key: {0}")]
+    MisplacedKey(String),
 }
 
 #[cfg(feature = "serialport")]


### PR DESCRIPTION
 The image format refactor introduced some layers to `ProjectConfig` struct so it needs some additional parsing/checking so `espflash.toml` doesn't ignore it's options.
  
 Closes https://github.com/esp-rs/espflash/issues/929