### PR TITLE
Bump cargo-espflash

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -242,7 +242,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-espflash"
-version = "4.2.0"
+version = "4.3.0"
 dependencies = [
  "cargo_metadata",
  "clap",

--- a/cargo-espflash/Cargo.toml
+++ b/cargo-espflash/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name         = "cargo-espflash"
-version      = "4.2.0"
+version      = "4.3.0"
 edition      = "2024"
 rust-version = "1.85"
 description  = "Cargo subcommand for interacting with Espressif devices"


### PR DESCRIPTION
Forgot to bump the cargo-espflash version number and noticed when releasing it :sweat: 
