### PR TITLE
Fix stub chunk timeout

### DIFF
--- a/espflash/src/target/flash_target/esp32.rs
+++ b/espflash/src/target/flash_target/esp32.rs
@@ -202,15 +202,27 @@ impl FlashTarget for Esp32Target {
         let mut decoder = ZlibDecoder::new(Vec::new());
         let mut decoded_size = 0;
 
+        let mut deferred_stub_timeout = CommandType::FlashDeflData.timeout();
+
         for (i, block) in chunks.enumerate() {
             if use_compression {
                 decoder.write_all(block)?;
                 decoder.flush()?;
                 let size = decoder.get_ref().len() - decoded_size;
                 decoded_size = decoder.get_ref().len();
+                let timeout_for_this_block = deferred_stub_timeout;
+                let timeout_for_next_block = CommandType::FlashDeflData.timeout_for_size(size as u32);
+
+                debug!(
+                    "FlashDeflData seq={i} compressed_len={} decoded_len={} timeout_now={:.3}s timeout_next={:.3}s",
+                    block.len(),
+                    size,
+                    timeout_for_this_block.as_secs_f32(),
+                    timeout_for_next_block.as_secs_f32(),
+                );
 
                 connection.with_timeout(
-                    CommandType::FlashDeflData.timeout_for_size(size as u32),
+                    timeout_for_this_block,
                     |connection| {
                         connection.command(Command::FlashDeflData {
                             sequence: i as u32,
@@ -221,6 +233,13 @@ impl FlashTarget for Esp32Target {
                         Ok(())
                     },
                 )?;
+
+                // Match esptool.py stub semantics: the stub ACKs once it has received
+                // the current compressed packet, then performs the corresponding flash
+                // write while the next packet is in flight. The timeout for the next
+                // packet therefore needs to reflect the amount of data this packet
+                // expands to on-device.
+                deferred_stub_timeout = timeout_for_next_block;
             } else {
                 connection.with_timeout(
                     CommandType::FlashData.timeout_for_size(block.len() as u32),

--- a/espflash/src/target/flash_target/esp32.rs
+++ b/espflash/src/target/flash_target/esp32.rs
@@ -3,7 +3,7 @@
 //! This module defines the traits and types used for flashing operations on a
 //! target device's flash memory.
 
-use std::io::Write;
+use std::{io::Write, time::Duration};
 
 use flate2::{
     Compression,
@@ -35,6 +35,8 @@ pub struct Esp32Target {
     verify: bool,
     skip: bool,
     need_flash_end: bool,
+    /// Deferred stub timeout for the final completion wait; esptool.py uses this on a final dummy read before flash_defl_finish().
+    flash_defl_end_timeout: Option<Duration>,
 }
 
 impl Esp32Target {
@@ -53,6 +55,7 @@ impl Esp32Target {
             verify,
             skip,
             need_flash_end: false,
+            flash_defl_end_timeout: None,
         }
     }
 }
@@ -258,6 +261,10 @@ impl FlashTarget for Esp32Target {
             progress.update(i + 1)
         }
 
+        if use_compression {
+            self.flash_defl_end_timeout = Some(deferred_stub_timeout);
+        }
+
         if self.verify {
             progress.verifying();
             let flash_checksum_md5: u128 = connection.with_timeout(
@@ -295,7 +302,17 @@ impl FlashTarget for Esp32Target {
                 // stub to reboot from FLASH_DEFL_END can race with response handling on some
                 // ESP32-P4 revisions/stubs, while the command's non-reboot path just exits
                 // flash mode.
-                connection.with_timeout(CommandType::FlashDeflEnd.timeout(), |connection| {
+                //
+                // Match esptool.py: FlashDeflEnd is not ACKed until the last compressed block
+                // has been written on-device, so use the deferred timeout from that block.
+                let flash_defl_end_timeout = self
+                    .flash_defl_end_timeout
+                    .unwrap_or_else(|| CommandType::FlashDeflEnd.timeout());
+                debug!(
+                    "FlashDeflEnd timeout={:.3}s",
+                    flash_defl_end_timeout.as_secs_f32(),
+                );
+                connection.with_timeout(flash_defl_end_timeout, |connection| {
                     connection.command(Command::FlashDeflEnd { reboot: false })
                 })
             } else {


### PR DESCRIPTION
## 主要根因

### 1. Stub 的真实行为决定了 timeout 必须「延后一包」

`esp-flasher-stub` 里 `FLASH_DEFL_DATA` 的处理顺序是：

1. 先 `s_send_response()` 回 ACK  
2. 再跑 `s_flash_defl_data_post_process()` 做解压 + 写 flash

```987:1000:../esp-flasher-stub/src/command_handler.c
    if (accumulated_result == RESPONSE_SUCCESS) {
        s_send_response(transport, command, RESPONSE_SUCCESS, &response);
    } else {
        ...
    }

    // Execute post-process AFTER response is sent (if registered by command)
    if (s_pending_post_process) {
        accumulated_result = s_pending_post_process(&ctx);
```

所以 host 发第 N 包时等的 ACK，往往只是「包收到了」；第 N 包对应的 flash 写入，是在 host 已经开始发第 N+1 包时，stub 后台还在做。

### 2. `esptool.py` 明确实现了这套语义

```1458:1474:../esptool/esptool/cmds.py
                                    block_timeout = max(
                                        DEFAULT_TIMEOUT,
                                        timeout_per_mb(
                                            ERASE_WRITE_TIMEOUT_PER_MB,
                                            block_uncompressed,
                                        ),
                                    )
                                    ...
                                    esp.flash_defl_block(block, seq, timeout=timeout)
                                    if esp.IS_STUB:
                                        # Stub ACKs when block is received, then writes
                                        # to flash while receiving the block after it
                                        timeout = block_timeout
```

要点：

- **当前包**用上一轮留下的 `timeout`
- **当前包解压后的大小**，决定**下一包**的 `timeout`

`FlashDeflEnd` 也会继承这个 deferred timeout：

```1532:1537:../esptool/esptool/cmds.py
                    # Stub only writes each block to flash after 'ack'ing the receive,
                    # so do a final operation which will not be 'ack'ed
                    # until the last block has actually been written out to flash
                    if cur_cycle == len(cycles) - 1:
                        if compress and not last_file_encrypted:
                            esp.flash_defl_finish(reboot=False, timeout=timeout)
```

### 3. patch 前 `espflash` 的 bug 很具体

patch 前逻辑是：

```rust
connection.with_timeout(
    CommandType::FlashDeflData.timeout_for_size(size as u32), // 用“当前块”解压大小
    ...
)
```

这等于把「大块后台写 flash 的耗时」绑在了**当前包**上，而实际应该在**下一包**等。

对你这份 bin，离线拆块后 spike 在 **seq=69**，解压约 **3.7MB**：

| seq | 解压大小 | patch 前 timeout | 实际在等什么 |
|-----|---------|------------------|-------------|
| 69 | 3.7MB | ~148s | ACK，很快回来 |
| **70** | ~56KB | **~10s** | **stub 还在写 seq=69 的 3.7MB** |


## 顺便同步尾包等待逻辑

在 `esp32.rs` 里补了同样逻辑：

1. 压缩写入循环结束后，把 `deferred_stub_timeout` 存到 `Esp32Target.flash_defl_end_timeout`
2. `finish()` 里 `FlashDeflEnd` 用这个值，而不是固定 10s
3. 加了 debug：`FlashDeflEnd timeout=...s`


## 当前 patch 与 `esptool.py` 的对齐情况

| 阶段 | esptool.py | espflash (patch 后) |
|------|-----------|---------------------|
| 中间 `FlashDeflData` | 延后一包 timeout | 已对齐 |
| 尾部 `FlashDeflEnd` | 用最后一包的 deferred timeout | **刚补上** |
| 小 block floor | 3s | 10s（次要差异，不影响大 spike） |