### PR TITLE
feat: include serial number in list-ports output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+
 ### Added
 
+- Add serial number to `list-ports` output for easier device identification (#998)
 - eFuse write support (#962)
 - esp32p4rc1 support for esp32p4 chips with revision < 3.0 (#922)
 - Support for binaries with INIT_ARRAY sections, which is needed for esp32p4 support. (#991)

--- a/espflash/src/cli/mod.rs
+++ b/espflash/src/cli/mod.rs
@@ -546,7 +546,7 @@ pub fn list_ports(args: &ListPortsArgs, config: &PortConfig) -> Result<()> {
                     }
                     SerialPortType::UsbPort(p) => {
                         println!(
-                            "{0: <name_width$}{3:04X}:{4:04X}:{5: <25}  {1: <manufacturer_width$}{2}",
+                            "{0: <name_width$}{4:04X}:{3:04X}:{5: <25}  {1: <manufacturer_width$}{2}",
                             port.port_name,
                             p.manufacturer.unwrap_or_default(),
                             p.product.unwrap_or_default(),

--- a/espflash/src/cli/mod.rs
+++ b/espflash/src/cli/mod.rs
@@ -546,12 +546,13 @@ pub fn list_ports(args: &ListPortsArgs, config: &PortConfig) -> Result<()> {
                     }
                     SerialPortType::UsbPort(p) => {
                         println!(
-                            "{0: <name_width$}{3:04X}:{4:04X}  {1: <manufacturer_width$}{2}",
+                            "{0: <name_width$}{3:04X}:{4:04X}:{5: <25}  {1: <manufacturer_width$}{2}",
                             port.port_name,
                             p.manufacturer.unwrap_or_default(),
                             p.product.unwrap_or_default(),
                             p.pid,
                             p.vid,
+                            p.serial_number.unwrap_or_else(|| "N/A".to_string()),
                             name_width = name_width,
                             manufacturer_width = manufacturer_width,
                         )


### PR DESCRIPTION
The current list-ports output lacks serial numbers, making it impossible to identify specific devices when multiple ESP32 are connected and now it is possible to get a port for the flash by PROBE.

```
$ probe-rs list  
The following debug probes were found:
[0]: ESP JTAG -- 303a:1001:B4:3A:45:AE:52:FC (EspJtag)
[1]: ESP JTAG -- 303a:1001:B8:F8:62:FC:17:8C (EspJtag)
$ espflash list-ports
/dev/ttyACM0  303A:1001:B4:3A:45:AE:52:FC          Espressif  USB JTAG/serial debug unit
/dev/ttyACM1  303A:1001:B8:F8:62:FC:17:8C          Espressif  USB JTAG/serial debug unit
```