### PR TITLE
docs: update docs.esp-rs.org links to docs.espressif.com

### DIFF
--- a/cargo-espflash/README.md
+++ b/cargo-espflash/README.md
@@ -189,7 +189,7 @@ You can have a local and/or a global configuration file(s):
 
 [`defmt`]: https://defmt.ferrous-systems.com/
 [`defmt` section]: https://github.com/esp-rs/esp-hal/tree/main/esp-println#defmt
-[`defmt` project]: https://docs.esp-rs.org/no_std-training/03_7_defmt.html
+[`defmt` project]: https://docs.espressif.com/projects/rust/no_std-training/03_7_defmt.html
 
 ## Development Kit Support Policy
 

--- a/espflash/README.md
+++ b/espflash/README.md
@@ -209,7 +209,7 @@ You can have a local and/or a global configuration file(s):
 
 [`defmt`]: https://defmt.ferrous-systems.com/
 [`defmt` section]: https://github.com/esp-rs/esp-hal/tree/main/esp-println#defmt
-[`defmt` project]: https://docs.esp-rs.org/no_std-training/03_7_defmt.html
+[`defmt` project]: https://docs.espressif.com/projects/rust/no_std-training/03_7_defmt.html
 
 ## Development Kit Support Policy
 


### PR DESCRIPTION
The `docs.esp-rs.org` domain has expired and now points to unsafe content.
This PR rewrites references to the official docs at `docs.espressif.com/projects/rust/`.

Each replacement URL was verified to resolve (HTTP 200, follows redirects) before this PR was opened.

_Auto-generated as part of a coordinated link cleanup across `esp-rs`._