### PR TITLE
Decode the correct status byte

### DIFF
--- a/cargo-espflash/src/cargo_config.rs
+++ b/cargo-espflash/src/cargo_config.rs
@@ -78,7 +78,7 @@ fn load_cargo_config(path: &Path) -> Result<Option<CargoConfig>> {
         .wrap_err_with(|| {
             format!(
                 "Failed to parse {}",
-                &config_path.as_path().to_string_lossy()
+                config_path.as_path().to_string_lossy()
             )
         })?;
 

--- a/espflash/src/cli/config.rs
+++ b/espflash/src/cli/config.rs
@@ -132,12 +132,12 @@ impl Config {
         Self::validate_partition_table_path(&project_config)?;
         Self::validate_bootloader_path(&project_config)?;
 
-        debug!("Config: {:#?}", &project_config);
+        debug!("Config: {:#?}", project_config);
 
         let mut port_config =
             Self::load_port_config(&port_config_file, &project_config_file, &raw_data)?;
         port_config.save_path = port_config_file;
-        debug!("Port Config: {:#?}", &port_config);
+        debug!("Port Config: {:#?}", port_config);
 
         Ok(Config {
             project_config,
@@ -218,7 +218,7 @@ impl Config {
             if data.contains("[connection]") || data.contains("[[usb_device]]") {
                 log::info!(
                     "espflash@3 configuration detected. Migrating port config to port_config_file: {:#?}",
-                    &port_config_file
+                    port_config_file
                 );
 
                 let port_config: PortConfig = toml::from_str(&data).into_diagnostic()?;

--- a/espflash/src/connection/mod.rs
+++ b/espflash/src/connection/mod.rs
@@ -653,7 +653,7 @@ impl Connection {
                         let _error = self.flush();
                         Err(Error::RomError(Box::new(RomError::new(
                             command.command_type(),
-                            RomErrorKind::from(response.error),
+                            RomErrorKind::from(response.status),
                         ))))
                     } else {
                         // Check if the response is a Vector and strip header (first 8 bytes)

--- a/espflash/src/error.rs
+++ b/espflash/src/error.rs
@@ -599,7 +599,7 @@ impl From<CommandType> for TimedOutCommand {
 }
 
 /// Errors originating from a device's ROM functionality.
-#[derive(Clone, Copy, Debug, Default, Diagnostic, Error, strum::FromRepr)]
+#[derive(Clone, Copy, Debug, Diagnostic, Error, strum::FromRepr)]
 #[non_exhaustive]
 #[repr(u8)]
 #[cfg(feature = "serialport")]
@@ -672,16 +672,23 @@ pub(crate) enum RomErrorKind {
     #[diagnostic(code(espflash::rom::too_much_data))]
     TooMuchData = 0xc9,
 
-    #[default]
-    #[error("Other")]
+    #[error("NAND program failed")]
+    #[diagnostic(code(espflash::rom::nand_program))]
+    NandProgramFailed = 0xca,
+
+    #[error("NAND erase failed")]
+    #[diagnostic(code(espflash::rom::nand_erase))]
+    NandEraseFailed = 0xcb,
+
+    #[error("Other ({0:#02x})")]
     #[diagnostic(code(espflash::rom::other))]
-    Other = 0xff,
+    Other(u8),
 }
 
 #[cfg(feature = "serialport")]
 impl From<u8> for RomErrorKind {
     fn from(raw: u8) -> Self {
-        Self::from_repr(raw).unwrap_or_default()
+        Self::from_repr(raw).unwrap_or_else(|| Self::Other(raw))
     }
 }
 

--- a/espflash/src/error.rs
+++ b/espflash/src/error.rs
@@ -688,7 +688,7 @@ pub(crate) enum RomErrorKind {
 #[cfg(feature = "serialport")]
 impl From<u8> for RomErrorKind {
     fn from(raw: u8) -> Self {
-        Self::from_repr(raw).unwrap_or_else(|| Self::Other(raw))
+        Self::from_repr(raw).unwrap_or(Self::Other(raw))
     }
 }
 


### PR DESCRIPTION
... and adds new variants:

https://github.com/espressif/esp-flasher-stub/blob/ca4ec075841bf7d89ea461200ef2d825c8899157/src/commands.h#L69-L71

I'm intentionally not touching `Sync` because I don't understand what that would do 🫠