### PR TITLE
Bump MSRV to 1.95.0, memory range sourcing from metadata

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
-  MSRV: "1.88"
+  MSRV: "1.95.0"
 
 # Cancel any currently running workflows from the same PR, branch, or
 # tag when a new workflow is triggered.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 ### Changed
+- Bump MSRV to 1.95.0 (#1056)
 
 ### Fixed
 - Regenerate efuses for S31 (#1053)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -963,6 +963,7 @@ dependencies = [
 [[package]]
 name = "esp-metadata-generated"
 version = "0.4.0"
+source = "git+https://github.com/esp-rs/esp-hal?rev=d91ecc5#d91ecc513f4e7915ce239f05f24d561a81fa2f46"
 
 [[package]]
 name = "espflash"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -961,6 +961,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "esp-metadata-generated"
+version = "0.4.0"
+
+[[package]]
 name = "espflash"
 version = "4.5.0"
 dependencies = [
@@ -978,6 +982,7 @@ dependencies = [
  "directories",
  "env_logger",
  "esp-idf-part",
+ "esp-metadata-generated",
  "flate2",
  "gimli 0.32.3",
  "indicatif",

--- a/cargo-espflash/Cargo.toml
+++ b/cargo-espflash/Cargo.toml
@@ -2,7 +2,7 @@
 name         = "cargo-espflash"
 version      = "4.5.0"
 edition      = "2024"
-rust-version = "1.88"
+rust-version = "1.95.0"
 description  = "Cargo subcommand for interacting with Espressif devices"
 repository   = "https://github.com/esp-rs/espflash"
 license      = "MIT OR Apache-2.0"

--- a/cargo-espflash/README.md
+++ b/cargo-espflash/README.md
@@ -2,7 +2,7 @@
 # cargo-espflash
 
 [![Crates.io](https://img.shields.io/crates/v/cargo-espflash?labelColor=1C2C2E&color=C96329&logo=Rust&style=flat-square)](https://crates.io/crates/cargo-espflash)
-![MSRV](https://img.shields.io/badge/MSRV-1.88-blue?labelColor=1C2C2E&logo=Rust&style=flat-square)
+![MSRV](https://img.shields.io/badge/MSRV-1.95.0-blue?labelColor=1C2C2E&logo=Rust&style=flat-square)
 ![Crates.io](https://img.shields.io/crates/l/cargo-espflash?labelColor=1C2C2E&style=flat-square)
 
 Cross-compiler and Cargo extension for flashing Espressif devices.
@@ -29,7 +29,7 @@ Supports the **ESP32**, **ESP32-C2/C3/C5/C6/C61**, **ESP32-H2**, **ESP32-P4**, a
 
 ## Installation
 
-If you are installing `cargo-espflash` from source (ie. using `cargo install`) then you must have `rustc>=1.88.0` installed on your system.
+If you are installing `cargo-espflash` from source (ie. using `cargo install`) then you must have `rustc>=1.95.0` installed on your system.
 
 To install:
 

--- a/espflash/Cargo.toml
+++ b/espflash/Cargo.toml
@@ -43,7 +43,7 @@ dialoguer       = { version = "0.12", optional = true }
 directories     = { version = "6.0", optional = true }
 env_logger      = { version = "0.11", optional = true }
 esp-idf-part    = "0.6"
-esp-metadata-generated = { git = "https://github.com/esp-rs/esp-hal", rev = "0000000", features = ["build-script"] }
+esp-metadata-generated = { git = "https://github.com/esp-rs/esp-hal", rev = "d91ecc5", features = ["build-script"] }
 flate2          = "1.1"
 gimli           = "0.32.3"
 indicatif       = { version = "0.18", optional = true }

--- a/espflash/Cargo.toml
+++ b/espflash/Cargo.toml
@@ -43,6 +43,7 @@ dialoguer       = { version = "0.12", optional = true }
 directories     = { version = "6.0", optional = true }
 env_logger      = { version = "0.11", optional = true }
 esp-idf-part    = "0.6"
+esp-metadata-generated = { git = "https://github.com/esp-rs/esp-hal", rev = "0000000", features = ["build-script"] }
 flate2          = "1.1"
 gimli           = "0.32.3"
 indicatif       = { version = "0.18", optional = true }

--- a/espflash/Cargo.toml
+++ b/espflash/Cargo.toml
@@ -2,7 +2,7 @@
 name         = "espflash"
 version      = "4.5.0"
 edition      = "2024"
-rust-version = "1.88"
+rust-version = "1.95.0"
 description  = "A command-line tool for interacting with Espressif devices"
 repository   = "https://github.com/esp-rs/espflash"
 license      = "MIT OR Apache-2.0"

--- a/espflash/README.md
+++ b/espflash/README.md
@@ -3,7 +3,7 @@
 
 [![Crates.io](https://img.shields.io/crates/v/espflash?labelColor=1C2C2E&color=C96329&logo=Rust&style=flat-square)](https://crates.io/crates/espflash)
 [![docs.rs](https://img.shields.io/docsrs/espflash?labelColor=1C2C2E&color=C96329&logo=rust&style=flat-square)](https://docs.rs/espflash)
-![MSRV](https://img.shields.io/badge/MSRV-1.88-blue?labelColor=1C2C2E&logo=Rust&style=flat-square)
+![MSRV](https://img.shields.io/badge/MSRV-1.95.0-blue?labelColor=1C2C2E&logo=Rust&style=flat-square)
 ![Crates.io](https://img.shields.io/crates/l/espflash?labelColor=1C2C2E&style=flat-square)
 
 A library and command-line tool for flashing Espressif devices.
@@ -31,7 +31,7 @@ Supports the **ESP32**, **ESP32-C2/C3/C5/C6/C61**, **ESP32-H2**, **ESP32-P4**, a
 
 ## Installation
 
-If you are installing `espflash` from source (ie. using `cargo install`) then you must have `rustc>=1.88.0` installed on your system.
+If you are installing `espflash` from source (ie. using `cargo install`) then you must have `rustc>=1.95.0` installed on your system.
 
 To install:
 

--- a/espflash/src/target/mod.rs
+++ b/espflash/src/target/mod.rs
@@ -6,6 +6,7 @@
 
 use std::collections::HashMap;
 
+use esp_metadata_generated::Chip as MetadataChip;
 use serde::{Deserialize, Serialize};
 use strum::{Display, EnumIter, EnumString, IntoEnumIterator, VariantNames};
 
@@ -601,81 +602,28 @@ impl Chip {
 
     /// Returns whether the provided address `addr` in flash.
     pub fn addr_is_flash(&self, addr: u32) -> bool {
+        let layout = self.metadata().memory_layout();
+
+        ["irom", "drom"].into_iter().any(|name| {
+            layout
+                .region(name)
+                .is_some_and(|region| region.range().contains(&addr))
+        })
+    }
+
+    fn metadata(&self) -> MetadataChip {
         match self {
-            Chip::Esp32 => {
-                const FLASH_RANGES: &[std::ops::Range<u32>] = &[
-                    0x400d_0000..0x4040_0000, // IROM
-                    0x3f40_0000..0x3f80_0000, // DROM
-                ];
-                FLASH_RANGES.iter().any(|range| range.contains(&addr))
-            }
-            Chip::Esp32c2 => {
-                const FLASH_RANGES: &[std::ops::Range<u32>] = &[
-                    0x4200_0000..0x4240_0000, // IROM
-                    0x3c00_0000..0x3c40_0000, // DROM
-                ];
-                FLASH_RANGES.iter().any(|range| range.contains(&addr))
-            }
-            Chip::Esp32c3 => {
-                const FLASH_RANGES: &[std::ops::Range<u32>] = &[
-                    0x4200_0000..0x4280_0000, // IROM
-                    0x3c00_0000..0x3c80_0000, // DROM
-                ];
-                FLASH_RANGES.iter().any(|range| range.contains(&addr))
-            }
-            Chip::Esp32c5 => {
-                const FLASH_RANGES: &[std::ops::Range<u32>] = &[
-                    0x3c00_0000..0x3c80_0000, // DROM
-                    0x4200_0000..0x4280_0000, // IROM
-                ];
-                FLASH_RANGES.iter().any(|range| range.contains(&addr))
-            }
-            Chip::Esp32c6 => {
-                const FLASH_RANGES: &[std::ops::Range<u32>] = &[
-                    0x4200_0000..0x4280_0000, // IROM
-                    0x3c00_0000..0x3c80_0000, // DROM
-                ];
-                FLASH_RANGES.iter().any(|range| range.contains(&addr))
-            }
-            Chip::Esp32c61 => {
-                const FLASH_RANGES: &[std::ops::Range<u32>] = &[
-                    0x4200_0000..0x4280_0000, // IROM
-                    0x3c00_0000..0x3c80_0000, // DROM
-                ];
-                FLASH_RANGES.iter().any(|range| range.contains(&addr))
-            }
-            Chip::Esp32h2 => {
-                const FLASH_RANGES: &[std::ops::Range<u32>] = &[
-                    0x4200_0000..0x4280_0000, // IROM
-                    0x3c00_0000..0x3c80_0000, // DROM
-                ];
-                FLASH_RANGES.iter().any(|range| range.contains(&addr))
-            }
-            Chip::Esp32p4 => {
-                const FLASH_RANGES: &[std::ops::Range<u32>] = &[
-                    0x4800_0000..0x4C00_0000, // IROM
-                    0x4000_0000..0x4400_0000, // DROM
-                ];
-                FLASH_RANGES.iter().any(|range| range.contains(&addr))
-            }
-            Chip::Esp32s2 => {
-                const FLASH_RANGES: &[std::ops::Range<u32>] = &[
-                    0x4008_0000..0x4180_0000, // IROM
-                    0x3f00_0000..0x3f3f_0000, // DROM
-                ];
-                FLASH_RANGES.iter().any(|range| range.contains(&addr))
-            }
-            Chip::Esp32s3 => {
-                const FLASH_RANGES: &[std::ops::Range<u32>] = &[
-                    0x4200_0000..0x4400_0000, // IROM
-                    0x3c00_0000..0x3e00_0000, // DROM
-                ];
-                FLASH_RANGES.iter().any(|range| range.contains(&addr))
-            }
-            Chip::Esp32s31 => {
-                // Datasheet: external flash = 256 MB at 0x40000000..0x50000000
-                (0x4000_0000..0x5000_0000).contains(&addr)
-            }
+            Chip::Esp32 => MetadataChip::Esp32,
+            Chip::Esp32c2 => MetadataChip::Esp32c2,
+            Chip::Esp32c3 => MetadataChip::Esp32c3,
+            Chip::Esp32c5 => MetadataChip::Esp32c5,
+            Chip::Esp32c6 => MetadataChip::Esp32c6,
+            Chip::Esp32c61 => MetadataChip::Esp32c61,
+            Chip::Esp32h2 => MetadataChip::Esp32h2,
+            Chip::Esp32p4 => MetadataChip::Esp32p4,
+            Chip::Esp32s2 => MetadataChip::Esp32s2,
+            Chip::Esp32s3 => MetadataChip::Esp32s3,
+            Chip::Esp32s31 => MetadataChip::Esp32s31,
         }
     }
 


### PR DESCRIPTION
closes https://github.com/esp-rs/espflash/issues/1047
this is waiting for https://github.com/esp-rs/esp-hal/pull/5966 to get merged