### PR TITLE
Fix unwraps in connection module when probing a loopback port

### DIFF
--- a/espflash/src/connection/mod.rs
+++ b/espflash/src/connection/mod.rs
@@ -397,22 +397,17 @@ impl Connection {
 
                 let value = match response.len() {
                     10 | 12 => CommandResponseValue::ValueU32(u32::from_le_bytes(
-                        response[4..][..4].try_into().unwrap(),
+                        response[4..][..4].try_into()?,
                     )),
-                    44 => {
                         // MD5 is in ASCII
-                        CommandResponseValue::ValueU128(
-                            u128::from_str_radix(
-                                std::str::from_utf8(&response[8..][..32]).unwrap(),
-                                16,
-                            )
-                            .unwrap(),
-                        )
-                    }
+                    44 => CommandResponseValue::ValueU128(u128::from_str_radix(
+                        std::str::from_utf8(&response[8..][..32])?,
+                        16,
+                    )?),
                     26 => {
                         // MD5 is BE bytes
                         CommandResponseValue::ValueU128(u128::from_be_bytes(
-                            response[8..][..16].try_into().unwrap(),
+                            response[8..][..16].try_into()?,
                         ))
                     }
                     _ => CommandResponseValue::Vector(response.clone()),
@@ -421,7 +416,7 @@ impl Connection {
                 let header = CommandResponse {
                     resp: response[0],
                     return_op: response[1],
-                    return_length: u16::from_le_bytes(response[2..][..2].try_into().unwrap()),
+                    return_length: u16::from_le_bytes(response[2..][..2].try_into()?),
                     value,
                     error: response[response.len() - status_len + 1],
                     status: response[response.len() - status_len],

--- a/espflash/src/error.rs
+++ b/espflash/src/error.rs
@@ -2,7 +2,7 @@
 
 #[cfg(feature = "serialport")]
 use std::fmt::{Display, Formatter};
-use std::{array::TryFromSliceError, io};
+use std::{array::TryFromSliceError, io, num::ParseIntError, str::Utf8Error};
 
 use miette::Diagnostic;
 #[cfg(feature = "serialport")]
@@ -294,6 +294,14 @@ pub enum Error {
     #[error(transparent)]
     TryFromSlice(CoreError),
 
+    /// Error while trying to parse int from text
+    #[error(transparent)]
+    ParseIntError(CoreError),
+
+    /// Error while trying to parse UTF-8 from bytes
+    #[error(transparent)]
+    Utf8Error(CoreError),
+
     /// Failed to open file
     #[error("Failed to open file: {0}")]
     FileOpenError(String, #[source] io::Error),
@@ -377,6 +385,18 @@ impl From<serialport::Error> for Error {
 impl From<TryFromSliceError> for Error {
     fn from(err: TryFromSliceError) -> Self {
         Self::TryFromSlice(Box::new(err))
+    }
+}
+
+impl From<ParseIntError> for Error {
+    fn from(err: ParseIntError) -> Self {
+        Self::ParseIntError(Box::new(err))
+    }
+}
+
+impl From<Utf8Error> for Error {
+    fn from(err: Utf8Error) -> Self {
+        Self::Utf8Error(Box::new(err))
     }
 }
 

--- a/espflash/src/flasher/mod.rs
+++ b/espflash/src/flasher/mod.rs
@@ -1051,8 +1051,8 @@ impl Flasher {
         {
             let metadata = image_format.metadata();
             if metadata.contains_key("app_size") && metadata.contains_key("part_size") {
-                let app_size = metadata["app_size"].parse::<u32>().unwrap();
-                let part_size = metadata["part_size"].parse::<u32>().unwrap();
+                let app_size = metadata["app_size"].parse::<u32>()?;
+                let part_size = metadata["part_size"].parse::<u32>()?;
 
                 crate::cli::display_image_size(app_size, Some(part_size));
             }


### PR DESCRIPTION
I'm setting up an ESP32-S3's CDC task manually for a project, and a common "hello world" is to echo back whatever bytes were received.

Trying to connect to a port with that behavior crashed `espflash`, specifically at `connection/mod.rs:409`. I also skimmed through the module and through other `unwraps()` I could tag with `?` without affecting expected behavior.