### PR TITLE
Use security info to detect chip

### DIFF
--- a/espflash/src/connection/mod.rs
+++ b/espflash/src/connection/mod.rs
@@ -5,6 +5,8 @@
 //! device.
 
 use std::{
+    collections::HashMap,
+    fmt,
     io::{BufWriter, Read, Write},
     iter::zip,
     thread::sleep,
@@ -13,6 +15,7 @@ use std::{
 
 use log::{debug, info};
 use regex::Regex;
+use serde::{Deserialize, Serialize};
 use serialport::{SerialPort, UsbPortInfo};
 use slip_codec::SlipDecoder;
 
@@ -40,6 +43,176 @@ use crate::{
 pub(crate) mod reset;
 
 pub use reset::{ResetAfterOperation, ResetBeforeOperation};
+
+/// Security Info Response containing chip security information
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Deserialize, Serialize)]
+pub struct SecurityInfo {
+    /// 32 bits flags
+    pub flags: u32,
+    /// 1 byte flash_crypt_cnt
+    pub flash_crypt_cnt: u8,
+    /// 7 bytes key purposes
+    pub key_purposes: [u8; 7],
+    /// 32-bit word chip id
+    pub chip_id: Option<u32>,
+    /// 32-bit word eco version
+    pub eco_version: Option<u32>,
+}
+
+impl SecurityInfo {
+    fn security_flag_map() -> HashMap<&'static str, u32> {
+        HashMap::from([
+            ("SECURE_BOOT_EN", 1 << 0),
+            ("SECURE_BOOT_AGGRESSIVE_REVOKE", 1 << 1),
+            ("SECURE_DOWNLOAD_ENABLE", 1 << 2),
+            ("SECURE_BOOT_KEY_REVOKE0", 1 << 3),
+            ("SECURE_BOOT_KEY_REVOKE1", 1 << 4),
+            ("SECURE_BOOT_KEY_REVOKE2", 1 << 5),
+            ("SOFT_DIS_JTAG", 1 << 6),
+            ("HARD_DIS_JTAG", 1 << 7),
+            ("DIS_USB", 1 << 8),
+            ("DIS_DOWNLOAD_DCACHE", 1 << 9),
+            ("DIS_DOWNLOAD_ICACHE", 1 << 10),
+        ])
+    }
+
+    fn security_flag_status(&self, flag_name: &str) -> bool {
+        if let Some(&flag) = Self::security_flag_map().get(flag_name) {
+            (self.flags & flag) != 0
+        } else {
+            false
+        }
+    }
+}
+
+impl TryFrom<&[u8]> for SecurityInfo {
+    type Error = Error;
+
+    fn try_from(bytes: &[u8]) -> Result<Self, Self::Error> {
+        let esp32s2 = bytes.len() == 12;
+
+        if bytes.len() < 12 {
+            return Err(Error::InvalidResponse(format!(
+                "expected response of at least 12 bytes, received {} bytes",
+                bytes.len()
+            )));
+        }
+
+        // Parse response bytes
+        let flags = u32::from_le_bytes(bytes[0..4].try_into()?);
+        let flash_crypt_cnt = bytes[4];
+        let key_purposes: [u8; 7] = bytes[5..12].try_into()?;
+
+        let (chip_id, eco_version) = if esp32s2 {
+            (None, None) // ESP32-S2 doesn't have these values
+        } else {
+            if bytes.len() < 20 {
+                return Err(Error::InvalidResponse(format!(
+                    "expected response of at least 20 bytes, received {} bytes",
+                    bytes.len()
+                )));
+            }
+            let chip_id = u32::from_le_bytes(bytes[12..16].try_into()?);
+            let eco_version = u32::from_le_bytes(bytes[16..20].try_into()?);
+            (Some(chip_id), Some(eco_version))
+        };
+
+        Ok(SecurityInfo {
+            flags,
+            flash_crypt_cnt,
+            key_purposes,
+            chip_id,
+            eco_version,
+        })
+    }
+}
+
+impl fmt::Display for SecurityInfo {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let key_purposes_str = self
+            .key_purposes
+            .iter()
+            .map(|b| format!("{b}"))
+            .collect::<Vec<_>>()
+            .join(", ");
+
+        writeln!(f, "\nSecurity Information:")?;
+        writeln!(f, "=====================")?;
+        writeln!(f, "Flags: {:#010x} ({:b})", self.flags, self.flags)?;
+        writeln!(f, "Key Purposes: [{key_purposes_str}]")?;
+
+        // Only print Chip ID if it's Some(value)
+        if let Some(chip_id) = self.chip_id {
+            writeln!(f, "Chip ID: {chip_id}")?;
+        }
+
+        // Only print API Version if it's Some(value)
+        if let Some(api_version) = self.eco_version {
+            writeln!(f, "API Version: {api_version}")?;
+        }
+
+        // Secure Boot
+        if self.security_flag_status("SECURE_BOOT_EN") {
+            writeln!(f, "Secure Boot: Enabled")?;
+            if self.security_flag_status("SECURE_BOOT_AGGRESSIVE_REVOKE") {
+                writeln!(f, "Secure Boot Aggressive key revocation: Enabled")?;
+            }
+
+            let revoked_keys: Vec<_> = [
+                "SECURE_BOOT_KEY_REVOKE0",
+                "SECURE_BOOT_KEY_REVOKE1",
+                "SECURE_BOOT_KEY_REVOKE2",
+            ]
+            .iter()
+            .enumerate()
+            .filter(|(_, key)| self.security_flag_status(key))
+            .map(|(i, _)| format!("Secure Boot Key{i} is Revoked"))
+            .collect();
+
+            if !revoked_keys.is_empty() {
+                writeln!(
+                    f,
+                    "Secure Boot Key Revocation Status:\n  {}",
+                    revoked_keys.join("\n  ")
+                )?;
+            }
+        } else {
+            writeln!(f, "Secure Boot: Disabled")?;
+        }
+
+        // Flash Encryption
+        if self.flash_crypt_cnt.count_ones() % 2 != 0 {
+            writeln!(f, "Flash Encryption: Enabled")?;
+        } else {
+            writeln!(f, "Flash Encryption: Disabled")?;
+        }
+
+        let crypt_cnt_str = "SPI Boot Crypt Count (SPI_BOOT_CRYPT_CNT)";
+        writeln!(f, "{}: 0x{:x}", crypt_cnt_str, self.flash_crypt_cnt)?;
+
+        // Cache Disabling
+        if self.security_flag_status("DIS_DOWNLOAD_DCACHE") {
+            writeln!(f, "Dcache in UART download mode: Disabled")?;
+        }
+        if self.security_flag_status("DIS_DOWNLOAD_ICACHE") {
+            writeln!(f, "Icache in UART download mode: Disabled")?;
+        }
+
+        // JTAG Status
+        if self.security_flag_status("HARD_DIS_JTAG") {
+            writeln!(f, "JTAG: Permanently Disabled")?;
+        } else if self.security_flag_status("SOFT_DIS_JTAG") {
+            writeln!(f, "JTAG: Software Access Disabled")?;
+        }
+
+        // USB Access
+        if self.security_flag_status("DIS_USB") {
+            writeln!(f, "USB Access: Disabled")?;
+        }
+
+        Ok(())
+    }
+}
 
 const MAX_CONNECT_ATTEMPTS: usize = 7;
 const MAX_SYNC_ATTEMPTS: usize = 5;
