### PR TITLE
efuse: Correct block sizes for ESP32-C2, ESP32-C3, and ESP32-S3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Corrected eFuse BLOCK0 definitions for ESP32-C2, ESP32-C3, and ESP32-S3 (#961)
+- Corrected eFuse block sizes for ESP32-C2, ESP32-C3, and ESP32-S3 (#964)
 
 ### Removed
 

--- a/espflash/src/target/efuse/esp32c2.rs
+++ b/espflash/src/target/efuse/esp32c2.rs
@@ -10,7 +10,7 @@
 use super::EfuseField;
 
 /// Total size in bytes of each block
-pub(crate) const BLOCK_SIZES: &[u32] = &[8, 11, 32, 32];
+pub(crate) const BLOCK_SIZES: &[u32] = &[12, 12, 32, 32];
 
 /// Disable programming of individual eFuses
 pub const WR_DIS: EfuseField = EfuseField::new(0, 0, 0, 8);

--- a/espflash/src/target/efuse/esp32c3.rs
+++ b/espflash/src/target/efuse/esp32c3.rs
@@ -10,7 +10,7 @@
 use super::EfuseField;
 
 /// Total size in bytes of each block
-pub(crate) const BLOCK_SIZES: &[u32] = &[23, 24, 32, 32, 32, 32, 32, 32, 32, 32, 32];
+pub(crate) const BLOCK_SIZES: &[u32] = &[24, 24, 32, 32, 32, 32, 32, 32, 32, 32, 32];
 
 /// Disable programming of individual eFuses
 pub const WR_DIS: EfuseField = EfuseField::new(0, 0, 0, 32);

--- a/espflash/src/target/efuse/esp32s3.rs
+++ b/espflash/src/target/efuse/esp32s3.rs
@@ -10,7 +10,7 @@
 use super::EfuseField;
 
 /// Total size in bytes of each block
-pub(crate) const BLOCK_SIZES: &[u32] = &[23, 24, 32, 32, 32, 32, 32, 32, 32, 32, 32];
+pub(crate) const BLOCK_SIZES: &[u32] = &[24, 24, 32, 32, 32, 32, 32, 32, 32, 32, 32];
 
 /// Disable programming of individual eFuses
 pub const WR_DIS: EfuseField = EfuseField::new(0, 0, 0, 32);


### PR DESCRIPTION
It seems like I've figured out how the incorrect base addresses that were corrected in #961 arose.

The `esptool`'s eFuse field definitions do not include the last byte of the block0/register5.  The technical reference manual lists the first 22 bits as a named field, it just happens to be that that field is a reserved one, and the remaining 8 bits is an unnamed reserved portions so the `esptool` definitions doesn't list it.  It seems like the `BLOCK_SIZES` definitions in `espflash` were derived from the sizes as calculated by those field definitions, which therefore were a byte short for -C2/-C3/-S3.

It seems like the base addresses were changed to try to adjust for this, but in exchange it accidentally shifted the data in block0 by one byte and block1 by two bytes, and I ran into it while testing out my eFuse write changes against block0.  On the other hand, changing fixing the base addresses without changing the block sizes means that we get the opposite problem where block0 works but the other blocks are shifted!

This PR corrects the block sizes for the three affected chips.

---

The simplest way to verify that these values are correct is by looking at the eFuse register summary tables and subtracting the start address of one block from the start address of the following one, which gives you the size of the block.

- [ESP8686 (ESP32-C2) Technical Reference Manual](https://documentation.espressif.com/api/resource/doc/file/3yD6ZlY5/FILE/esp8684_technical_reference_manual_en.pdf#section.4.4)
- [ESP32-S3 Technical Reference Manual](https://documentation.espressif.com/api/resource/doc/file/wyBAprze/FILE/esp32-s3_technical_reference_manual_en.pdf#Regfloat.5.96)
- [ESP32-C3 Technical Reference Manual](https://documentation.espressif.com/api/resource/doc/file/aY69Zg1p/FILE/esp32-c3_technical_reference_manual_en.pdf#section.4.4)