### PR TITLE
Fix SDM detection for P4

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,2 +1,3 @@
 [alias]
 xtask = "run --package xtask --"
+xrun = "run --package espflash --"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Corrected eFuse BLOCK0 definitions for ESP32-C2, ESP32-C3, and ESP32-S3 (#961)
+- Fixed Secure Download Mode detection on ESP32-P4 (#972)
 
 ### Removed
 

--- a/espflash/src/connection/mod.rs
+++ b/espflash/src/connection/mod.rs
@@ -87,7 +87,7 @@ impl SecurityInfo {
         ])
     }
 
-    fn security_flag_status(&self, flag_name: &str) -> bool {
+    pub(crate) fn security_flag_status(&self, flag_name: &str) -> bool {
         if let Some(&flag) = Self::security_flag_map().get(flag_name) {
             (self.flags & flag) != 0
         } else {


### PR DESCRIPTION
On the P4, the old magic address of `0x40001000` is actually external memory, and trying to read that just gives a timeout. This causes espflash to mis-detect secure download mode.

With this PR, `espflash board-info --no-stub` now responds with

```
Chip type:         esp32p4 (revision v3.0)
Crystal frequency: 40 MHz
Flash size:        16MB
Features:          High-Performance MCU
MAC address:       30:ed:a0:ec:f1:01

Security Information:
=====================
Flags: 0x00000000 (0)
Key Purposes: [0, 0, 0, 0, 0, 0, 19]
Chip ID: 18
API Version: 5
Secure Boot: Disabled
Flash Encryption: Disabled
SPI Boot Crypt Count (SPI_BOOT_CRYPT_CNT): 0x0
```