### PR TITLE
Fix compatibility with newer serialport api

### DIFF
--- a/espflash/src/cli/mod.rs
+++ b/espflash/src/cli/mod.rs
@@ -433,6 +433,7 @@ pub fn connect(
                 serial_number: None,
                 manufacturer: None,
                 product: None,
+                interface: None,
             }
         }
         _ => unreachable!(),


### PR DESCRIPTION
Newer versions have "interface" field that needs to be initialized.