### PR TITLE
Fix C3 HIL failures

### DIFF
--- a/espflash/src/cli/mod.rs
+++ b/espflash/src/cli/mod.rs
@@ -730,10 +730,22 @@ pub fn serial_monitor(args: MonitorArgs, config: &Config) -> Result<()> {
             .map_err(Error::from)
             .wrap_err_with(|| format!("Failed to reopen serial port {port_name}"))?;
         monitor_args.no_reset = true;
-        return monitor(serial, elf_refs, pid, monitor_args, args.connect_args.non_interactive);
+        return monitor(
+            serial,
+            elf_refs,
+            pid,
+            monitor_args,
+            args.connect_args.non_interactive,
+        );
     }
 
-    monitor(flasher.into(), elf_refs, pid, monitor_args, args.connect_args.non_interactive)
+    monitor(
+        flasher.into(),
+        elf_refs,
+        pid,
+        monitor_args,
+        args.connect_args.non_interactive,
+    )
 }
 
 /// Convert the provided firmware image from ELF to binary

--- a/espflash/src/cli/mod.rs
+++ b/espflash/src/cli/mod.rs
@@ -716,7 +716,9 @@ pub fn serial_monitor(args: MonitorArgs, config: &Config) -> Result<()> {
     if args.connect_args.non_interactive
         && !monitor_args.no_reset
         && flasher.connection().is_using_usb_serial_jtag()
-        && chip.can_rtc_wdt_reset(flasher.connection())?
+        && chip
+            .can_rtc_wdt_reset(flasher.connection())
+            .unwrap_or(false)
     {
         let port_name = serial::serial_port_info(&args.connect_args, config)?.port_name;
         chip.rtc_wdt_reset(flasher.connection())?;

--- a/espflash/src/cli/mod.rs
+++ b/espflash/src/cli/mod.rs
@@ -709,13 +709,31 @@ pub fn serial_monitor(args: MonitorArgs, config: &Config) -> Result<()> {
     let elfs = load_monitor_elfs(firmware_elf.as_deref(), &monitor_args, &dev_info)?;
     let elf_refs = elfs.refs();
 
-    monitor(
-        flasher.into(),
-        elf_refs,
-        pid,
-        monitor_args,
-        args.connect_args.non_interactive,
-    )
+    // UsbJtagSerialReset issues USB_UART_CHIP_RESET, which does not re-initialize
+    // the RISC-V debug module, which causes probe-rs JTAG sessions to timing
+    // out on DMI access. rtc_wdt_reset performs a full chip reset that fixes this,
+    // but also causes USB re-enumeration, so the port must be reopened.
+    if args.connect_args.non_interactive
+        && !monitor_args.no_reset
+        && flasher.connection().is_using_usb_serial_jtag()
+        && chip.can_rtc_wdt_reset(flasher.connection())?
+    {
+        let port_name = serial::serial_port_info(&args.connect_args, config)?.port_name;
+        chip.rtc_wdt_reset(flasher.connection())?;
+        drop(flasher);
+
+        // Reopen the port after the reset
+        std::thread::sleep(std::time::Duration::from_millis(1500));
+        let serial = serialport::new(&port_name, monitor_args.monitor_baud)
+            .flow_control(FlowControl::None)
+            .open_native()
+            .map_err(Error::from)
+            .wrap_err_with(|| format!("Failed to reopen serial port {port_name}"))?;
+        monitor_args.no_reset = true;
+        return monitor(serial, elf_refs, pid, monitor_args, args.connect_args.non_interactive);
+    }
+
+    monitor(flasher.into(), elf_refs, pid, monitor_args, args.connect_args.non_interactive)
 }
 
 /// Convert the provided firmware image from ELF to binary


### PR DESCRIPTION
If I understand things correctly, on C3 USB_UART_CHIP_RESET doesn't seem reinit the debug unit.
So, this is probably why we saw that DMI timeout thing.


Testing proves my theory, let's see how HIL tests will behave