### PR TITLE
Fix compatibility with newer serialport api

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 ### Changed
+- `espflash` enables interface feature on serialport allowing tools to build with this dependency (#937)
 
 ### Fixed
 

--- a/espflash/Cargo.toml
+++ b/espflash/Cargo.toml
@@ -51,7 +51,7 @@ miette          = "7.6"
 object          = "0.37"
 regex           = { version = "1.11", optional = true }
 serde           = { version = "1.0", features = ["derive"] }
-serialport      = { version = "4.7", default-features = false, optional = true }
+serialport      = { version = "4.7", default-features = false, features = ["usbportinfo-interface"], optional = true }
 sha2            = "0.10"
 slip-codec      = { version = "0.4", optional = true }
 strum           = { version = "0.27", features = ["derive"] }

--- a/espflash/src/cli/mod.rs
+++ b/espflash/src/cli/mod.rs
@@ -433,6 +433,7 @@ pub fn connect(
                 serial_number: None,
                 manufacturer: None,
                 product: None,
+                interface: None,
             }
         }
         _ => unreachable!(),


### PR DESCRIPTION
Newer versions have "interface" field that needs to be initialized. When using espflash as a library, if the calling application needs this feature, espflash won't compile anymore due to the dependency being added in the resulting serialport build.

Enable the feature and initialize the field in espflash, so that applications using espflash as a library can use serialport crate with this feature.