### PR TITLE
Fix P4 flashing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,12 +10,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Added `Flasher::try_connect()` as a variant of `Flasher::connect()` that returns the `Connection`
+- Add ESP32-P4 ECO6/ECO7 flash power-on handling (#1043)
 
 ### Changed
 
 - Update ESP32-P4 stub (#1037)
 
 ### Fixed
+
+- Fix flash finish command encoding and reset handling when using the stub loader (#1043)
 
 ### Removed
 

--- a/espflash/src/command.rs
+++ b/espflash/src/command.rs
@@ -502,7 +502,8 @@ impl Command<'_> {
                 data_command(writer, data, pad_to, pad_byte, sequence)?;
             }
             Command::FlashEnd { reboot } => {
-                write_basic(writer, &[u8::from(!reboot)], 0)?;
+                // 0 means reboot, 1 means do nothing/run user code.
+                write_basic(writer, &u32::from(!reboot).to_le_bytes(), 0)?;
             }
             Command::MemBegin {
                 size,
@@ -618,8 +619,8 @@ impl Command<'_> {
             }
             Command::FlashDeflEnd { reboot } => {
                 // As per the logic here: https://github.com/espressif/esptool/blob/0a9caaf04cfde6fd97c785d4811f3fde09b1b71f/flasher_stub/stub_flasher.c#L402
-                // 0 means reboot, 1 means do nothing
-                write_basic(writer, &[u8::from(!reboot)], 0)?;
+                // 0 means reboot, 1 means do nothing/run user code.
+                write_basic(writer, &u32::from(!reboot).to_le_bytes(), 0)?;
             }
             Command::FlashMd5 { offset, size } => {
                 // length

--- a/espflash/src/flasher/mod.rs
+++ b/espflash/src/flasher/mod.rs
@@ -643,6 +643,10 @@ impl Flasher {
         }
 
         if !flasher.connection.secure_download_mode {
+            if let Err(e) = flasher.power_on_flash() {
+                return Err(Box::new((e, flasher.into_connection())));
+            }
+
             // Load flash stub if enabled.
             if use_stub {
                 info!("Using flash stub");
@@ -693,6 +697,101 @@ impl Flasher {
             .chip
             .flash_target(self.spi_params, self.use_stub, false, false);
         target.begin(&mut self.connection).flashing()?;
+        Ok(())
+    }
+
+    fn power_on_flash(&mut self) -> Result<(), Error> {
+        if self.chip != Chip::Esp32p4 || self.connection.secure_download_mode {
+            return Ok(());
+        }
+
+        // Flash power-on related registers and bits needed for ESP32-P4 ECO6/ECO7.
+        const EFUSE_RD_REPEAT_DATA1_REG: u32 = 0x5012_D034;
+        const EFUSE_DOWNLOAD_MODE_XPD_ON_MASK: u32 = 1 << 16;
+        const LP_SYSTEM_REG_ANA_XPD_PAD_GROUP_REG: u32 = 0x5011_010C;
+        const PMU_EXT_LDO_P0_0P1A_REG: u32 = 0x5011_51B8;
+        const PMU_EXT_LDO_P0_0P1A_ANA_REG: u32 = 0x5011_51BC;
+        const PMU_DATE_REG: u32 = 0x5011_53FC;
+        const PMU_ANA_0P1A_EN_CUR_LIM_0: u32 = 1 << 27;
+        const PMU_0P1A_FORCE_TIEH_SEL_0: u32 = 1 << 7;
+        const PMU_0P1A_TARGET0_0: u32 = 0xFF << 23;
+
+        let Some((major, minor)) = self.chip_revision()? else {
+            debug!("Skipping ESP32-P4 flash power-on: chip revision is unknown");
+            return Ok(());
+        };
+
+        let revision = major * 100 + minor;
+        // Flash defaults off on ECO6/ECO7 after the 1.8 V -> 3.3 V default
+        // change. Other silicon revisions do not need this sequence.
+        if !matches!(revision, 301 | 302) {
+            return Ok(());
+        }
+
+        // On ECO7, skip the power-up sequence when DOWNLOAD_MODE_XPD_ON is
+        // programmed: ROM already asserts flash XPD in download mode. Clear the
+        // PMU date register to release the force-on state left by the ROM path.
+        if revision == 302
+            && (self.connection.read_reg(EFUSE_RD_REPEAT_DATA1_REG)?
+                & EFUSE_DOWNLOAD_MODE_XPD_ON_MASK)
+                != 0
+        {
+            debug!("Clearing ESP32-P4 ECO7 flash force-on state");
+            self.connection.write_reg(PMU_DATE_REG, 0, None)?;
+            return Ok(());
+        }
+
+        debug!("Powering on ESP32-P4 flash");
+
+        // Power up pad group.
+        self.connection
+            .write_reg(LP_SYSTEM_REG_ANA_XPD_PAD_GROUP_REG, 1, None)?;
+        sleep(Duration::from_millis(10));
+
+        // Flash power-up sequence.
+        let value = self.connection.read_reg(PMU_EXT_LDO_P0_0P1A_ANA_REG)?;
+        self.connection.write_reg(
+            PMU_EXT_LDO_P0_0P1A_ANA_REG,
+            value | PMU_ANA_0P1A_EN_CUR_LIM_0,
+            None,
+        )?;
+
+        let value = self.connection.read_reg(PMU_EXT_LDO_P0_0P1A_REG)?;
+        self.connection.write_reg(
+            PMU_EXT_LDO_P0_0P1A_REG,
+            value | PMU_0P1A_FORCE_TIEH_SEL_0,
+            None,
+        )?;
+
+        let value = self.connection.read_reg(PMU_DATE_REG)?;
+        self.connection.write_reg(PMU_DATE_REG, value | 3, None)?;
+        sleep(Duration::from_micros(50));
+
+        let value = self.connection.read_reg(PMU_EXT_LDO_P0_0P1A_ANA_REG)?;
+        self.connection.write_reg(
+            PMU_EXT_LDO_P0_0P1A_ANA_REG,
+            value & !PMU_ANA_0P1A_EN_CUR_LIM_0,
+            None,
+        )?;
+
+        let value = self.connection.read_reg(PMU_EXT_LDO_P0_0P1A_REG)?;
+        self.connection
+            .write_reg(PMU_EXT_LDO_P0_0P1A_REG, value & !PMU_0P1A_TARGET0_0, None)?;
+
+        // Update eFuse voltage to PMU.
+        let value = self.connection.read_reg(PMU_EXT_LDO_P0_0P1A_REG)?;
+        self.connection
+            .write_reg(PMU_EXT_LDO_P0_0P1A_REG, value | 0x80, None)?;
+
+        let value = self.connection.read_reg(PMU_EXT_LDO_P0_0P1A_REG)?;
+        self.connection.write_reg(
+            PMU_EXT_LDO_P0_0P1A_REG,
+            value & !PMU_0P1A_FORCE_TIEH_SEL_0,
+            None,
+        )?;
+
+        sleep(Duration::from_micros(1_800));
+
         Ok(())
     }
 

--- a/espflash/src/target/efuse/esp32p4.rs
+++ b/espflash/src/target/efuse/esp32p4.rs
@@ -265,11 +265,13 @@ pub const FORCE_DISABLE_SW_INIT_KEY: EfuseField = EfuseField::new(0, 2, 77, 1);
 /// Set this bit to configure flash encryption use xts-128 key; else use xts-256
 /// key
 pub const XTS_KEY_LENGTH_256: EfuseField = EfuseField::new(0, 2, 78, 1);
-/// Reserved; it was created by set_missed_fields_in_regs func
-pub const RESERVE_0_79: EfuseField = EfuseField::new(0, 2, 79, 1);
+/// Set this bit to permanently turn on ECC const-time mode
+pub const ECC_FORCE_CONST_TIME: EfuseField = EfuseField::new(0, 2, 79, 1);
+/// Set this bit to power on XPD in download mode
+pub const DOWNLOAD_MODE_XPD_ON: EfuseField = EfuseField::new(0, 2, 80, 1);
 /// Represents whether RTC watchdog timeout threshold is selected at startup. 1:
 /// selected. 0: not selected
-pub const WDT_DELAY_SEL: EfuseField = EfuseField::new(0, 2, 80, 2);
+pub const WDT_DELAY_SEL: EfuseField = EfuseField::new(0, 2, 81, 1);
 /// Enables flash encryption when 1 or 3 bits are set and disables otherwise
 pub const SPI_BOOT_CRYPT_CNT: EfuseField = EfuseField::new(0, 2, 82, 3);
 /// Revoke 1st secure boot key

--- a/espflash/src/target/flash_target/esp32.rs
+++ b/espflash/src/target/flash_target/esp32.rs
@@ -272,10 +272,12 @@ impl FlashTarget for Esp32Target {
             // avoiding that error.
             let flash_end_reboot = connection.secure_download_mode || reboot;
             let result = if self.use_stub {
+                // Let the host-side reset path handle rebooting after stub flashing. Asking the
+                // stub to reboot from FLASH_DEFL_END can race with response handling on some
+                // ESP32-P4 revisions/stubs, while the command's non-reboot path just exits
+                // flash mode.
                 connection.with_timeout(CommandType::FlashDeflEnd.timeout(), |connection| {
-                    connection.command(Command::FlashDeflEnd {
-                        reboot: flash_end_reboot,
-                    })
+                    connection.command(Command::FlashDeflEnd { reboot: false })
                 })
             } else {
                 connection.with_timeout(CommandType::FlashEnd.timeout(), |connection| {


### PR DESCRIPTION
- Add ESP32-P4 ECO6/ECO7 flash power-on handling before SPI flash attach                                          
- Fix flash finish command encoding to use a 4-byte payload, matching `esptool`                                     
- Avoid rebooting directly from the stub `FLASH_DEFL_END` command

cc @bjoernQ 