@@ -561,10 +734,7 @@ impl Connection {
 
     /// Gets security information from the chip.
     #[cfg(feature = "serialport")]
-    pub fn security_info(
-        &mut self,
-        use_stub: bool,
-    ) -> Result<crate::flasher::SecurityInfo, crate::error::Error> {
+    pub fn security_info(&mut self, use_stub: bool) -> Result<SecurityInfo, crate::error::Error> {
         self.with_timeout(CommandType::GetSecurityInfo.timeout(), |connection| {
             let response = connection.command(Command::GetSecurityInfo)?;
             // Extract raw bytes and convert them into `SecurityInfo`
@@ -572,7 +742,7 @@ impl Connection {
                 // HACK: Not quite sure why there seem to be 4 extra bytes at the end of the
                 //       response when the stub is not being used...
                 let end = if use_stub { data.len() } else { data.len() - 4 };
-                crate::flasher::SecurityInfo::try_from(&data[..end])
+                SecurityInfo::try_from(&data[..end])
             } else {
                 Err(Error::InvalidResponse(
                     "response was not a vector of bytes".into(),

--- a/espflash/src/connection/mod.rs
+++ b/espflash/src/connection/mod.rs
@@ -760,7 +760,7 @@ impl Connection {
         // First try to detect chip using security_info when possible
         if let Ok(security_info) = self.security_info(use_stub) {
             if let Some(chip_id) = security_info.chip_id {
-                info!("Detected chip using security info chip_id: {chip_id}");
+                debug!("Detected chip using security info chip_id: {chip_id}");
                 // Convert u32 chip_id to u16 for compatibility with Chip::try_from
                 match Chip::try_from(chip_id as u16) {
                     Ok(chip) => return Ok(chip),

--- a/espflash/src/connection/mod.rs
+++ b/espflash/src/connection/mod.rs
@@ -559,12 +559,51 @@ impl Connection {
         self.before_operation
     }
 
+    /// Gets security information from the chip.
+    #[cfg(feature = "serialport")]
+    pub fn security_info(
+        &mut self,
+        use_stub: bool,
+    ) -> Result<crate::flasher::SecurityInfo, crate::error::Error> {
+        self.with_timeout(CommandType::GetSecurityInfo.timeout(), |connection| {
+            let response = connection.command(Command::GetSecurityInfo)?;
+            // Extract raw bytes and convert them into `SecurityInfo`
+            if let crate::command::CommandResponseValue::Vector(data) = response {
+                // HACK: Not quite sure why there seem to be 4 extra bytes at the end of the
+                //       response when the stub is not being used...
+                let end = if use_stub { data.len() } else { data.len() - 4 };
+                crate::flasher::SecurityInfo::try_from(&data[..end])
+            } else {
+                Err(Error::InvalidResponse(
+                    "response was not a vector of bytes".into(),
+                ))
+            }
+        })
+    }
+
     /// Detects which chip is connected to this connection.
+    #[cfg(feature = "serialport")]
     pub fn detect_chip(
         &mut self,
         use_stub: bool,
     ) -> Result<crate::target::Chip, crate::error::Error> {
-        // Try to read the magic value from the chip
+        // First try to detect chip using security_info when possible
+        if let Ok(security_info) = self.security_info(use_stub) {
+            if let Some(chip_id) = security_info.chip_id {
+                info!("Detected chip using security info chip_id: {chip_id}");
+                // Convert u32 chip_id to u16 for compatibility with Chip::try_from
+                match Chip::try_from(chip_id as u16) {
+                    Ok(chip) => return Ok(chip),
+                    Err(_) => {
+                        debug!(
+                            "Unknown chip_id from security_info: {chip_id}, falling back to magic register"
+                        );
+                    }
+                }
+            }
+        }
+
+        // Fall back to reading the magic value from the chip
         let magic = if use_stub {
             self.with_timeout(CommandType::ReadReg.timeout(), |connection| {
                 connection.command(Command::ReadReg {

--- a/espflash/src/flasher/mod.rs
+++ b/espflash/src/flasher/mod.rs
@@ -1143,7 +1143,7 @@ impl Flasher {
 
     /// Get security info.
     pub fn security_info(&mut self) -> Result<SecurityInfo, Error> {
-        security_info(&mut self.connection, self.use_stub)
+        self.connection.security_info(self.use_stub)
     }
 
     /// Change the baud rate of the connection.
@@ -1368,24 +1368,6 @@ impl Flasher {
     pub fn into_connection(self) -> Connection {
         self.connection
     }
-}
-
-#[cfg(feature = "serialport")]
-fn security_info(connection: &mut Connection, use_stub: bool) -> Result<SecurityInfo, Error> {
-    connection.with_timeout(CommandType::GetSecurityInfo.timeout(), |connection| {
-        let response = connection.command(Command::GetSecurityInfo)?;
-        // Extract raw bytes and convert them into `SecurityInfo`
-        if let crate::command::CommandResponseValue::Vector(data) = response {
-            // HACK: Not quite sure why there seem to be 4 extra bytes at the end of the
-            //       response when the stub is not being used...
-            let end = if use_stub { data.len() } else { data.len() - 4 };
-            SecurityInfo::try_from(&data[..end])
-        } else {
-            Err(Error::InvalidResponse(
-                "response was not a vector of bytes".into(),
-            ))
-        }
-    })
 }
 
 #[cfg(feature = "serialport")]

--- a/espflash/src/flasher/mod.rs
+++ b/espflash/src/flasher/mod.rs
@@ -975,6 +975,7 @@ impl Flasher {
     }
 
     /// Get security info.
+    // TODO: Deprecate this method in the next major release
     pub fn security_info(&mut self) -> Result<SecurityInfo, Error> {
         self.connection.security_info(self.use_stub)
     }

--- a/espflash/src/flasher/mod.rs
+++ b/espflash/src/flasher/mod.rs
@@ -6,9 +6,9 @@
 
 #[cfg(feature = "serialport")]
 use std::fs::OpenOptions;
+use std::str::FromStr;
 #[cfg(feature = "serialport")]
 use std::{borrow::Cow, io::Write, path::PathBuf, thread::sleep, time::Duration};
-use std::{collections::HashMap, fmt, str::FromStr};
 
 #[cfg(feature = "serialport")]
 use log::{debug, info, warn};
@@ -21,6 +21,9 @@ use strum::{Display, EnumIter, IntoEnumIterator, VariantNames};
 
 #[cfg(feature = "serialport")]
 use crate::connection::Port;
+// Re-export SecurityInfo from connection module for backward compatibility
+// TODO: Remove in the next major release
+pub use crate::connection::SecurityInfo;
 #[cfg(feature = "serialport")]
 use crate::target::{DefaultProgressCallback, ProgressCallbacks};
 use crate::{
@@ -52,176 +55,6 @@ pub(crate) const TRY_SPI_PARAMS: [SpiAttachParams; 2] =
 #[cfg(feature = "serialport")]
 pub(crate) const FLASH_SECTOR_SIZE: usize = 0x1000;
 pub(crate) const FLASH_WRITE_SIZE: usize = 0x400;
-
-/// Security Info Response containing
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Deserialize, Serialize)]
-pub struct SecurityInfo {
-    /// 32 bits flags
-    pub flags: u32,
-    /// 1 byte flash_crypt_cnt
-    pub flash_crypt_cnt: u8,
-    /// 7 bytes key purposes
-    pub key_purposes: [u8; 7],
-    /// 32-bit word chip id
-    pub chip_id: Option<u32>,
-    /// 32-bit word eco version
-    pub eco_version: Option<u32>,
-}
-
-impl SecurityInfo {
-    fn security_flag_map() -> HashMap<&'static str, u32> {
-        HashMap::from([
-            ("SECURE_BOOT_EN", 1 << 0),
-            ("SECURE_BOOT_AGGRESSIVE_REVOKE", 1 << 1),
-            ("SECURE_DOWNLOAD_ENABLE", 1 << 2),
-            ("SECURE_BOOT_KEY_REVOKE0", 1 << 3),
-            ("SECURE_BOOT_KEY_REVOKE1", 1 << 4),
-            ("SECURE_BOOT_KEY_REVOKE2", 1 << 5),
-            ("SOFT_DIS_JTAG", 1 << 6),
-            ("HARD_DIS_JTAG", 1 << 7),
-            ("DIS_USB", 1 << 8),
-            ("DIS_DOWNLOAD_DCACHE", 1 << 9),
-            ("DIS_DOWNLOAD_ICACHE", 1 << 10),
-        ])
-    }
-
-    fn security_flag_status(&self, flag_name: &str) -> bool {
-        if let Some(&flag) = Self::security_flag_map().get(flag_name) {
-            (self.flags & flag) != 0
-        } else {
-            false
-        }
-    }
-}
-
-impl TryFrom<&[u8]> for SecurityInfo {
-    type Error = Error;
-
-    fn try_from(bytes: &[u8]) -> Result<Self, Self::Error> {
-        let esp32s2 = bytes.len() == 12;
-
-        if bytes.len() < 12 {
-            return Err(Error::InvalidResponse(format!(
-                "expected response of at least 12 bytes, received {} bytes",
-                bytes.len()
-            )));
-        }
-
-        // Parse response bytes
-        let flags = u32::from_le_bytes(bytes[0..4].try_into()?);
-        let flash_crypt_cnt = bytes[4];
-        let key_purposes: [u8; 7] = bytes[5..12].try_into()?;
-
-        let (chip_id, eco_version) = if esp32s2 {
-            (None, None) // ESP32-S2 doesn't have these values
-        } else {
-            if bytes.len() < 20 {
-                return Err(Error::InvalidResponse(format!(
-                    "expected response of at least 20 bytes, received {} bytes",
-                    bytes.len()
-                )));
-            }
-            let chip_id = u32::from_le_bytes(bytes[12..16].try_into()?);
-            let eco_version = u32::from_le_bytes(bytes[16..20].try_into()?);
-            (Some(chip_id), Some(eco_version))
-        };
-
-        Ok(SecurityInfo {
-            flags,
-            flash_crypt_cnt,
-            key_purposes,
-            chip_id,
-            eco_version,
-        })
-    }
-}
-
-impl fmt::Display for SecurityInfo {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let key_purposes_str = self
-            .key_purposes
-            .iter()
-            .map(|b| format!("{b}"))
-            .collect::<Vec<_>>()
-            .join(", ");
-
-        writeln!(f, "\nSecurity Information:")?;
-        writeln!(f, "=====================")?;
-        writeln!(f, "Flags: {:#010x} ({:b})", self.flags, self.flags)?;
-        writeln!(f, "Key Purposes: [{key_purposes_str}]")?;
-
-        // Only print Chip ID if it's Some(value)
-        if let Some(chip_id) = self.chip_id {
-            writeln!(f, "Chip ID: {chip_id}")?;
-        }
-
-        // Only print API Version if it's Some(value)
-        if let Some(api_version) = self.eco_version {
-            writeln!(f, "API Version: {api_version}")?;
-        }
-
-        // Secure Boot
-        if self.security_flag_status("SECURE_BOOT_EN") {
-            writeln!(f, "Secure Boot: Enabled")?;
-            if self.security_flag_status("SECURE_BOOT_AGGRESSIVE_REVOKE") {
-                writeln!(f, "Secure Boot Aggressive key revocation: Enabled")?;
-            }
-
-            let revoked_keys: Vec<_> = [
-                "SECURE_BOOT_KEY_REVOKE0",
-                "SECURE_BOOT_KEY_REVOKE1",
-                "SECURE_BOOT_KEY_REVOKE2",
-            ]
-            .iter()
-            .enumerate()
-            .filter(|(_, key)| self.security_flag_status(key))
-            .map(|(i, _)| format!("Secure Boot Key{i} is Revoked"))
-            .collect();
-
-            if !revoked_keys.is_empty() {
-                writeln!(
-                    f,
-                    "Secure Boot Key Revocation Status:\n  {}",
-                    revoked_keys.join("\n  ")
-                )?;
-            }
-        } else {
-            writeln!(f, "Secure Boot: Disabled")?;
-        }
-
-        // Flash Encryption
-        if self.flash_crypt_cnt.count_ones() % 2 != 0 {
-            writeln!(f, "Flash Encryption: Enabled")?;
-        } else {
-            writeln!(f, "Flash Encryption: Disabled")?;
-        }
-
-        let crypt_cnt_str = "SPI Boot Crypt Count (SPI_BOOT_CRYPT_CNT)";
-        writeln!(f, "{}: 0x{:x}", crypt_cnt_str, self.flash_crypt_cnt)?;
-
-        // Cache Disabling
-        if self.security_flag_status("DIS_DOWNLOAD_DCACHE") {
-            writeln!(f, "Dcache in UART download mode: Disabled")?;
-        }
-        if self.security_flag_status("DIS_DOWNLOAD_ICACHE") {
-            writeln!(f, "Icache in UART download mode: Disabled")?;
-        }
-
-        // JTAG Status
-        if self.security_flag_status("HARD_DIS_JTAG") {
-            writeln!(f, "JTAG: Permanently Disabled")?;
-        } else if self.security_flag_status("SOFT_DIS_JTAG") {
-            writeln!(f, "JTAG: Software Access Disabled")?;
-        }
-
-        // USB Access
-        if self.security_flag_status("DIS_USB") {
-            writeln!(f, "USB Access: Disabled")?;
-        }
-
-        Ok(())
-    }
-}
 
 /// Supported flash frequencies
 ///


### PR DESCRIPTION
As @jessebraham spotted, in https://github.com/esp-rs/espflash/pull/882 we reverted the way `detect_chip` work, to rely again in the magic value instead of chip security info, which should be the preferred way. In this PR:
- I moved all the security info stuff to the connection module (its where its used) although we have to reexport it and keep a "stub" method in flasher struct to avoid breaking changes (those could be deleted in the next major), also this helps in https://github.com/esp-rs/espflash/issues/793
- When detecting a chip, we try to use the securtiy info, if that doesnt work/chip doesnt have it, we fallback to the magic value