### PR TITLE
efuse: Correct block0 offset definitions for ESP32-C2, -C3, and -S3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Corrected eFuse BLOCK0 definitions for ESP32-C2, ESP32-C3, and ESP32-S3 (#961)
+
 ### Removed
 
 ## [4.2.0] - 2025-10-13

--- a/espflash/src/target/mod.rs
+++ b/espflash/src/target/mod.rs
@@ -386,14 +386,14 @@ impl Chip {
     pub fn block0_offset(&self) -> u32 {
         match self {
             Chip::Esp32 => 0x0,
-            Chip::Esp32c2 => 0x35,
-            Chip::Esp32c3 => 0x2D,
+            Chip::Esp32c2 => 0x2C,
+            Chip::Esp32c3 => 0x2C,
             Chip::Esp32c5 => 0x2C,
             Chip::Esp32c6 => 0x2C,
             Chip::Esp32h2 => 0x2C,
             Chip::Esp32p4 => 0x2C,
             Chip::Esp32s2 => 0x2C,
-            Chip::Esp32s3 => 0x2D,
+            Chip::Esp32s3 => 0x2C,
         }
     }
 


### PR DESCRIPTION
According to both the technical reference manuals and to the esptool definitions these are all at 0x02C.